### PR TITLE
ui: complete editorial reskin — orange brand, stone palette, serif typography

### DIFF
--- a/src/app/(app)/dashboard/dashboard-client.tsx
+++ b/src/app/(app)/dashboard/dashboard-client.tsx
@@ -62,23 +62,23 @@ const accentColors: Record<
 > = {
   sky: {
     bg: "bg-sky-500/10",
-    text: "text-sky-400",
-    glow: "hover:shadow-[0_0_40px_rgba(56,189,248,0.15)] hover:border-sky-500/30",
+    text: "text-sky-500",
+    glow: "hover:border-sky-500/30",
   },
   indigo: {
-    bg: "bg-indigo-500/10",
-    text: "text-indigo-400",
-    glow: "hover:shadow-[0_0_40px_rgba(99,102,241,0.15)] hover:border-indigo-500/30",
+    bg: "bg-brand/10",
+    text: "text-brand",
+    glow: "hover:border-brand/30",
   },
   emerald: {
     bg: "bg-emerald-500/10",
-    text: "text-emerald-400",
-    glow: "hover:shadow-[0_0_40px_rgba(16,185,129,0.15)] hover:border-emerald-500/30",
+    text: "text-emerald-500",
+    glow: "hover:border-emerald-500/30",
   },
   amber: {
     bg: "bg-amber-500/10",
-    text: "text-amber-400",
-    glow: "hover:shadow-[0_0_40px_rgba(245,158,11,0.15)] hover:border-amber-500/30",
+    text: "text-amber-500",
+    glow: "hover:border-amber-500/30",
   },
 };
 
@@ -163,13 +163,13 @@ export default function DashboardClient({
                 key={card.title}
                 href={card.href}
                 className={cn(
-                  "group glass-panel rounded-2xl p-6 transition-all duration-200 hover:-translate-y-1 border border-border",
+                  "group bg-surface border border-border rounded p-6 transition-all duration-200 hover:-translate-y-1 border border-border",
                   colors.glow
                 )}
               >
                 <div
                   className={cn(
-                    "w-12 h-12 rounded-xl flex items-center justify-center mb-4 group-hover:scale-110 transition-transform",
+                    "w-12 h-12 rounded flex items-center justify-center mb-4 group-hover:scale-110 transition-transform",
                     colors.bg,
                     colors.text
                   )}
@@ -192,36 +192,36 @@ export default function DashboardClient({
           Your Research at a Glance
         </h2>
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-          <div className="glass-panel rounded-2xl p-5 border border-border">
+          <div className="bg-surface border border-border rounded p-5 border border-border">
             <div className="flex items-center gap-3 mb-2">
-              <div className="w-9 h-9 rounded-lg bg-indigo-500/10 flex items-center justify-center text-indigo-400">
+              <div className="w-9 h-9 rounded-lg bg-brand/10 flex items-center justify-center text-brand">
                 <FileText size={18} />
               </div>
               <span className="text-2xl font-bold text-ink">{stats.projectCount}</span>
             </div>
             <p className="text-xs text-ink-muted">Projects</p>
           </div>
-          <div className="glass-panel rounded-2xl p-5 border border-border">
+          <div className="bg-surface border border-border rounded p-5 border border-border">
             <div className="flex items-center gap-3 mb-2">
-              <div className="w-9 h-9 rounded-lg bg-sky-500/10 flex items-center justify-center text-sky-400">
+              <div className="w-9 h-9 rounded-lg bg-sky-500/10 flex items-center justify-center text-sky-500">
                 <Books size={18} />
               </div>
               <span className="text-2xl font-bold text-ink">{stats.paperCount}</span>
             </div>
             <p className="text-xs text-ink-muted">Papers Saved</p>
           </div>
-          <div className="glass-panel rounded-2xl p-5 border border-border">
+          <div className="bg-surface border border-border rounded p-5 border border-border">
             <div className="flex items-center gap-3 mb-2">
-              <div className="w-9 h-9 rounded-lg bg-emerald-500/10 flex items-center justify-center text-emerald-400">
+              <div className="w-9 h-9 rounded-lg bg-emerald-500/10 flex items-center justify-center text-emerald-500">
                 <MagnifyingGlass size={18} />
               </div>
               <span className="text-2xl font-bold text-ink">{stats.searchCount}</span>
             </div>
             <p className="text-xs text-ink-muted">Searches</p>
           </div>
-          <div className="glass-panel rounded-2xl p-5 border border-border">
+          <div className="bg-surface border border-border rounded p-5 border border-border">
             <div className="flex items-center gap-3 mb-2">
-              <div className="w-9 h-9 rounded-lg bg-amber-500/10 flex items-center justify-center text-amber-400">
+              <div className="w-9 h-9 rounded-lg bg-amber-500/10 flex items-center justify-center text-amber-500">
                 <ChatCircleDots size={18} />
               </div>
               <span className="text-2xl font-bold text-ink">{stats.conversationCount}</span>
@@ -245,7 +245,7 @@ export default function DashboardClient({
           </Link>
         </div>
 
-        <div className="glass-panel rounded-2xl overflow-hidden border border-border">
+        <div className="bg-surface border border-border rounded overflow-hidden border border-border">
           {recentProjects.length === 0 ? (
             <div className="p-8 text-center text-ink-muted text-sm">
               No projects yet. Create your first manuscript to get started.
@@ -306,7 +306,7 @@ export default function DashboardClient({
               Search →
             </Link>
           </div>
-          <div className="glass-panel rounded-2xl overflow-hidden border border-border">
+          <div className="bg-surface border border-border rounded overflow-hidden border border-border">
             {recentSearches.length === 0 ? (
               <div className="p-6 text-center text-ink-muted text-sm">
                 No searches yet. Start exploring academic papers.
@@ -351,7 +351,7 @@ export default function DashboardClient({
               Recent Activity
             </h2>
           </div>
-          <div className="glass-panel rounded-2xl overflow-hidden border border-border">
+          <div className="bg-surface border border-border rounded overflow-hidden border border-border">
             {recentActivity.length === 0 ? (
               <div className="p-6 text-center text-ink-muted text-sm">
                 No activity yet. Your research actions will appear here.

--- a/src/app/(app)/research/page.tsx
+++ b/src/app/(app)/research/page.tsx
@@ -341,13 +341,13 @@ export default function ResearchPage() {
                 onChange={(e) => setQuery(e.target.value)}
                 onKeyDown={(e) => e.key === "Enter" && handleSearch(0)}
                 placeholder="Search 200M+ papers — try 'CRISPR sickle cell gene therapy'"
-                className="w-full pl-12 pr-4 py-3.5 rounded-2xl bg-surface border border-border text-ink placeholder:text-ink-muted text-sm focus:outline-none focus:ring-2 focus:ring-brand/40 transition-all"
+                className="w-full pl-12 pr-4 py-3.5 rounded bg-surface border border-border text-ink placeholder:text-ink-muted text-sm focus:outline-none focus:ring-2 focus:ring-brand/40 transition-all"
               />
             </div>
             <button
               onClick={() => handleSearch(0)}
               disabled={loading}
-              className="px-6 py-3.5 rounded-2xl bg-brand text-white text-sm font-medium hover:bg-brand-hover transition-colors disabled:opacity-50"
+              className="px-6 py-3.5 rounded bg-brand text-white text-sm font-medium hover:bg-brand-hover transition-colors disabled:opacity-50"
             >
               {loading ? "Searching..." : "Search"}
             </button>
@@ -423,7 +423,7 @@ export default function ResearchPage() {
                 <CaretDown size={12} />
               </button>
               {showSortDropdown && (
-                <div className="absolute right-0 top-full mt-1 z-20 bg-surface border border-border rounded-xl shadow-lg py-1 min-w-[140px]">
+                <div className="absolute right-0 top-full mt-1 z-20 bg-surface border border-border rounded shadow-lg py-1 min-w-[140px]">
                   {SORT_OPTIONS.map((option) => (
                     <button
                       key={option.value}
@@ -494,7 +494,7 @@ export default function ResearchPage() {
         {loading && (
           <div className="space-y-4">
             {Array.from({ length: 4 }).map((_, i) => (
-              <div key={i} className="glass-panel rounded-xl p-5 animate-pulse">
+              <div key={i} className="bg-surface border border-border rounded p-5 animate-pulse">
                 <div className="h-4 bg-surface-raised rounded w-3/4 mb-3" />
                 <div className="h-3 bg-surface-raised rounded w-1/2 mb-2" />
                 <div className="h-3 bg-surface-raised rounded w-full" />
@@ -519,7 +519,7 @@ export default function ResearchPage() {
 
               return (
                 <div key={`${key}-${idx}`}>
-                  <div className="glass-panel rounded-xl p-5 hover:bg-surface-raised/30 transition-all">
+                  <div className="bg-surface border border-border rounded p-5 hover:bg-surface-raised/30 transition-all">
                     {/* Title */}
                     <h3 className="font-medium text-ink text-sm leading-snug mb-1.5">
                       {r.doi ? (
@@ -675,7 +675,7 @@ export default function ResearchPage() {
                       {similarResults[similarKey].map((sim, simIdx) => (
                         <div
                           key={simIdx}
-                          className="glass-panel rounded-lg p-3 text-xs"
+                          className="bg-surface border border-border rounded p-3 text-xs"
                         >
                           <p className="font-medium text-ink leading-snug">
                             {sim.title}
@@ -709,7 +709,7 @@ export default function ResearchPage() {
             <button
               onClick={() => handleSearch(page - 1)}
               disabled={page === 0}
-              className="flex items-center gap-1.5 px-4 py-2 rounded-xl text-xs font-medium bg-surface-raised text-ink-muted border border-border hover:text-ink disabled:opacity-40 transition-colors"
+              className="flex items-center gap-1.5 px-4 py-2 rounded text-xs font-medium bg-surface-raised text-ink-muted border border-border hover:text-ink disabled:opacity-40 transition-colors"
             >
               <ArrowLeft size={14} />
               Previous
@@ -720,7 +720,7 @@ export default function ResearchPage() {
             <button
               onClick={() => handleSearch(page + 1)}
               disabled={!hasMore}
-              className="flex items-center gap-1.5 px-4 py-2 rounded-xl text-xs font-medium bg-surface-raised text-ink-muted border border-border hover:text-ink disabled:opacity-40 transition-colors"
+              className="flex items-center gap-1.5 px-4 py-2 rounded text-xs font-medium bg-surface-raised text-ink-muted border border-border hover:text-ink disabled:opacity-40 transition-colors"
             >
               Next
               <ArrowRight size={14} />
@@ -745,7 +745,7 @@ export default function ResearchPage() {
           "fixed right-6 bottom-6 z-40 p-3 rounded-full shadow-lg transition-all",
           showCopilot
             ? "bg-brand text-white"
-            : "glass-panel text-ink-muted hover:text-ink"
+            : "bg-surface border border-border text-ink-muted hover:text-ink"
         )}
       >
         <ChatCircleDots size={24} />
@@ -753,7 +753,7 @@ export default function ResearchPage() {
 
       {/* Research Copilot Sidebar */}
       {showCopilot && (
-        <aside className="w-96 shrink-0 glass-panel rounded-2xl p-5 flex flex-col h-full">
+        <aside className="w-96 shrink-0 bg-shell border border-shell-border rounded p-5 flex flex-col h-full text-shell-active">
           <div className="flex items-center justify-between mb-4">
             <div className="flex items-center gap-2">
               <Brain size={18} className="text-brand" />
@@ -800,7 +800,7 @@ export default function ResearchPage() {
                 <div
                   key={msg.id}
                   className={cn(
-                    "text-sm rounded-xl px-3 py-2",
+                    "text-sm rounded px-3 py-2",
                     msg.role === "user"
                       ? "bg-brand/10 text-ink ml-8"
                       : "bg-surface-raised text-ink mr-4"
@@ -827,7 +827,7 @@ export default function ResearchPage() {
               value={chatInput}
               onChange={(e) => setChatInput(e.target.value)}
               placeholder="Ask about papers, topics, methods..."
-              className="w-full px-4 py-2.5 pr-10 rounded-xl bg-surface-raised border border-border text-ink placeholder:text-ink-muted text-sm focus:outline-none focus:ring-2 focus:ring-brand/40"
+              className="w-full px-4 py-2.5 pr-10 rounded bg-surface-raised border border-border text-ink placeholder:text-ink-muted text-sm focus:outline-none focus:ring-2 focus:ring-brand/40"
             />
             <button
               type="submit"

--- a/src/app/(app)/studio/page.tsx
+++ b/src/app/(app)/studio/page.tsx
@@ -170,7 +170,7 @@ function ProjectSelector({
         <CaretDown size={10} className="shrink-0" />
       </button>
       {open && (
-        <div className="absolute left-0 top-full mt-1 w-56 rounded-lg glass-panel border border-border shadow-lg z-50 py-1 max-h-60 overflow-y-auto">
+        <div className="absolute left-0 top-full mt-1 w-56 rounded bg-surface border border-border shadow-lg z-50 py-1 max-h-60 overflow-y-auto">
           {projects.map((p) => (
             <button
               key={p.id}
@@ -549,20 +549,20 @@ function StudioContent() {
   return (
     <div className="flex h-[calc(100vh-7rem)] -m-6 -mt-0">
       {/* Left Sidebar */}
-      <aside className="w-64 shrink-0 glass-panel border-r border-border flex flex-col">
-        <div className="px-4 py-4 border-b border-border-subtle">
+      <aside className="w-60 shrink-0 bg-shell border-r border-shell-border flex flex-col text-shell-active">
+        <div className="px-4 py-4 border-b border-shell-border">
           <input
             type="text"
             value={docTitle}
             onChange={(e) => setDocTitle(e.target.value)}
-            className="w-full text-sm font-semibold text-ink bg-transparent focus:outline-none"
+            className="w-full text-sm font-semibold text-shell-active bg-transparent focus:outline-none"
           />
-          <div className="flex mt-3 p-0.5 bg-surface-raised rounded-lg">
+          <div className="flex mt-3 p-0.5 bg-white/5 rounded">
             <button
               onClick={() => setIsLearnMode(false)}
               className={cn(
-                "flex-1 py-1.5 rounded-md text-xs font-medium transition-all",
-                !isLearnMode ? "bg-brand text-white" : "text-ink-muted hover:text-ink"
+                "flex-1 py-1.5 rounded text-xs font-medium transition-all",
+                !isLearnMode ? "bg-brand text-white" : "text-shell-text hover:text-shell-active"
               )}
             >
               Write
@@ -570,8 +570,8 @@ function StudioContent() {
             <button
               onClick={() => setIsLearnMode(true)}
               className={cn(
-                "flex-1 py-1.5 rounded-md text-xs font-medium transition-all",
-                isLearnMode ? "bg-emerald-500 text-white" : "text-ink-muted hover:text-ink"
+                "flex-1 py-1.5 rounded text-xs font-medium transition-all",
+                isLearnMode ? "bg-emerald-500 text-white" : "text-shell-text hover:text-shell-active"
               )}
             >
               Learn
@@ -591,22 +591,22 @@ function StudioContent() {
         </div>
 
         <nav className="px-3 py-3 space-y-0.5">
-          <div className="px-3 py-2 rounded-lg bg-surface-raised text-ink text-sm font-medium">
+          <div className="px-3 py-2 rounded bg-white/5 text-shell-active text-sm font-medium border-l-2 border-brand">
             Current Draft
           </div>
-          <Link href="/library" className="flex items-center gap-2 px-3 py-2 rounded-lg text-sm text-ink-muted hover:text-ink hover:bg-surface-raised/50 transition-colors">
+          <Link href="/library" className="flex items-center gap-2 px-3 py-2 rounded text-sm text-shell-text hover:text-shell-active hover:bg-white/5 transition-colors">
             <Books size={16} />
             My Library
           </Link>
-          <Link href="/research" className="flex items-center gap-2 px-3 py-2 rounded-lg text-sm text-ink-muted hover:text-ink hover:bg-surface-raised/50 transition-colors">
+          <Link href="/research" className="flex items-center gap-2 px-3 py-2 rounded text-sm text-shell-text hover:text-shell-active hover:bg-white/5 transition-colors">
             <GlobeHemisphereWest size={16} />
             Deep Research
           </Link>
         </nav>
 
-        <div className="px-4 py-3 border-t border-border-subtle flex-1 overflow-y-auto">
+        <div className="px-4 py-3 border-t border-shell-border flex-1 overflow-y-auto scroll-subtle">
           <div className="flex items-center justify-between mb-2">
-            <span className="text-xs font-medium text-ink-muted uppercase tracking-wider">
+            <span className="text-[10px] font-mono font-medium text-shell-text uppercase tracking-widest">
               References ({references.size})
             </span>
             <button onClick={openCitationDialog} className="text-brand hover:text-brand-hover">
@@ -616,18 +616,18 @@ function StudioContent() {
           <div className="space-y-2">
             {citedSourcesList.length > 0 ? (
               citedSourcesList.map((src) => (
-                <div key={src.num} className="flex items-start gap-2 p-2 rounded-lg bg-surface-raised/50">
-                  <span className="text-[10px] font-mono font-bold text-blue-500 shrink-0 mt-0.5">
+                <div key={src.num} className="flex items-start gap-2 p-2 rounded bg-white/5">
+                  <span className="text-[10px] font-mono font-bold text-brand shrink-0 mt-0.5">
                     [{src.num}]
                   </span>
                   <div className="min-w-0">
-                    <p className="text-xs text-ink truncate">{src.title}</p>
-                    <p className="text-[10px] text-ink-muted">{src.author}</p>
+                    <p className="text-xs text-shell-active truncate">{src.title}</p>
+                    <p className="text-[10px] text-shell-text">{src.author}</p>
                   </div>
                 </div>
               ))
             ) : (
-              <p className="text-[10px] text-ink-muted text-center py-2">
+              <p className="text-[10px] text-shell-text text-center py-2">
                 Use Cmd+Shift+C to add citations
               </p>
             )}
@@ -642,7 +642,7 @@ function StudioContent() {
           </div>
         </div>
 
-        <div className="mt-auto px-4 py-4 border-t border-border-subtle">
+        <div className="mt-auto px-4 py-4 border-t border-shell-border">
           <ProgressBar
             value={usageStats?.tokens_used ?? 0}
             max={usageStats?.tokens_limit ?? 50000}
@@ -658,7 +658,7 @@ function StudioContent() {
           <div className="px-4 py-2 bg-brand/5 border-b border-brand/10">
             <div className="flex items-center justify-between">
               <p className="text-xs font-medium text-ink-muted">AI Intensity</p>
-              <div className="flex p-0.5 bg-surface-raised rounded-lg">
+              <div className="flex p-0.5 bg-surface-raised rounded">
                 {(["focus", "collaborate", "accelerate"] as DraftModeIntensity[]).map((mode) => (
                   <button
                     key={mode}
@@ -699,7 +699,7 @@ function StudioContent() {
                   <CaretDown size={10} />
                 </button>
                 {showDocTypePicker && (
-                  <div className="absolute right-0 top-full mt-1 w-48 rounded-lg glass-panel border border-border shadow-lg z-50 py-1">
+                  <div className="absolute right-0 top-full mt-1 w-48 rounded bg-surface border border-border shadow-lg z-50 py-1">
                     {(Object.entries(GUIDE_DOC_TYPE_LABELS) as [GuideDocumentType, string][]).map(([key, label]) => (
                       <button
                         key={key}
@@ -751,13 +751,13 @@ function StudioContent() {
           <div className="relative">
             <button
               onClick={() => setShowExport((v) => !v)}
-              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium text-ink-muted hover:text-ink bg-surface-raised hover:bg-surface-raised/80 border border-border transition-colors"
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded text-xs font-medium text-ink-muted hover:text-ink bg-surface-raised hover:bg-surface-raised/80 border border-border transition-colors"
             >
               <DownloadSimple size={14} />
               Export
             </button>
             {showExport && (
-              <div className="absolute right-0 top-full mt-1 w-48 rounded-lg glass-panel border border-border shadow-lg z-50">
+              <div className="absolute right-0 top-full mt-1 w-48 rounded bg-surface border border-border shadow-lg z-50">
                 <button
                   onClick={handleExportPDF}
                   className="flex items-center gap-2 w-full px-3 py-2 text-xs text-ink hover:bg-surface-raised rounded-t-lg transition-colors"
@@ -819,16 +819,16 @@ function StudioContent() {
           onOpenCitationDialog={openCitationDialog}
         />
       ) : (
-        <aside className="w-80 shrink-0 glass-panel border-l border-border flex flex-col">
-          <div className="px-4 py-3 border-b border-border-subtle">
-            <Tabs tabs={aiPanelTabs} activeTab={aiTab} onChange={setAiTab} />
+        <aside className="w-80 shrink-0 bg-shell border-l border-shell-border flex flex-col text-shell-active">
+          <div className="px-4 py-3 border-b border-shell-border">
+            <Tabs tabs={aiPanelTabs} activeTab={aiTab} onChange={setAiTab} variant="dark" />
           </div>
 
           {aiTab === "chat" && (
             <div className="flex-1 flex flex-col overflow-hidden">
-              <div className="flex-1 overflow-y-auto px-4 py-3 space-y-3">
+              <div className="flex-1 overflow-y-auto scroll-subtle px-4 py-3 space-y-3">
                 {chatError && (
-                  <div className="p-3 rounded-lg bg-amber-500/10 text-amber-500 text-xs">
+                  <div className="p-3 rounded bg-amber-500/10 text-amber-400 text-xs">
                     {chatError}
                   </div>
                 )}
@@ -847,10 +847,10 @@ function StudioContent() {
                     )}
                     <div
                       className={cn(
-                        "max-w-[85%] px-3 py-2 rounded-xl text-sm",
+                        "max-w-[85%] px-3 py-2 rounded text-sm",
                         msg.role === "user"
-                          ? "bg-surface-raised text-ink"
-                          : "bg-brand/5 text-ink"
+                          ? "bg-white/10 text-shell-active"
+                          : "bg-brand/10 text-shell-active"
                       )}
                     >
                       <p className="whitespace-pre-wrap text-xs leading-relaxed">{msg.content}</p>
@@ -862,7 +862,7 @@ function StudioContent() {
                     <div className="w-6 h-6 rounded-full bg-brand/20 flex items-center justify-center shrink-0">
                       <Sparkle size={12} className="text-brand animate-spin" />
                     </div>
-                    <div className="px-3 py-2 rounded-xl bg-brand/5">
+                    <div className="px-3 py-2 rounded bg-brand/10">
                       <div className="flex gap-1">
                         <span className="w-1.5 h-1.5 rounded-full bg-brand/40 animate-bounce" />
                         <span className="w-1.5 h-1.5 rounded-full bg-brand/40 animate-bounce [animation-delay:150ms]" />
@@ -873,18 +873,18 @@ function StudioContent() {
                 )}
                 <div ref={messagesEndRef} />
               </div>
-              <form onSubmit={handleSubmit} className="px-4 py-3 border-t border-border-subtle">
+              <form onSubmit={handleSubmit} className="px-4 py-3 border-t border-shell-border">
                 <div className="flex gap-2">
                   <input
                     value={input}
                     onChange={(e) => setInput(e.target.value)}
                     placeholder={isLearnMode ? "Ask me to challenge your thinking..." : "Ask your AI research assistant..."}
-                    className="flex-1 px-3 py-2 rounded-xl bg-surface-raised border border-border text-ink placeholder:text-ink-muted text-xs focus:outline-none focus:ring-2 focus:ring-brand/40"
+                    className="flex-1 px-3 py-2 rounded bg-white/5 border border-shell-border text-shell-active placeholder:text-shell-text text-xs focus:outline-none focus:ring-2 focus:ring-brand/40"
                   />
                   <button
                     type="submit"
                     disabled={isLoading || !input.trim()}
-                    className="p-2 rounded-xl bg-brand text-white hover:bg-brand-hover transition-colors disabled:opacity-50"
+                    className="p-2 rounded bg-brand text-white hover:bg-brand-hover transition-colors disabled:opacity-50"
                   >
                     <PaperPlaneRight size={16} />
                   </button>
@@ -894,25 +894,25 @@ function StudioContent() {
           )}
 
           {aiTab === "research" && (
-            <div className="flex-1 px-4 py-3 space-y-3 overflow-y-auto">
+            <div className="flex-1 px-4 py-3 space-y-3 overflow-y-auto scroll-subtle">
               <button
                 onClick={() => useResearchStore.getState().openSidebar()}
-                className="w-full flex items-center justify-center gap-2 px-4 py-3 rounded-lg bg-brand/10 border border-brand/20 text-brand text-xs font-medium hover:bg-brand/15 transition-colors"
+                className="w-full flex items-center justify-center gap-2 px-4 py-3 rounded bg-brand/10 border border-brand/20 text-brand text-xs font-medium hover:bg-brand/15 transition-colors"
               >
                 <Books size={16} />
                 Open Literature Research Panel
               </button>
-              <p className="text-center text-[10px] text-ink-muted">
-                Or press <kbd className="px-1 py-0.5 rounded bg-surface-raised border border-border text-[9px]">Cmd+Shift+L</kbd> to toggle
+              <p className="text-center text-[10px] text-shell-text">
+                Or press <kbd className="px-1 py-0.5 rounded bg-white/5 border border-shell-border text-[9px]">Cmd+Shift+L</kbd> to toggle
               </p>
               <div className="flex gap-2">
                 <div className="relative flex-1">
-                  <MagnifyingGlass size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-ink-muted" />
+                  <MagnifyingGlass size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-shell-text" />
                   <input
                     value={researchQuery}
                     onChange={(e) => setResearchQuery(e.target.value)}
                     placeholder="Quick search PubMed..."
-                    className="w-full pl-8 pr-3 py-2 rounded-lg bg-surface-raised border border-border text-ink placeholder:text-ink-muted text-xs focus:outline-none"
+                    className="w-full pl-8 pr-3 py-2 rounded bg-white/5 border border-shell-border text-shell-active placeholder:text-shell-text text-xs focus:outline-none"
                   />
                 </div>
                 <button
@@ -924,7 +924,7 @@ function StudioContent() {
                       store.setActiveTab("search");
                     }
                   }}
-                  className="px-3 py-2 rounded-lg bg-brand text-white text-xs font-medium hover:bg-brand-hover transition-colors"
+                  className="px-3 py-2 rounded bg-brand text-white text-xs font-medium hover:bg-brand-hover transition-colors"
                 >
                   Search
                 </button>
@@ -933,24 +933,24 @@ function StudioContent() {
           )}
 
           {aiTab === "checks" && (
-            <div className="flex-1 px-4 py-3 space-y-4 overflow-y-auto">
+            <div className="flex-1 px-4 py-3 space-y-4 overflow-y-auto scroll-subtle">
               <div className="flex flex-col items-center py-4">
                 <CircularGauge value={92} label="Human Score" size={100} />
               </div>
               <div className="space-y-3">
-                <div className="p-3 rounded-lg bg-surface-raised">
+                <div className="p-3 rounded bg-white/5">
                   <div className="flex items-center gap-2 mb-1">
                     <ShieldCheck size={14} className="text-emerald-500" />
-                    <span className="text-xs font-medium text-ink">AI Detection</span>
+                    <span className="text-xs font-medium text-shell-active">AI Detection</span>
                   </div>
-                  <p className="text-xs text-ink-muted">92% human-written confidence</p>
+                  <p className="text-xs text-shell-text">92% human-written confidence</p>
                 </div>
-                <div className="p-3 rounded-lg bg-surface-raised">
+                <div className="p-3 rounded bg-white/5">
                   <div className="flex items-center gap-2 mb-1">
                     <ShieldCheck size={14} className="text-amber-500" />
-                    <span className="text-xs font-medium text-ink">Plagiarism</span>
+                    <span className="text-xs font-medium text-shell-active">Plagiarism</span>
                   </div>
-                  <p className="text-xs text-ink-muted">2 matches found</p>
+                  <p className="text-xs text-shell-text">2 matches found</p>
                   <Link
                     href="/compliance"
                     className="text-xs text-brand hover:text-brand-hover mt-1 inline-block"

--- a/src/app/(marketing)/layout.tsx
+++ b/src/app/(marketing)/layout.tsx
@@ -3,9 +3,5 @@ export default function MarketingLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return (
-    <div className="dark" style={{ colorScheme: "dark" }}>
-      {children}
-    </div>
-  );
+  return <>{children}</>;
 }

--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -6,296 +6,312 @@ import {
   PenNib,
   ShieldCheck,
   ArrowRight,
-  Sparkle,
-  SquaresFour,
   Check,
+  Notebook,
+  ProjectorScreenChart,
+  Books,
+  FilePdf,
+  Export,
+  GraduationCap,
 } from "@phosphor-icons/react/dist/ssr";
 
 export default function LandingPage() {
   return (
-    <div className="bg-[#020617] text-[#f1f5f9] font-sans antialiased overflow-x-hidden selection:bg-sky-500 selection:text-white">
+    <div className="bg-background text-ink font-sans antialiased overflow-x-hidden">
       <MarketingNav />
 
       {/* Hero */}
-      <section className="relative pt-40 pb-32 px-6 overflow-hidden">
-        <div className="absolute top-0 left-1/2 -translate-x-1/2 w-[800px] h-[600px] bg-[radial-gradient(ellipse_at_center,rgba(14,165,233,0.12),transparent)] opacity-50 blur-[100px] pointer-events-none" />
+      <section className="relative pt-24 pb-20 px-6 overflow-hidden">
+        <div className="absolute inset-0 grid-bg opacity-40 pointer-events-none" />
 
-        <div className="max-w-5xl mx-auto text-center relative z-10">
-          <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full border border-sky-500/20 bg-sky-500/5 text-sky-400 text-xs font-medium mb-8 animate-pulse">
-            <span className="w-1.5 h-1.5 rounded-full bg-sky-400" />
-            <span>Now in Beta</span>
-          </div>
-
-          <h1 className="text-5xl md:text-7xl font-serif font-light leading-[1.1] mb-8">
-            <span className="text-transparent bg-clip-text bg-gradient-to-b from-white via-white to-white/50">
-              Think Clearly.
-            </span>
-            <br />
-            <span className="italic text-white text-glow">Write Deeply.</span>
-          </h1>
-
-          <p className="text-lg md:text-xl text-[#94a3b8] max-w-2xl mx-auto mb-12 leading-relaxed font-light">
-            Escape the noise. ScholarSync is a luminous workspace designed for
-            the flow state, combining deep research, architectural outlining, and
-            distraction-free writing.
-          </p>
-
-          <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
-            <Link
-              href="/sign-up"
-              className="group relative px-8 py-4 bg-sky-500 text-white rounded-full font-medium transition-all hover:scale-105 hover:shadow-[0_0_80px_-20px_rgba(14,165,233,0.3)] overflow-hidden"
-            >
-              <div className="absolute inset-0 bg-white/20 translate-y-full group-hover:translate-y-0 transition-transform" />
-              <span className="relative flex items-center gap-2">
-                Start Researching <ArrowRight size={16} />
-              </span>
-            </Link>
-            <a
-              href="#demo"
-              className="px-8 py-4 glass-panel text-[#94a3b8] hover:text-white rounded-full font-medium transition-all hover:border-white/20"
-            >
-              View Demo
-            </a>
-          </div>
-        </div>
-
-        {/* App Preview */}
-        <div
-          id="demo"
-          className="mt-24 max-w-6xl mx-auto relative group"
-        >
-          <div className="absolute inset-0 bg-sky-500/10 blur-[80px] -z-10 rounded-full" />
-          <div className="glass-panel rounded-xl border border-white/10 p-2 shadow-2xl relative overflow-hidden">
-            <div className="h-10 bg-black/40 border-b border-white/5 flex items-center px-4 gap-2">
-              <div className="flex gap-1.5">
-                <div className="w-3 h-3 rounded-full bg-white/10" />
-                <div className="w-3 h-3 rounded-full bg-white/10" />
-                <div className="w-3 h-3 rounded-full bg-white/10" />
+        <div className="max-w-6xl mx-auto relative z-10">
+          <div className="grid lg:grid-cols-2 gap-16 items-center">
+            <div>
+              <div className="inline-flex items-center gap-2 px-3 py-1 rounded border border-brand/20 bg-accent-muted text-brand text-xs font-medium mb-8">
+                <span className="w-1.5 h-1.5 rounded-full bg-brand animate-pulse" />
+                Now in Beta
               </div>
-              <div className="mx-auto bg-white/5 px-4 py-1 rounded-md text-[10px] text-[#94a3b8] font-mono">
-                scholarsync.app/studio
+
+              <h1 className="font-serif text-4xl md:text-5xl lg:text-6xl font-semibold leading-[1.1] mb-6 tracking-tight">
+                Think like a researcher.{" "}
+                <span className="text-brand">Write like a pro.</span>
+              </h1>
+
+              <p className="text-lg text-ink-muted max-w-lg mb-10 leading-relaxed">
+                One AI-powered workspace for finding papers, writing with citations,
+                and submitting with confidence. Built for medical students and researchers.
+              </p>
+
+              <div className="flex flex-col sm:flex-row items-start gap-4">
+                <Link
+                  href="/sign-up"
+                  className="group flex items-center gap-2 bg-brand text-white px-6 py-3 rounded font-medium text-sm hover:bg-brand-hover transition-colors"
+                >
+                  Start Writing — Free
+                  <ArrowRight size={16} className="group-hover:translate-x-0.5 transition-transform" />
+                </Link>
+                <a
+                  href="#features"
+                  className="px-6 py-3 rounded border border-border text-ink-muted hover:text-ink hover:border-ink/20 text-sm font-medium transition-all"
+                >
+                  See Features
+                </a>
               </div>
             </div>
-            <div className="bg-[#0f172a] h-[400px] md:h-[600px] flex">
-              <div className="w-64 border-r border-white/5 p-6 hidden md:block">
-                <div className="space-y-4">
-                  <div className="h-4 w-24 bg-white/10 rounded" />
-                  <div className="h-4 w-32 bg-white/5 rounded" />
-                  <div className="h-4 w-20 bg-white/5 rounded" />
-                </div>
-              </div>
-              <div className="flex-1 p-8 md:p-16 flex justify-center bg-[#020617]">
-                <div className="w-full max-w-2xl bg-[#0f172a] border border-white/5 rounded-lg shadow-2xl p-8 md:p-12">
-                  <div className="h-12 w-3/4 bg-white/10 rounded mb-8" />
-                  <div className="space-y-4">
-                    <div className="h-4 w-full bg-white/5 rounded" />
-                    <div className="h-4 w-full bg-white/5 rounded" />
-                    <div className="h-4 w-2/3 bg-white/5 rounded" />
+
+            {/* App Preview */}
+            <div className="relative hidden lg:block">
+              <div className="rounded border border-border bg-surface shadow-xl overflow-hidden">
+                <div className="h-9 bg-surface-raised border-b border-border flex items-center px-4 gap-2">
+                  <div className="flex gap-1.5">
+                    <div className="w-2.5 h-2.5 rounded-full bg-border" />
+                    <div className="w-2.5 h-2.5 rounded-full bg-border" />
+                    <div className="w-2.5 h-2.5 rounded-full bg-border" />
+                  </div>
+                  <div className="mx-auto bg-background px-4 py-0.5 rounded text-[10px] text-ink-muted font-mono">
+                    scholarsync.app/studio
                   </div>
                 </div>
-              </div>
-            </div>
-            <div className="absolute bottom-10 right-10 glass-panel p-4 rounded-xl hidden md:flex items-center gap-3 animate-bounce">
-              <div className="w-8 h-8 rounded-full bg-sky-500 flex items-center justify-center text-white">
-                <Sparkle size={16} weight="fill" />
-              </div>
-              <div className="text-sm text-white">
-                Citation Audit Complete: 100% Integrity
+                <div className="flex h-[360px]">
+                  <div className="w-48 bg-[#0e0e10] border-r border-[#27272a] p-4 hidden md:block">
+                    <div className="space-y-3">
+                      <div className="h-3 w-20 bg-white/10 rounded" />
+                      <div className="h-3 w-28 bg-white/5 rounded" />
+                      <div className="h-3 w-16 bg-white/5 rounded" />
+                    </div>
+                  </div>
+                  <div className="flex-1 p-8 bg-surface">
+                    <div className="max-w-sm mx-auto">
+                      <div className="h-8 w-3/4 bg-ink/10 rounded mb-6" />
+                      <div className="space-y-3">
+                        <div className="h-3 w-full bg-ink/5 rounded" />
+                        <div className="h-3 w-full bg-ink/5 rounded" />
+                        <div className="h-3 w-2/3 bg-ink/5 rounded" />
+                        <div className="h-3 w-full bg-ink/5 rounded" />
+                        <div className="h-3 w-1/2 bg-ink/5 rounded" />
+                      </div>
+                    </div>
+                  </div>
+                  <div className="w-48 bg-[#0e0e10] border-l border-[#27272a] p-4 hidden md:block">
+                    <div className="space-y-3">
+                      <div className="h-3 w-16 bg-white/10 rounded" />
+                      <div className="h-3 w-24 bg-white/5 rounded" />
+                      <div className="h-3 w-20 bg-white/5 rounded" />
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
         </div>
       </section>
 
+      {/* Problem Section */}
+      <section className="py-20 px-6 border-t border-border">
+        <div className="max-w-3xl mx-auto text-center">
+          <h2 className="font-serif text-2xl md:text-3xl font-semibold mb-6">
+            You&apos;ve been here before.
+          </h2>
+          <p className="text-ink-muted leading-relaxed text-lg">
+            Thirty browser tabs. A half-written draft. Citations scattered across
+            three apps. The deadline is tomorrow, and you&apos;re still
+            reformatting references. Academic writing shouldn&apos;t feel this broken.
+          </p>
+        </div>
+      </section>
+
+      {/* Solution Bridge */}
+      <section className="py-16 px-6 bg-accent-muted border-y border-brand/10">
+        <div className="max-w-3xl mx-auto text-center">
+          <p className="font-serif text-xl md:text-2xl text-brand font-medium">
+            One workspace. Everything your paper needs.
+          </p>
+        </div>
+      </section>
+
       {/* Features */}
-      <section
-        id="features"
-        className="py-32 px-6 bg-[#0f172a] relative border-t border-white/5"
-      >
-        <div className="max-w-7xl mx-auto">
+      <section id="features" className="py-24 px-6">
+        <div className="max-w-6xl mx-auto">
           <div className="text-center mb-16">
-            <h2 className="font-serif text-3xl md:text-4xl text-white mb-4">
-              Built for Researchers
+            <p className="text-xs font-mono text-brand uppercase tracking-widest mb-3">FEATURES</p>
+            <h2 className="font-serif text-3xl md:text-4xl font-semibold">
+              Built for the way you work
             </h2>
-            <p className="text-[#94a3b8] max-w-xl mx-auto">
-              Every feature designed to keep you in flow state.
-            </p>
           </div>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
-            <div className="glass-panel p-8 rounded-2xl hover:bg-white/5 transition-colors group">
-              <div className="w-12 h-12 rounded-xl bg-sky-500/10 flex items-center justify-center text-sky-400 mb-6 group-hover:scale-110 transition-transform">
-                <GlobeHemisphereWest size={24} />
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {[
+              {
+                icon: GlobeHemisphereWest,
+                tag: "DISCOVER",
+                title: "Find papers fast",
+                desc: "Search 282M+ papers across PubMed, Semantic Scholar, and OpenAlex. AI-augmented queries find what you actually need.",
+              },
+              {
+                icon: PenNib,
+                tag: "WRITE",
+                title: "Write with citations",
+                desc: "A distraction-free editor with inline citations, auto-formatting in APA, Vancouver, and 10,000+ styles.",
+              },
+              {
+                icon: Brain,
+                tag: "THINK",
+                title: "AI that helps you think",
+                desc: "Socratic co-pilot that challenges your arguments, detects weak claims, and teaches methodology — never writes for you.",
+              },
+              {
+                icon: ShieldCheck,
+                tag: "CHECK",
+                title: "Submit with confidence",
+                desc: "AI detection, plagiarism scanning, and citation verification. Know your paper is clean before you submit.",
+              },
+            ].map((card) => (
+              <div
+                key={card.title}
+                className="group p-6 rounded border border-border bg-surface hover:border-brand/30 hover:shadow-sm transition-all"
+              >
+                <div className="w-10 h-10 rounded bg-accent-muted flex items-center justify-center text-brand mb-4 group-hover:scale-110 transition-transform">
+                  <card.icon size={20} />
+                </div>
+                <p className="text-[10px] font-mono text-brand uppercase tracking-widest mb-2">{card.tag}</p>
+                <h3 className="font-semibold text-ink mb-2">{card.title}</h3>
+                <p className="text-sm text-ink-muted leading-relaxed">{card.desc}</p>
               </div>
-              <h3 className="font-serif text-xl text-white mb-3">
-                Deep Research
-              </h3>
-              <p className="text-[#94a3b8] text-sm leading-relaxed">
-                Search 200M+ papers from PubMed and Semantic Scholar. Find
-                consensus, not just citations.
-              </p>
-            </div>
+            ))}
+          </div>
+        </div>
+      </section>
 
-            <div className="glass-panel p-8 rounded-2xl hover:bg-white/5 transition-colors group">
-              <div className="w-12 h-12 rounded-xl bg-indigo-500/10 flex items-center justify-center text-indigo-400 mb-6 group-hover:scale-110 transition-transform">
-                <Brain size={24} />
+      {/* How It Works */}
+      <section id="how-it-works" className="py-24 px-6 bg-surface-raised border-y border-border">
+        <div className="max-w-4xl mx-auto">
+          <div className="text-center mb-16">
+            <p className="text-xs font-mono text-brand uppercase tracking-widest mb-3">WORKFLOW</p>
+            <h2 className="font-serif text-3xl md:text-4xl font-semibold">
+              Three steps to a better paper
+            </h2>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+            {[
+              { num: "1", title: "Research", desc: "Search across databases, save papers, and let AI synthesize findings into structured notes." },
+              { num: "2", title: "Write", desc: "Draft in a serif editor with inline citations, AI suggestions, and real-time word count." },
+              { num: "3", title: "Check & Export", desc: "Run compliance checks, format references, and export to PDF or Word in one click." },
+            ].map((step) => (
+              <div key={step.num} className="text-center">
+                <div className="w-10 h-10 rounded-full bg-brand text-white font-mono font-bold flex items-center justify-center mx-auto mb-4">
+                  {step.num}
+                </div>
+                <h3 className="font-semibold text-ink mb-2">{step.title}</h3>
+                <p className="text-sm text-ink-muted leading-relaxed">{step.desc}</p>
               </div>
-              <h3 className="font-serif text-xl text-white mb-3">
-                Socratic Co-Pilot
-              </h3>
-              <p className="text-[#94a3b8] text-sm leading-relaxed">
-                It doesn&apos;t write for you; it thinks with you. Challenge
-                arguments and detect weak claims in real time.
-              </p>
-            </div>
+            ))}
+          </div>
+        </div>
+      </section>
 
-            <div className="glass-panel p-8 rounded-2xl hover:bg-white/5 transition-colors group">
-              <div className="w-12 h-12 rounded-xl bg-rose-500/10 flex items-center justify-center text-rose-400 mb-6 group-hover:scale-110 transition-transform">
-                <PenNib size={24} />
+      {/* Secondary Features */}
+      <section className="py-24 px-6">
+        <div className="max-w-6xl mx-auto">
+          <div className="text-center mb-16">
+            <p className="text-xs font-mono text-brand uppercase tracking-widest mb-3">AND MORE</p>
+            <h2 className="font-serif text-3xl md:text-4xl font-semibold">
+              Everything else you need
+            </h2>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {[
+              { icon: Notebook, title: "Source Notebook", desc: "Upload PDFs and synthesize research across multiple papers with RAG." },
+              { icon: ProjectorScreenChart, title: "Slide Generator", desc: "Convert your paper into presentation slides automatically." },
+              { icon: Books, title: "Reference Library", desc: "Save, organize, and manage your entire paper collection." },
+              { icon: FilePdf, title: "PDF Chat", desc: "Ask questions about any uploaded paper. Get answers with page references." },
+              { icon: Export, title: "Export Anywhere", desc: "PDF, Word, and LaTeX export with properly formatted citations." },
+              { icon: GraduationCap, title: "Learn Mode", desc: "Socratic tutoring that teaches research methodology step by step." },
+            ].map((card) => (
+              <div key={card.title} className="flex gap-4 p-4 rounded border border-border bg-surface hover:border-brand/20 transition-colors">
+                <div className="w-9 h-9 rounded bg-accent-muted flex items-center justify-center text-brand shrink-0">
+                  <card.icon size={18} />
+                </div>
+                <div>
+                  <h3 className="font-medium text-ink text-sm mb-1">{card.title}</h3>
+                  <p className="text-xs text-ink-muted leading-relaxed">{card.desc}</p>
+                </div>
               </div>
-              <h3 className="font-serif text-xl text-white mb-3">
-                Luminous Editor
-              </h3>
-              <p className="text-[#94a3b8] text-sm leading-relaxed">
-                A writing surface that respects focus. Automated citations and
-                structure management built in.
-              </p>
-            </div>
-
-            <div className="glass-panel p-8 rounded-2xl hover:bg-white/5 transition-colors group">
-              <div className="w-12 h-12 rounded-xl bg-emerald-500/10 flex items-center justify-center text-emerald-400 mb-6 group-hover:scale-110 transition-transform">
-                <ShieldCheck size={24} />
-              </div>
-              <h3 className="font-serif text-xl text-white mb-3">
-                Integrity Guard
-              </h3>
-              <p className="text-[#94a3b8] text-sm leading-relaxed">
-                AI plagiarism detection and citation verification. Submit with
-                confidence every time.
-              </p>
-            </div>
+            ))}
           </div>
         </div>
       </section>
 
       {/* Pricing */}
-      <section
-        id="pricing"
-        className="py-32 px-6 bg-[#020617] border-t border-white/5"
-      >
+      <section id="pricing" className="py-24 px-6 bg-surface-raised border-y border-border">
         <div className="max-w-5xl mx-auto">
           <div className="text-center mb-16">
-            <h2 className="font-serif text-3xl md:text-4xl text-white mb-4">
-              Membership
+            <p className="text-xs font-mono text-brand uppercase tracking-widest mb-3">PRICING</p>
+            <h2 className="font-serif text-3xl md:text-4xl font-semibold mb-3">
+              Simple, honest pricing
             </h2>
-            <p className="text-[#94a3b8]">
-              Free tier for exploring, Pro tier for sustained research
-              workflows.
-            </p>
+            <p className="text-ink-muted">Start free. Upgrade when you need more.</p>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             {/* Free */}
-            <div className="glass-panel rounded-2xl p-8 flex flex-col">
-              <h3 className="text-lg font-semibold text-white mb-1">Free</h3>
-              <div className="text-3xl font-bold text-white mb-6">
-                ₹0
-                <span className="text-sm font-normal text-[#94a3b8]">
-                  /month
-                </span>
+            <div className="rounded border border-border bg-surface p-6 flex flex-col">
+              <h3 className="font-semibold text-ink mb-1">Free</h3>
+              <div className="text-3xl font-bold text-ink mb-6">
+                &#8377;0<span className="text-sm font-normal text-ink-muted">/month</span>
               </div>
-              <ul className="space-y-3 text-sm text-[#94a3b8] mb-8 flex-1">
-                <li className="flex items-center gap-2">
-                  <Check size={16} className="text-sky-400" /> 10K AI tokens
-                </li>
-                <li className="flex items-center gap-2">
-                  <Check size={16} className="text-sky-400" /> 50 paper searches
-                </li>
-                <li className="flex items-center gap-2">
-                  <Check size={16} className="text-sky-400" /> 1 plagiarism check
-                </li>
-                <li className="flex items-center gap-2">
-                  <Check size={16} className="text-sky-400" /> 3 projects
-                </li>
+              <ul className="space-y-3 text-sm text-ink-muted mb-8 flex-1">
+                <li className="flex items-center gap-2"><Check size={16} className="text-brand shrink-0" /> 10K AI tokens</li>
+                <li className="flex items-center gap-2"><Check size={16} className="text-brand shrink-0" /> 50 paper searches</li>
+                <li className="flex items-center gap-2"><Check size={16} className="text-brand shrink-0" /> 1 plagiarism check</li>
+                <li className="flex items-center gap-2"><Check size={16} className="text-brand shrink-0" /> 3 projects</li>
               </ul>
               <Link
                 href="/sign-up"
-                className="block text-center py-3 rounded-full border border-white/10 text-white text-sm font-medium hover:bg-white/5 transition-colors"
+                className="block text-center py-3 rounded border border-border text-ink text-sm font-medium hover:bg-surface-raised transition-colors"
               >
                 Get Started
               </Link>
             </div>
 
-            {/* Basic */}
-            <div className="glass-panel rounded-2xl p-8 flex flex-col ring-2 ring-sky-500/50 relative">
-              <div className="absolute -top-3 left-1/2 -translate-x-1/2 px-3 py-1 bg-sky-500 text-white text-xs font-bold rounded-full">
+            {/* Basic — Recommended */}
+            <div className="rounded border-2 border-brand bg-surface p-6 flex flex-col relative">
+              <div className="absolute -top-3 left-1/2 -translate-x-1/2 px-3 py-0.5 bg-brand text-white text-xs font-medium rounded">
                 Popular
               </div>
-              <h3 className="text-lg font-semibold text-white mb-1">Basic</h3>
-              <div className="text-3xl font-bold text-white mb-6">
-                ₹1,000
-                <span className="text-sm font-normal text-[#94a3b8]">
-                  /month
-                </span>
+              <h3 className="font-semibold text-ink mb-1">Basic</h3>
+              <div className="text-3xl font-bold text-ink mb-6">
+                &#8377;1,000<span className="text-sm font-normal text-ink-muted">/month</span>
               </div>
-              <ul className="space-y-3 text-sm text-[#94a3b8] mb-8 flex-1">
-                <li className="flex items-center gap-2">
-                  <Check size={16} className="text-sky-400" /> 100K AI tokens
-                </li>
-                <li className="flex items-center gap-2">
-                  <Check size={16} className="text-sky-400" /> Unlimited searches
-                </li>
-                <li className="flex items-center gap-2">
-                  <Check size={16} className="text-sky-400" /> 10 plagiarism
-                  checks
-                </li>
-                <li className="flex items-center gap-2">
-                  <Check size={16} className="text-sky-400" /> 10 exports
-                </li>
-                <li className="flex items-center gap-2">
-                  <Check size={16} className="text-sky-400" /> 5 deep research
-                  sessions
-                </li>
+              <ul className="space-y-3 text-sm text-ink-muted mb-8 flex-1">
+                <li className="flex items-center gap-2"><Check size={16} className="text-brand shrink-0" /> 100K AI tokens</li>
+                <li className="flex items-center gap-2"><Check size={16} className="text-brand shrink-0" /> Unlimited searches</li>
+                <li className="flex items-center gap-2"><Check size={16} className="text-brand shrink-0" /> 10 plagiarism checks</li>
+                <li className="flex items-center gap-2"><Check size={16} className="text-brand shrink-0" /> 10 exports</li>
+                <li className="flex items-center gap-2"><Check size={16} className="text-brand shrink-0" /> 5 deep research sessions</li>
               </ul>
               <Link
                 href="/sign-up"
-                className="block text-center py-3 rounded-full bg-sky-500 text-white text-sm font-medium hover:bg-sky-600 transition-colors"
+                className="block text-center py-3 rounded bg-brand text-white text-sm font-medium hover:bg-brand-hover transition-colors"
               >
                 Get Started
               </Link>
             </div>
 
             {/* Pro */}
-            <div className="glass-panel rounded-2xl p-8 flex flex-col">
-              <h3 className="text-lg font-semibold text-white mb-1">Pro</h3>
-              <div className="text-3xl font-bold text-white mb-6">
-                ₹2,000
-                <span className="text-sm font-normal text-[#94a3b8]">
-                  /month
-                </span>
+            <div className="rounded border border-border bg-surface p-6 flex flex-col">
+              <h3 className="font-semibold text-ink mb-1">Pro</h3>
+              <div className="text-3xl font-bold text-ink mb-6">
+                &#8377;2,000<span className="text-sm font-normal text-ink-muted">/month</span>
               </div>
-              <ul className="space-y-3 text-sm text-[#94a3b8] mb-8 flex-1">
-                <li className="flex items-center gap-2">
-                  <Check size={16} className="text-sky-400" /> 500K AI tokens
-                </li>
-                <li className="flex items-center gap-2">
-                  <Check size={16} className="text-sky-400" /> Unlimited
-                  everything
-                </li>
-                <li className="flex items-center gap-2">
-                  <Check size={16} className="text-sky-400" /> 50 plagiarism
-                  checks
-                </li>
-                <li className="flex items-center gap-2">
-                  <Check size={16} className="text-sky-400" /> 25 deep research
-                  sessions
-                </li>
-                <li className="flex items-center gap-2">
-                  <Check size={16} className="text-sky-400" /> Priority support
-                </li>
+              <ul className="space-y-3 text-sm text-ink-muted mb-8 flex-1">
+                <li className="flex items-center gap-2"><Check size={16} className="text-brand shrink-0" /> 500K AI tokens</li>
+                <li className="flex items-center gap-2"><Check size={16} className="text-brand shrink-0" /> Unlimited everything</li>
+                <li className="flex items-center gap-2"><Check size={16} className="text-brand shrink-0" /> 50 plagiarism checks</li>
+                <li className="flex items-center gap-2"><Check size={16} className="text-brand shrink-0" /> 25 deep research sessions</li>
+                <li className="flex items-center gap-2"><Check size={16} className="text-brand shrink-0" /> Priority support</li>
               </ul>
               <Link
                 href="/sign-up"
-                className="block text-center py-3 rounded-full border border-white/10 text-white text-sm font-medium hover:bg-white/5 transition-colors"
+                className="block text-center py-3 rounded border border-border text-ink text-sm font-medium hover:bg-surface-raised transition-colors"
               >
                 Get Started
               </Link>
@@ -304,40 +320,53 @@ export default function LandingPage() {
         </div>
       </section>
 
-      {/* Social Proof */}
-      <section className="py-24 px-6 bg-[#0f172a] border-t border-white/5">
-        <div className="max-w-4xl mx-auto text-center">
-          <p className="text-2xl md:text-3xl font-serif italic text-white/80 leading-relaxed mb-8">
-            &ldquo;ScholarSync changed how I approach my thesis. The deep
-            research mode found connections across 300 papers that I would have
-            missed manually.&rdquo;
+      {/* Founder Note */}
+      <section className="py-20 px-6">
+        <div className="max-w-3xl mx-auto text-center">
+          <p className="text-xs font-mono text-brand uppercase tracking-widest mb-6">FROM THE FOUNDER</p>
+          <p className="font-serif text-xl md:text-2xl text-ink leading-relaxed mb-6 italic">
+            &ldquo;I built ScholarSync because I was tired of juggling five tools
+            to write one paper. This is the workspace I wish I had during my
+            residency.&rdquo;
           </p>
-          <div className="text-[#94a3b8] text-sm">
-            — Dr. Priya Sharma, AIIMS New Delhi
-          </div>
+          <p className="text-sm text-ink-muted">— Dr. Shailesh Singh</p>
+        </div>
+      </section>
+
+      {/* Final CTA */}
+      <section className="py-20 px-6 bg-ink text-background">
+        <div className="max-w-3xl mx-auto text-center">
+          <h2 className="font-serif text-3xl md:text-4xl font-semibold mb-4">
+            Your next paper doesn&apos;t have to be this hard.
+          </h2>
+          <p className="text-background/60 mb-8">
+            Join researchers who are writing smarter, not harder.
+          </p>
+          <Link
+            href="/sign-up"
+            className="inline-flex items-center gap-2 bg-brand text-white px-8 py-3 rounded font-medium hover:bg-brand-hover transition-colors"
+          >
+            Start Writing — Free <ArrowRight size={16} />
+          </Link>
         </div>
       </section>
 
       {/* Footer */}
-      <footer className="bg-[#020617] border-t border-white/5 py-12 px-6">
-        <div className="max-w-7xl mx-auto flex flex-col md:flex-row justify-between items-center gap-6 opacity-60">
+      <footer className="bg-background border-t border-border py-10 px-6">
+        <div className="max-w-6xl mx-auto flex flex-col md:flex-row justify-between items-center gap-6">
           <div className="flex items-center gap-2">
-            <SquaresFour size={16} className="text-white" weight="fill" />
-            <span className="font-semibold text-white">ScholarSync</span>
+            <div className="w-6 h-6 rounded bg-brand flex items-center justify-center">
+              <span className="font-serif text-white font-bold text-xs leading-none">S</span>
+            </div>
+            <span className="font-serif font-semibold text-ink text-sm">ScholarSync</span>
           </div>
-          <div className="text-sm text-[#94a3b8] flex gap-6">
-            <a href="#" className="hover:text-white transition-colors">
-              Privacy
-            </a>
-            <a href="#" className="hover:text-white transition-colors">
-              Terms
-            </a>
-            <a href="#" className="hover:text-white transition-colors">
-              Twitter
-            </a>
+          <div className="text-sm text-ink-muted flex gap-6">
+            <a href="#" className="hover:text-ink transition-colors">Privacy</a>
+            <a href="#" className="hover:text-ink transition-colors">Terms</a>
+            <a href="#" className="hover:text-ink transition-colors">Twitter</a>
           </div>
-          <div className="text-sm text-[#94a3b8]">
-            &copy; 2026 ScholarSync Inc.
+          <div className="text-sm text-ink-muted">
+            &copy; 2026 ScholarSync. All rights reserved.
           </div>
         </div>
       </footer>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,92 +12,143 @@
   --color-glow: var(--glow);
   --color-brand: var(--brand);
   --color-brand-hover: var(--brand-hover);
+  --color-shell: var(--shell);
+  --color-shell-border: var(--shell-border);
+  --color-shell-text: var(--shell-text);
+  --color-shell-active: var(--shell-active);
+  --color-accent-muted: var(--accent-muted);
   --font-sans: var(--font-sans-family);
   --font-serif: var(--font-serif-family);
+  --font-mono: var(--font-mono-family);
 }
 
 :root {
-  --background: #f8fafc;
+  --background: #faf9f7;
   --surface: #ffffff;
-  --surface-raised: #f1f5f9;
-  --ink: #0f172a;
-  --ink-muted: #64748b;
-  --border-color: #e2e8f0;
-  --border-subtle: #f1f5f9;
-  --glass: rgba(255, 255, 255, 0.8);
-  --glass-border: rgba(226, 232, 240, 0.6);
-  --glow: #6366f1;
-  --brand: #6366f1;
-  --brand-hover: #4f46e5;
-  --font-sans-family: var(--font-plus-jakarta), system-ui, sans-serif;
-  --font-serif-family: var(--font-merriweather), Georgia, serif;
+  --surface-raised: #f5f5f4;
+  --ink: #1a1a1a;
+  --ink-muted: #57534e;
+  --border-color: #e7e5e4;
+  --border-subtle: #f5f5f4;
+  --glass: rgba(250, 249, 247, 0.9);
+  --glass-border: rgba(231, 229, 228, 0.6);
+  --glow: #ea580c;
+  --brand: #ea580c;
+  --brand-hover: #dc4a04;
+  --shell: #0e0e10;
+  --shell-border: #27272a;
+  --shell-text: #71717a;
+  --shell-active: #e4e4e7;
+  --accent-muted: rgba(234, 88, 12, 0.08);
+  --font-sans-family: var(--font-inter), system-ui, sans-serif;
+  --font-serif-family: var(--font-crimson-pro), Georgia, serif;
+  --font-mono-family: var(--font-jetbrains-mono), 'JetBrains Mono', monospace;
 }
 
 .dark {
-  --background: #020617;
-  --surface: #0f172a;
-  --surface-raised: #1e293b;
-  --ink: #f1f5f9;
-  --ink-muted: #94a3b8;
-  --border-color: rgba(255, 255, 255, 0.08);
+  --background: #111113;
+  --surface: #18181b;
+  --surface-raised: #1f1f23;
+  --ink: #e4e4e7;
+  --ink-muted: #a1a1aa;
+  --border-color: #27272a;
   --border-subtle: rgba(255, 255, 255, 0.04);
-  --glass: rgba(15, 23, 42, 0.6);
-  --glass-border: rgba(255, 255, 255, 0.08);
-  --glow: #0ea5e9;
-  --brand: #6366f1;
-  --brand-hover: #818cf8;
+  --glass: rgba(17, 17, 19, 0.9);
+  --glass-border: rgba(39, 39, 42, 0.6);
+  --glow: #ea580c;
+  --brand: #ea580c;
+  --brand-hover: #f97316;
+  --shell: #0a0a0b;
+  --shell-border: #1f1f23;
+  --shell-text: #52525b;
+  --shell-active: #e4e4e7;
+  --accent-muted: rgba(234, 88, 12, 0.12);
   --font-sans-family: var(--font-inter), system-ui, sans-serif;
-  --font-serif-family: var(--font-merriweather), Georgia, serif;
+  --font-serif-family: var(--font-crimson-pro), Georgia, serif;
+  --font-mono-family: var(--font-jetbrains-mono), 'JetBrains Mono', monospace;
 }
 
 body {
   font-family: var(--font-sans-family);
 }
 
+::selection {
+  background: var(--brand);
+  color: white;
+}
+
 .glass-panel {
   background: var(--glass);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
   border: 1px solid var(--glass-border);
 }
 
-:root .glass-panel {
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
+.grid-bg {
+  background-image: linear-gradient(to right, var(--border-color) 1px, transparent 1px),
+                    linear-gradient(to bottom, var(--border-color) 1px, transparent 1px);
+  background-size: 48px 48px;
 }
 
-.text-glow {
-  text-shadow: 0 0 20px var(--glow), 0 0 40px color-mix(in srgb, var(--glow) 30%, transparent);
-}
+/* Subtle scrollbar for dark panels */
+.scroll-subtle::-webkit-scrollbar { width: 4px; }
+.scroll-subtle::-webkit-scrollbar-track { background: transparent; }
+.scroll-subtle::-webkit-scrollbar-thumb { background: #3f3f46; border-radius: 2px; }
+.scroll-subtle::-webkit-scrollbar-thumb:hover { background: #52525b; }
 
-.lamp-glow {
-  box-shadow: 0 0 30px color-mix(in srgb, var(--glow) 20%, transparent),
-    0 0 60px color-mix(in srgb, var(--glow) 10%, transparent);
+/* Light scrollbar for editor */
+.scroll-light::-webkit-scrollbar { width: 4px; }
+.scroll-light::-webkit-scrollbar-track { background: transparent; }
+.scroll-light::-webkit-scrollbar-thumb { background: #d4d4d8; border-radius: 2px; }
+
+/* Citation link style */
+.cite-link {
+  color: var(--brand);
+  text-decoration: none;
+  border-bottom: 1px solid rgba(234, 88, 12, 0.3);
+  transition: border-color 0.15s ease;
+  cursor: pointer;
 }
+.cite-link:hover { border-bottom-color: var(--brand); }
+
+/* AI highlight on text */
+.ai-flag {
+  background: rgba(234, 88, 12, 0.06);
+  border-bottom: 2px solid rgba(234, 88, 12, 0.4);
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+.ai-flag:hover { background: rgba(234, 88, 12, 0.12); }
 
 /* ===== Academic Editor Styles ===== */
 
 .academic-editor-content {
   font-family: var(--font-serif-family);
-  font-size: 16px;
-  line-height: 1.75;
+  font-size: 18px;
+  line-height: 1.85;
   color: var(--ink);
+  caret-color: var(--brand);
+}
+
+.academic-editor-content ::selection {
+  background: rgba(234, 88, 12, 0.2);
 }
 
 /* Headings */
 .academic-editor-content h1 {
-  font-family: var(--font-sans-family);
-  font-size: 28px;
-  font-weight: 700;
-  line-height: 1.3;
+  font-family: var(--font-serif-family);
+  font-size: 2.25rem;
+  font-weight: 600;
+  line-height: 1.08;
   margin-top: 0;
-  margin-bottom: 0.75rem;
+  margin-bottom: 1rem;
   color: var(--ink);
+  letter-spacing: -0.02em;
 }
 
 .academic-editor-content h2 {
-  font-family: var(--font-sans-family);
-  font-size: 22px;
+  font-family: var(--font-serif-family);
+  font-size: 1.5rem;
   font-weight: 600;
   line-height: 1.3;
   margin-top: 2rem;
@@ -108,8 +159,8 @@ body {
 }
 
 .academic-editor-content h3 {
-  font-family: var(--font-sans-family);
-  font-size: 18px;
+  font-family: var(--font-serif-family);
+  font-size: 1.25rem;
   font-weight: 600;
   line-height: 1.3;
   margin-top: 1.5rem;
@@ -214,21 +265,21 @@ body {
 .academic-editor-content pre {
   background: var(--surface-raised);
   border: 1px solid var(--border-color);
-  border-radius: 0.5rem;
+  border-radius: 0.25rem;
   padding: 1rem;
   margin-bottom: 0.75rem;
   overflow-x: auto;
-  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-family: var(--font-mono-family);
   font-size: 14px;
   line-height: 1.5;
 }
 
 .academic-editor-content code {
-  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-family: var(--font-mono-family);
   font-size: 0.875em;
   background: var(--surface-raised);
   border: 1px solid var(--border-color);
-  border-radius: 0.25rem;
+  border-radius: 0.125rem;
   padding: 0.1em 0.3em;
 }
 
@@ -243,15 +294,14 @@ body {
 /* Links */
 .academic-editor-content a {
   color: var(--brand);
-  text-decoration: underline;
-  text-decoration-color: color-mix(in srgb, var(--brand) 40%, transparent);
-  text-underline-offset: 2px;
+  text-decoration: none;
+  border-bottom: 1px solid rgba(234, 88, 12, 0.3);
   cursor: pointer;
-  transition: text-decoration-color 0.15s;
+  transition: border-color 0.15s;
 }
 
 .academic-editor-content a:hover {
-  text-decoration-color: var(--brand);
+  border-bottom-color: var(--brand);
 }
 
 /* Horizontal rule */
@@ -265,7 +315,7 @@ body {
 .academic-editor-content img {
   max-width: 100%;
   height: auto;
-  border-radius: 0.5rem;
+  border-radius: 0.25rem;
   margin: 1rem 0;
 }
 
@@ -351,11 +401,6 @@ body {
 .tableWrapper {
   overflow-x: auto;
   margin: 1rem 0;
-}
-
-/* Selection styling */
-.academic-editor-content ::selection {
-  background: color-mix(in srgb, var(--brand) 20%, transparent);
 }
 
 /* Comment highlight */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { ClerkProvider } from "@clerk/nextjs";
 import { ThemeProvider } from "@/components/providers/theme-provider";
-import { inter, plusJakarta, merriweather } from "@/lib/fonts";
+import { inter, crimsonPro, jetbrainsMono } from "@/lib/fonts";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -19,7 +19,7 @@ function Providers({ children }: { children: React.ReactNode }) {
     return (
       <ClerkProvider
         appearance={{
-          variables: { colorPrimary: "#6366f1" },
+          variables: { colorPrimary: "#ea580c" },
         }}
       >
         {children}
@@ -39,12 +39,12 @@ export default function RootLayout({
       <html
         lang="en"
         suppressHydrationWarning
-        className={`${inter.variable} ${plusJakarta.variable} ${merriweather.variable}`}
+        className={`${inter.variable} ${crimsonPro.variable} ${jetbrainsMono.variable}`}
       >
         <body className="bg-background text-ink antialiased">
           <ThemeProvider
             attribute="class"
-            defaultTheme="dark"
+            defaultTheme="light"
             enableSystem={false}
             disableTransitionOnChange
           >

--- a/src/components/layout/app-header.tsx
+++ b/src/components/layout/app-header.tsx
@@ -3,35 +3,27 @@
 import { Bell, List } from "@phosphor-icons/react";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
 
-function getGreeting() {
-  const hour = new Date().getHours();
-  if (hour < 12) return "Good morning";
-  if (hour < 18) return "Good afternoon";
-  return "Good evening";
-}
-
 interface AppHeaderProps {
   onMenuClick?: () => void;
 }
 
 export function AppHeader({ onMenuClick }: AppHeaderProps) {
   return (
-    <header className="h-16 flex items-center justify-between px-6 border-b border-border-subtle">
+    <header className="h-14 flex items-center justify-between px-6 border-b border-border bg-surface">
       <div className="flex items-center gap-3">
         {onMenuClick && (
           <button
             onClick={onMenuClick}
-            className="md:hidden p-2 rounded-xl text-ink-muted hover:text-ink hover:bg-surface-raised transition-colors"
+            className="md:hidden p-2 rounded text-ink-muted hover:text-ink hover:bg-surface-raised transition-colors"
           >
             <List size={20} />
           </button>
         )}
-        <p className="text-ink-muted text-sm">{getGreeting()}</p>
       </div>
-      <div className="flex items-center gap-4">
+      <div className="flex items-center gap-3">
         <ThemeToggle />
-        <button className="relative p-2 rounded-xl text-ink-muted hover:text-ink hover:bg-surface-raised transition-colors">
-          <Bell size={20} />
+        <button className="relative p-2 rounded text-ink-muted hover:text-ink hover:bg-surface-raised transition-colors">
+          <Bell size={18} />
         </button>
       </div>
     </header>

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -20,19 +20,34 @@ import { cn } from "@/lib/utils";
 
 const ClerkUserButton = dynamic(
   () => import("@clerk/nextjs").then((mod) => mod.UserButton),
-  { ssr: false, loading: () => <div className="w-8 h-8 rounded-full bg-surface-raised" /> }
+  { ssr: false, loading: () => <div className="w-8 h-8 rounded-full bg-shell-border" /> }
 );
 
-const navItems = [
-  { label: "Dashboard", href: "/dashboard", icon: House },
-  { label: "Studio", href: "/studio", icon: PenNib },
-  { label: "Deep Research", href: "/research", icon: GlobeHemisphereWest },
-  { label: "Notebook", href: "/notebook", icon: Notebook },
-  { label: "Library", href: "/library", icon: Books },
-  { label: "Archive", href: "/projects", icon: FolderOpen },
-  { label: "Compliance", href: "/compliance", icon: ShieldCheck },
-  { label: "Presentation", href: "/presentation", icon: ProjectorScreenChart },
-  { label: "Settings", href: "/settings", icon: Gear },
+const navSections = [
+  {
+    label: "WORKSPACE",
+    items: [
+      { label: "Dashboard", href: "/dashboard", icon: House },
+      { label: "Studio", href: "/studio", icon: PenNib },
+      { label: "Deep Research", href: "/research", icon: GlobeHemisphereWest },
+      { label: "Notebook", href: "/notebook", icon: Notebook },
+    ],
+  },
+  {
+    label: "LIBRARY",
+    items: [
+      { label: "Papers", href: "/library", icon: Books },
+      { label: "Archive", href: "/projects", icon: FolderOpen },
+    ],
+  },
+  {
+    label: "TOOLS",
+    items: [
+      { label: "Compliance", href: "/compliance", icon: ShieldCheck },
+      { label: "Presentation", href: "/presentation", icon: ProjectorScreenChart },
+      { label: "Settings", href: "/settings", icon: Gear },
+    ],
+  },
 ];
 
 const hasClerkKeys =
@@ -50,45 +65,54 @@ export function AppSidebar({ open, onClose }: AppSidebarProps) {
 
   const sidebarContent = (
     <>
-      <div className="h-20 flex items-center justify-between px-6 border-b border-border-subtle">
+      <div className="h-16 flex items-center justify-between px-5 border-b border-shell-border">
         <Logo />
         {onClose && (
           <button
             onClick={onClose}
-            className="md:hidden p-1.5 rounded-lg text-ink-muted hover:text-ink hover:bg-surface-raised transition-colors"
+            className="md:hidden p-1.5 rounded text-shell-text hover:text-shell-active transition-colors"
           >
             <X size={20} />
           </button>
         )}
       </div>
 
-      <nav className="flex-1 px-3 py-6 space-y-1 overflow-y-auto">
-        {navItems.map((item) => {
-          const isActive = pathname === item.href || pathname.startsWith(item.href + "/");
-          const IconComponent = item.icon;
-          return (
-            <Link
-              key={item.href}
-              href={item.href}
-              onClick={onClose}
-              className={cn(
-                "flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all",
-                isActive
-                  ? "bg-surface-raised border border-border-subtle text-ink"
-                  : "text-ink-muted hover:bg-surface-raised/50 hover:text-ink"
-              )}
-            >
-              <IconComponent
-                size={20}
-                weight={isActive ? "fill" : "regular"}
-              />
-              {item.label}
-            </Link>
-          );
-        })}
+      <nav className="flex-1 px-3 py-4 overflow-y-auto scroll-subtle">
+        {navSections.map((section) => (
+          <div key={section.label} className="mb-4">
+            <p className="px-3 mb-1.5 text-[10px] font-mono font-medium text-shell-text uppercase tracking-widest">
+              {section.label}
+            </p>
+            <div className="space-y-0.5">
+              {section.items.map((item) => {
+                const isActive = pathname === item.href || pathname.startsWith(item.href + "/");
+                const IconComponent = item.icon;
+                return (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    onClick={onClose}
+                    className={cn(
+                      "flex items-center gap-3 px-3 py-2 rounded text-sm font-medium transition-all",
+                      isActive
+                        ? "text-shell-active border-l-2 border-brand bg-white/5"
+                        : "text-shell-text hover:text-shell-active hover:bg-white/5"
+                    )}
+                  >
+                    <IconComponent
+                      size={18}
+                      weight={isActive ? "fill" : "regular"}
+                    />
+                    {item.label}
+                  </Link>
+                );
+              })}
+            </div>
+          </div>
+        ))}
       </nav>
 
-      <div className="px-6 py-4 border-t border-border-subtle">
+      <div className="px-5 py-4 border-t border-shell-border">
         {hasClerkKeys ? (
           <ClerkUserButton afterSignOutUrl="/" />
         ) : (
@@ -101,7 +125,7 @@ export function AppSidebar({ open, onClose }: AppSidebarProps) {
   return (
     <>
       {/* Desktop sidebar */}
-      <aside className="hidden md:flex w-64 flex-col shrink-0 glass-panel border-r border-border h-screen">
+      <aside className="hidden md:flex w-60 flex-col shrink-0 bg-shell border-r border-shell-border h-screen">
         {sidebarContent}
       </aside>
 
@@ -112,7 +136,7 @@ export function AppSidebar({ open, onClose }: AppSidebarProps) {
             className="absolute inset-0 bg-black/50 backdrop-blur-sm"
             onClick={onClose}
           />
-          <aside className="absolute left-0 top-0 bottom-0 w-64 flex flex-col glass-panel border-r border-border">
+          <aside className="absolute left-0 top-0 bottom-0 w-60 flex flex-col bg-shell border-r border-shell-border">
             {sidebarContent}
           </aside>
         </div>

--- a/src/components/layout/marketing-nav.tsx
+++ b/src/components/layout/marketing-nav.tsx
@@ -1,42 +1,42 @@
 import Link from "next/link";
-import { SquaresFour } from "@phosphor-icons/react/dist/ssr";
 
 export function MarketingNav() {
   return (
-    <nav className="fixed top-6 left-0 right-0 z-50 flex justify-center px-4">
-      <div className="glass-panel rounded-full px-6 py-3 flex items-center gap-8 shadow-[0_8px_32px_0_rgba(0,0,0,0.5)]">
-        <Link href="/" className="flex items-center gap-2">
-          <div className="w-6 h-6 rounded bg-gradient-to-tr from-sky-500 to-indigo-500 flex items-center justify-center text-white text-xs">
-            <SquaresFour size={14} weight="fill" />
+    <nav className="sticky top-0 z-50 bg-background/90 backdrop-blur-md border-b border-border">
+      <div className="max-w-6xl mx-auto px-6 h-14 flex items-center justify-between">
+        <Link href="/" className="flex items-center gap-2.5">
+          <div className="w-7 h-7 rounded bg-brand flex items-center justify-center">
+            <span className="font-serif text-white font-bold text-sm leading-none">S</span>
           </div>
-          <span className="font-semibold tracking-tight text-sm text-white">
+          <span className="font-serif font-semibold tracking-tight text-ink">
             ScholarSync
           </span>
         </Link>
 
-        <div className="hidden md:flex items-center gap-6 text-xs font-medium text-[#94a3b8]">
-          <a href="#features" className="hover:text-white transition-colors">
+        <div className="hidden md:flex items-center gap-8 text-sm text-ink-muted">
+          <a href="#features" className="hover:text-ink transition-colors">
             Features
           </a>
-          <a href="#pricing" className="hover:text-white transition-colors">
+          <a href="#how-it-works" className="hover:text-ink transition-colors">
+            How It Works
+          </a>
+          <a href="#pricing" className="hover:text-ink transition-colors">
             Pricing
           </a>
         </div>
 
-        <div className="w-px h-4 bg-white/10 hidden md:block" />
-
         <div className="flex items-center gap-4">
           <Link
             href="/sign-in"
-            className="text-xs font-medium text-[#94a3b8] hover:text-white transition-colors"
+            className="text-sm text-ink-muted hover:text-ink transition-colors"
           >
             Sign In
           </Link>
           <Link
             href="/sign-up"
-            className="bg-gradient-to-r from-indigo-500 to-sky-500 text-white px-4 py-1.5 rounded-full text-xs font-bold hover:opacity-90 transition-opacity shadow-[0_0_20px_rgba(99,102,241,0.3)]"
+            className="bg-ink text-background px-4 py-2 rounded text-sm font-medium hover:opacity-90 transition-opacity"
           >
-            Get Started
+            Start Writing — Free
           </Link>
         </div>
       </div>

--- a/src/components/research/citation-network.tsx
+++ b/src/components/research/citation-network.tsx
@@ -26,7 +26,7 @@ interface CitationNetworkProps {
 }
 
 const NODE_COLORS = {
-  seed: { fill: "#6366f1", stroke: "#818cf8", label: "Selected Paper" },
+  seed: { fill: "#ea580c", stroke: "#f97316", label: "Selected Paper" },
   reference: { fill: "#0ea5e9", stroke: "#38bdf8", label: "References" },
   citation: { fill: "#10b981", stroke: "#34d399", label: "Cited By" },
 };
@@ -167,7 +167,7 @@ export function CitationNetwork({ paperId, className }: CitationNetworkProps) {
               y1={source.y!}
               x2={target.x}
               y2={target.y!}
-              stroke={isHighlighted ? "#6366f1" : "#334155"}
+              stroke={isHighlighted ? "#ea580c" : "#334155"}
               strokeWidth={isHighlighted ? 2 : 1}
               strokeOpacity={isHighlighted ? 0.8 : 0.3}
             />

--- a/src/components/ui/glass-panel.tsx
+++ b/src/components/ui/glass-panel.tsx
@@ -6,7 +6,7 @@ export function GlassPanel({
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) {
   return (
-    <div className={cn("glass-panel rounded-2xl", className)} {...props}>
+    <div className={cn("bg-surface border border-border rounded", className)} {...props}>
       {children}
     </div>
   );

--- a/src/components/ui/glow-card.tsx
+++ b/src/components/ui/glow-card.tsx
@@ -17,11 +17,11 @@ export function GlowCard({
   return (
     <div
       className={cn(
-        "glass-panel rounded-2xl p-6 transition-all duration-200 hover:-translate-y-1 hover:shadow-[0_0_30px_rgba(99,102,241,0.15)] cursor-pointer group",
+        "bg-surface border border-border rounded p-6 transition-all duration-200 hover:-translate-y-1 hover:border-brand/30 cursor-pointer group",
         className
       )}
     >
-      <div className="w-12 h-12 rounded-xl bg-brand/10 flex items-center justify-center text-brand mb-4 group-hover:scale-110 transition-transform">
+      <div className="w-12 h-12 rounded bg-accent-muted flex items-center justify-center text-brand mb-4 group-hover:scale-110 transition-transform">
         <IconComponent size={24} />
       </div>
       <h3 className="font-semibold text-lg text-ink mb-2">{title}</h3>

--- a/src/components/ui/logo.tsx
+++ b/src/components/ui/logo.tsx
@@ -1,13 +1,12 @@
-import { SquaresFour } from "@phosphor-icons/react/dist/ssr";
 import { cn } from "@/lib/utils";
 
 export function Logo({ className }: { className?: string }) {
   return (
-    <div className={cn("flex items-center gap-2", className)}>
-      <div className="w-8 h-8 rounded-lg bg-gradient-to-tr from-sky-500 to-indigo-500 flex items-center justify-center text-white">
-        <SquaresFour size={18} weight="fill" />
+    <div className={cn("flex items-center gap-2.5", className)}>
+      <div className="w-8 h-8 rounded bg-brand flex items-center justify-center">
+        <span className="font-serif text-white font-bold text-lg leading-none">S</span>
       </div>
-      <span className="font-semibold tracking-tight text-ink">
+      <span className="font-serif font-semibold tracking-tight text-shell-active">
         ScholarSync
       </span>
     </div>

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -14,9 +14,12 @@ interface TabsProps {
   onChange: (key: string) => void;
   className?: string;
   vertical?: boolean;
+  variant?: "light" | "dark";
 }
 
-export function Tabs({ tabs, activeTab, onChange, className, vertical }: TabsProps) {
+export function Tabs({ tabs, activeTab, onChange, className, vertical, variant = "light" }: TabsProps) {
+  const isDark = variant === "dark";
+
   return (
     <div
       className={cn(
@@ -30,11 +33,15 @@ export function Tabs({ tabs, activeTab, onChange, className, vertical }: TabsPro
           key={tab.key}
           onClick={() => onChange(tab.key)}
           className={cn(
-            "px-4 py-2 rounded-lg text-sm font-medium transition-all whitespace-nowrap",
+            "px-4 py-2 rounded text-sm font-medium transition-all whitespace-nowrap",
             vertical && "text-left",
             activeTab === tab.key
-              ? "bg-surface-raised text-ink border border-border-subtle"
-              : "text-ink-muted hover:text-ink hover:bg-surface-raised/50"
+              ? isDark
+                ? "bg-white/10 text-shell-active"
+                : "bg-surface-raised text-ink border border-border-subtle"
+              : isDark
+                ? "text-shell-text hover:text-shell-active hover:bg-white/5"
+                : "text-ink-muted hover:text-ink hover:bg-surface-raised/50"
           )}
         >
           {tab.label}
@@ -44,7 +51,9 @@ export function Tabs({ tabs, activeTab, onChange, className, vertical }: TabsPro
                 "ml-1.5 text-xs px-1.5 py-0.5 rounded-full",
                 activeTab === tab.key
                   ? "bg-brand/10 text-brand"
-                  : "bg-surface-raised text-ink-muted"
+                  : isDark
+                    ? "bg-white/10 text-shell-text"
+                    : "bg-surface-raised text-ink-muted"
               )}
             >
               {tab.count}

--- a/src/components/ui/theme-toggle.tsx
+++ b/src/components/ui/theme-toggle.tsx
@@ -14,39 +14,39 @@ export function ThemeToggle({ className }: { className?: string }) {
   const mounted = useSyncExternalStore(emptySubscribe, getSnapshot, getServerSnapshot);
 
   if (!mounted) {
-    return <div className={cn("h-9 w-[156px] rounded-full bg-surface-raised", className)} />;
+    return <div className={cn("h-8 w-[140px] rounded bg-surface-raised", className)} />;
   }
 
   return (
     <div
       className={cn(
-        "flex items-center gap-1 rounded-full bg-surface-raised p-1 border border-border",
+        "flex items-center gap-0.5 rounded bg-surface-raised p-0.5 border border-border",
         className
       )}
     >
       <button
         onClick={() => setTheme("light")}
         className={cn(
-          "flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium transition-all",
+          "flex items-center gap-1.5 rounded px-3 py-1.5 text-xs font-medium transition-all",
           theme === "light"
             ? "bg-surface text-ink shadow-sm"
             : "text-ink-muted hover:text-ink"
         )}
       >
         <Sun size={14} weight={theme === "light" ? "fill" : "regular"} />
-        Daylight
+        Light
       </button>
       <button
         onClick={() => setTheme("dark")}
         className={cn(
-          "flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium transition-all",
+          "flex items-center gap-1.5 rounded px-3 py-1.5 text-xs font-medium transition-all",
           theme === "dark"
             ? "bg-surface text-ink shadow-sm"
             : "text-ink-muted hover:text-ink"
         )}
       >
         <Moon size={14} weight={theme === "dark" ? "fill" : "regular"} />
-        Night
+        Dark
       </button>
     </div>
   );

--- a/src/lib/editor/editor-config.ts
+++ b/src/lib/editor/editor-config.ts
@@ -53,7 +53,7 @@ export const EDITOR_SHORTCUTS = {
 export const EDITOR_FONTS = {
   serif: {
     label: "Serif",
-    family: "var(--font-merriweather), Georgia, serif",
+    family: "var(--font-crimson-pro), Georgia, serif",
     description: "Best for manuscript drafting",
   },
   sans: {

--- a/src/lib/fonts.ts
+++ b/src/lib/fonts.ts
@@ -1,6 +1,6 @@
 // System font stacks used as CSS variables.
 // In production with internet access, swap back to next/font/google:
-//   import { Inter, Plus_Jakarta_Sans, Merriweather } from "next/font/google";
+//   import { Inter, Crimson_Pro, JetBrains_Mono } from "next/font/google";
 
 const makeFontVar = (variable: string) => ({
   variable,
@@ -9,5 +9,5 @@ const makeFontVar = (variable: string) => ({
 });
 
 export const inter = makeFontVar("font-inter");
-export const plusJakarta = makeFontVar("font-plus-jakarta");
-export const merriweather = makeFontVar("font-merriweather");
+export const crimsonPro = makeFontVar("font-crimson-pro");
+export const jetbrainsMono = makeFontVar("font-jetbrains-mono");


### PR DESCRIPTION
## Summary

- **Brand color**: `#6366f1` (indigo) → `#ea580c` (orange) across all components
- **Fonts**: Plus Jakarta Sans/Merriweather → Inter (sans), Crimson Pro (serif), JetBrains Mono (mono)
- **Default theme**: dark → light (paper-white `#faf9f7`)
- **App shell**: always-dark sidebar (`#0e0e10`) with mono section labels and orange active borders
- **Landing page**: complete rewrite with new editorial copy ("Write like a pro"), problem section, pricing, founder note
- **All components**: sharp corners (`rounded` not `rounded-2xl`), solid backgrounds replacing glass-morphism, stone palette

### Files changed (18)
Theme foundation: `globals.css`, `fonts.ts`, `layout.tsx`, `editor-config.ts`
App shell: `app-sidebar.tsx`, `app-header.tsx`, `logo.tsx`, `theme-toggle.tsx`
Landing page: `marketing-nav.tsx`, `(marketing)/layout.tsx`, `(marketing)/page.tsx`
App pages: `studio/page.tsx`, `research/page.tsx`, `dashboard-client.tsx`
UI components: `glass-panel.tsx`, `glow-card.tsx`, `tabs.tsx`, `citation-network.tsx`

## Test plan

- [x] `npx tsc --noEmit` — zero type errors
- [x] `npx eslint --max-warnings 0` — zero lint warnings
- [x] `npm test` — all 335 tests pass
- [x] `npm run build` — production build succeeds
- [ ] Visual verification: landing page, studio, research, dashboard in both light/dark modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Refreshed visual design system with updated color palette and typography across the entire application.
  * Redesigned landing page with improved hero section, feature cards, and pricing layout.
  * Simplified component styling with updated borders, spacing, and rounded corners.
  * Reorganized navigation structure with grouped sections in the sidebar.
  * Updated logo design from icon to text-based format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->