### PR TITLE
fix: production deployment — CSP for Clerk, Cloud SQL socket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ coverage/
 playwright-report/
 test-results/
 blob-report/
+cloud-sql-proxy

--- a/INFRASTRUCTURE.md
+++ b/INFRASTRUCTURE.md
@@ -1,0 +1,114 @@
+# ScholarSync — GCP Infrastructure
+
+**Project:** `metal-node-486118-t7`
+**Region:** `asia-south1` (Mumbai)
+**Service Account:** `my-professional-app-deployer@metal-node-486118-t7.iam.gserviceaccount.com`
+
+---
+
+## Cloud SQL (PostgreSQL 16)
+
+| Property | Value |
+|----------|-------|
+| Instance name | `scholarsync-db` |
+| Connection name | `metal-node-486118-t7:asia-south1:scholarsync-db` |
+| Edition | Enterprise |
+| Tier | `db-f1-micro` |
+| Storage | 10 GB SSD |
+| Availability | Zonal |
+| Database | `scholarsync` |
+| App user | `scholarsync_app` |
+
+### DATABASE_URL format
+
+```
+postgresql://scholarsync_app:<PASSWORD>@/scholarsync?host=/cloudsql/metal-node-486118-t7:asia-south1:scholarsync-db
+```
+
+> Replace `<PASSWORD>` with the `scholarsync_app` user password.
+
+### Enable pgvector
+
+After connecting to the database, run:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS vector;
+```
+
+---
+
+## Serverless VPC Access Connector
+
+| Property | Value |
+|----------|-------|
+| Name | `scholarsync-connector` |
+| Region | `asia-south1` |
+| IP range | `10.8.0.0/28` |
+
+Used by Cloud Run to reach Cloud SQL via private IP.
+
+---
+
+## GCS Bucket (PDF Storage)
+
+| Property | Value |
+|----------|-------|
+| Bucket | `gs://scholarsync-pdfs` |
+| Location | `asia-south1` |
+| Access | Uniform bucket-level |
+| Public access | Prevented |
+
+---
+
+## Artifact Registry (Docker Images)
+
+| Property | Value |
+|----------|-------|
+| Repository | `scholarsync` |
+| Location | `asia-south1` |
+| Format | Docker |
+| Full path | `asia-south1-docker.pkg.dev/metal-node-486118-t7/scholarsync/web` |
+
+---
+
+## Secret Manager
+
+All secrets are created with placeholder values. Update them before deploying.
+
+| Secret Name | Maps to ENV var |
+|-------------|----------------|
+| `scholarsync-database-url` | `DATABASE_URL` |
+| `scholarsync-clerk-publishable-key` | `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` |
+| `scholarsync-clerk-secret-key` | `CLERK_SECRET_KEY` |
+| `scholarsync-clerk-webhook-secret` | `CLERK_WEBHOOK_SECRET` |
+| `scholarsync-anthropic-api-key` | `ANTHROPIC_API_KEY` |
+| `scholarsync-openai-api-key` | `OPENAI_API_KEY` |
+| `scholarsync-razorpay-key-id` | `RAZORPAY_KEY_ID` |
+| `scholarsync-razorpay-key-secret` | `RAZORPAY_KEY_SECRET` |
+| `scholarsync-razorpay-webhook-secret` | `RAZORPAY_WEBHOOK_SECRET` |
+| `scholarsync-upstash-redis-url` | `UPSTASH_REDIS_REST_URL` |
+| `scholarsync-upstash-redis-token` | `UPSTASH_REDIS_REST_TOKEN` |
+
+### Update a secret value
+
+```bash
+echo -n "real-value" | gcloud secrets versions add SECRET_NAME --data-file=-
+```
+
+---
+
+## IAM
+
+The default Compute Engine service account (`24661688411-compute@developer.gserviceaccount.com`) has `roles/secretmanager.secretAccessor` on all 11 secrets.
+
+---
+
+## Enabled APIs
+
+- Cloud SQL Admin (`sqladmin.googleapis.com`)
+- Cloud Run (`run.googleapis.com`)
+- Cloud Build (`cloudbuild.googleapis.com`)
+- Artifact Registry (`artifactregistry.googleapis.com`)
+- Secret Manager (`secretmanager.googleapis.com`)
+- Cloud Storage (`storage.googleapis.com`)
+- VPC Access (`vpcaccess.googleapis.com`)

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -10,7 +10,7 @@ steps:
       - '--build-arg'
       - 'CLERK_SECRET_KEY=${_CLERK_SECRET_KEY}'
       - '-t'
-      - '${_REPO}:$COMMIT_SHA'
+      - '${_REPO}:${SHORT_SHA}'
       - '-t'
       - '${_REPO}:latest'
       - '.'
@@ -22,27 +22,8 @@ steps:
       - '--all-tags'
       - '${_REPO}'
 
-  # Deploy to Cloud Run
-  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
-    entrypoint: gcloud
-    args:
-      - 'run'
-      - 'deploy'
-      - '${_SERVICE_NAME}'
-      - '--image'
-      - '${_REPO}:$COMMIT_SHA'
-      - '--region'
-      - '${_REGION}'
-      - '--platform'
-      - 'managed'
-      - '--allow-unauthenticated'
-      - '--set-env-vars'
-      - 'NODE_ENV=production,GCS_BUCKET_NAME=scholarsync-pdfs,GCS_PROJECT_ID=metal-node-486118-t7,NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${_NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}'
-      - '--set-secrets'
-      - 'DATABASE_URL=DATABASE_URL:latest,CLERK_SECRET_KEY=CLERK_SECRET_KEY:latest,ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest,RAZORPAY_KEY_ID=RAZORPAY_KEY_ID:latest,RAZORPAY_KEY_SECRET=RAZORPAY_KEY_SECRET:latest,RAZORPAY_WEBHOOK_SECRET=RAZORPAY_WEBHOOK_SECRET:latest,UPSTASH_REDIS_REST_URL=UPSTASH_REDIS_REST_URL:latest,UPSTASH_REDIS_REST_TOKEN=UPSTASH_REDIS_REST_TOKEN:latest,COPYLEAKS_API_KEY=COPYLEAKS_API_KEY:latest'
-
 images:
-  - '${_REPO}:$COMMIT_SHA'
+  - '${_REPO}:${SHORT_SHA}'
   - '${_REPO}:latest'
 
 substitutions:

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,12 +2,12 @@ import type { NextConfig } from "next";
 
 const csp = [
   "default-src 'self'",
-  "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://checkout.razorpay.com https://api.razorpay.com https://cdn.clerk.io",
-  "style-src 'self' 'unsafe-inline' https://cdn.clerk.io",
-  "img-src 'self' data: blob: https://img.clerk.com https://*.googleusercontent.com",
-  "font-src 'self' data:",
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://checkout.razorpay.com https://api.razorpay.com https://cdn.clerk.io https://*.clerk.accounts.dev",
+  "style-src 'self' 'unsafe-inline' https://cdn.clerk.io https://*.clerk.accounts.dev",
+  "img-src 'self' data: blob: https://img.clerk.com https://*.clerk.accounts.dev https://*.googleusercontent.com",
+  "font-src 'self' data: https://*.clerk.accounts.dev",
   "connect-src 'self' https://api.clerk.io https://*.clerk.accounts.dev https://api.anthropic.com https://api.openai.com https://eutils.ncbi.nlm.nih.gov https://api.semanticscholar.org https://api.openalex.org https://api.copyleaks.com https://checkout.razorpay.com https://lumberjack.razorpay.com https://*.upstash.io",
-  "frame-src https://checkout.razorpay.com https://accounts.clerk.dev",
+  "frame-src https://checkout.razorpay.com https://accounts.clerk.dev https://*.clerk.accounts.dev",
   "worker-src 'self' blob:",
 ].join("; ");
 

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -8,6 +8,21 @@ function createDb() {
       "DATABASE_URL is not set. Add it to your .env.local file."
     );
   }
+
+  const instanceConnection = process.env.CLOUD_SQL_CONNECTION_NAME;
+  if (instanceConnection) {
+    // Cloud Run: connect via Unix socket at /cloudsql/<connection-name>
+    const url = new URL(process.env.DATABASE_URL);
+    const client = postgres({
+      host: `/cloudsql/${instanceConnection}`,
+      port: 5432,
+      database: url.pathname.slice(1) || "scholarsync",
+      username: url.username,
+      password: decodeURIComponent(url.password),
+    });
+    return drizzle(client, { schema });
+  }
+
   const client = postgres(process.env.DATABASE_URL);
   return drizzle(client, { schema });
 }


### PR DESCRIPTION
## Summary
- Add `*.clerk.accounts.dev` to all CSP directives so Clerk JS loads in production
- Fix Cloud SQL connection: use Unix socket via `CLOUD_SQL_CONNECTION_NAME` env var
- Simplify `cloudbuild.yaml` to build-only (deploy via `gcloud run deploy`)
- Add `INFRASTRUCTURE.md` documenting all GCP resources

## Test plan
- [x] TypeScript: 0 errors
- [x] ESLint: 0 warnings
- [x] Production deployment: dashboard loads, health check 200
- [x] Clerk sign-in form loads without CSP violations
- [x] Cloud SQL queries succeed via Unix socket

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive infrastructure documentation covering GCP deployment setup and configuration

* **Chores**
  * Updated build pipeline configuration and image tagging
  * Expanded authentication security policies
  * Enhanced cloud-based database connection handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->