### PR TITLE
test(unit): add Vitest coverage for 12 untested lib modules

### DIFF
--- a/src/lib/analytics/__tests__/analytics.test.ts
+++ b/src/lib/analytics/__tests__/analytics.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PresentationViewTracker } from "../view-tracker";
+
+describe("PresentationViewTracker", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  it("tracks slide timing and flushes via sendBeacon", () => {
+    const beacon = vi.fn();
+    Object.defineProperty(global.navigator, "sendBeacon", { value: beacon, configurable: true });
+
+    const tracker = new PresentationViewTracker(1, 2, "share");
+    tracker.onSlideEnter("s1", 0);
+    vi.advanceTimersByTime(1200);
+    tracker.onSlideEnter("s2", 1);
+    vi.advanceTimersByTime(1200);
+    tracker.flush();
+
+    expect(beacon).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(beacon.mock.calls[0][1]);
+    expect(payload.slidesViewed).toBe(2);
+    expect(payload.completed).toBe(true);
+
+    tracker.destroy();
+  });
+
+  it("does not flush short sessions", () => {
+    const beacon = vi.fn();
+    Object.defineProperty(global.navigator, "sendBeacon", { value: beacon, configurable: true });
+    const tracker = new PresentationViewTracker(1, 1);
+    tracker.onSlideEnter("s1", 0);
+    vi.advanceTimersByTime(1000);
+    tracker.flush();
+    expect(beacon).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/billing/__tests__/billing.test.ts
+++ b/src/lib/billing/__tests__/billing.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+
+describe("billing/razorpay", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    process.env.RAZORPAY_KEY_ID = "rzp_key";
+    process.env.RAZORPAY_KEY_SECRET = "rzp_secret";
+  });
+
+  it("creates an order with selected plan pricing", async () => {
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ id: "order_1" }) });
+    const mod = await import("../razorpay");
+    const result = await mod.createRazorpayOrder("pro", "user-1");
+    expect(result).toEqual({ id: "order_1" });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.razorpay.com/v1/orders",
+      expect.objectContaining({ method: "POST" })
+    );
+    const call = fetchMock.mock.calls[0][1];
+    expect(call.headers.Authorization).toContain("Basic ");
+    expect(JSON.parse(call.body).amount).toBe(mod.PLAN_PRICES.pro);
+  });
+
+  it("throws when order creation fails", async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false, text: async () => "bad request" });
+    const mod = await import("../razorpay");
+    await expect(mod.createRazorpayOrder("basic", "u")).rejects.toThrow("Razorpay order creation failed: bad request");
+  });
+
+  it("verifies valid and invalid payment signatures", async () => {
+    const mod = await import("../razorpay");
+    const crypto = await import("crypto");
+    const valid = crypto.createHmac("sha256", "rzp_secret").update("order|pay").digest("hex");
+    await expect(mod.verifyPaymentSignature("order", "pay", valid)).resolves.toBe(true);
+    await expect(mod.verifyPaymentSignature("order", "pay", "abcd")).resolves.toBe(false);
+  });
+
+  it("returns null for non-ok payment fetch", async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false });
+    const mod = await import("../razorpay");
+    await expect(mod.fetchPayment("pay_1")).resolves.toBeNull();
+  });
+
+  it("isConfigured reflects env presence", async () => {
+    const mod = await import("../razorpay");
+    expect(mod.isConfigured()).toBe(true);
+    vi.resetModules();
+    delete process.env.RAZORPAY_KEY_ID;
+    delete process.env.RAZORPAY_KEY_SECRET;
+    const mod2 = await import("../razorpay");
+    expect(mod2.isConfigured()).toBe(false);
+  });
+});

--- a/src/lib/config/__tests__/config.test.ts
+++ b/src/lib/config/__tests__/config.test.ts
@@ -1,0 +1,22 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("config/branding", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("uses defaults when env vars missing", async () => {
+    delete process.env.NEXT_PUBLIC_BRAND_NAME;
+    delete process.env.NEXT_PUBLIC_BRAND_TAGLINE;
+    const { BRAND } = await import("../branding");
+    expect(BRAND.name).toBe("ScholarSync");
+    expect(BRAND.tagline).toContain("Academic Integrity");
+  });
+
+  it("uses env overrides", async () => {
+    process.env.NEXT_PUBLIC_BRAND_NAME = "Custom";
+    process.env.NEXT_PUBLIC_BRAND_TAGLINE = "Tag";
+    const { BRAND } = await import("../branding");
+    expect(BRAND).toEqual({ name: "Custom", tagline: "Tag" });
+  });
+});

--- a/src/lib/crypto/__tests__/crypto.test.ts
+++ b/src/lib/crypto/__tests__/crypto.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { hashPassword, isHashedPassword, verifyPassword } from "../password";
+
+describe("password crypto", () => {
+  it("hashes and verifies passwords", async () => {
+    const hash = await hashPassword("secret");
+    expect(isHashedPassword(hash)).toBe(true);
+    await expect(verifyPassword("secret", hash)).resolves.toBe(true);
+    await expect(verifyPassword("wrong", hash)).resolves.toBe(false);
+  });
+
+  it("returns false for malformed hashes", async () => {
+    expect(isHashedPassword("abc")).toBe(false);
+    await expect(verifyPassword("secret", "abc")).resolves.toBe(false);
+  });
+});

--- a/src/lib/db/__tests__/db.test.ts
+++ b/src/lib/db/__tests__/db.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const postgresMock = vi.fn(() => ({ client: true }));
+const drizzleMock = vi.fn(() => ({ query: { ok: true } }));
+
+vi.mock("postgres", () => ({ default: postgresMock }));
+vi.mock("drizzle-orm/postgres-js", () => ({ drizzle: drizzleMock }));
+vi.mock("../schema", () => ({ any: "schema" }));
+
+describe("db proxy", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    process.env.DATABASE_URL = "postgres://local";
+  });
+
+  it("lazily initializes once and proxies properties", async () => {
+    const mod = await import("../index");
+    expect(postgresMock).not.toHaveBeenCalled();
+    expect(mod.db.query).toEqual({ ok: true });
+    expect(mod.db.query).toEqual({ ok: true });
+    expect(postgresMock).toHaveBeenCalledTimes(1);
+    expect(drizzleMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws when no DATABASE_URL is available", async () => {
+    delete process.env.DATABASE_URL;
+    const mod = await import("../index");
+    expect(() => mod.db.query).toThrow("DATABASE_URL is not set and Hyperdrive is not available");
+  });
+});

--- a/src/lib/liveblocks/__tests__/liveblocks.test.ts
+++ b/src/lib/liveblocks/__tests__/liveblocks.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from "vitest";
+
+const createClient = vi.fn(() => ({ client: true }));
+const createRoomContext = vi.fn(() => ({ RoomProvider: "RP", useRoom: "UR" }));
+
+vi.mock("@liveblocks/client", () => ({ createClient, LiveMap: class {}, LiveObject: class {} }));
+vi.mock("@liveblocks/react", () => ({ createRoomContext }));
+vi.mock("@/stores/systematic-review-store", () => ({}));
+
+describe("liveblocks config", () => {
+  it("creates client + room context for presentation and SR", async () => {
+    const mod = await import("../config");
+    const sr = await import("../sr-config");
+    expect(createClient).toHaveBeenCalledWith({ authEndpoint: "/api/liveblocks-auth" });
+    expect(createRoomContext).toHaveBeenCalledTimes(2);
+    expect(mod.RoomProvider).toBe("RP");
+    expect(sr.SRRoomProvider).toBe("RP");
+  }, 15000);
+});

--- a/src/lib/pdf/__tests__/pdf.test.ts
+++ b/src/lib/pdf/__tests__/pdf.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const getDocument = vi.fn();
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+vi.mock("pdfjs-dist", () => ({ getDocument }));
+
+describe("pdf module helpers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("extracts text and section headings", async () => {
+    getDocument.mockReturnValue({
+      promise: Promise.resolve({
+        numPages: 2,
+        getPage: vi
+          .fn()
+          .mockResolvedValueOnce({ getTextContent: async () => ({ items: [{ str: "Abstract" }, { str: "Intro" }] }) })
+          .mockResolvedValueOnce({ getTextContent: async () => ({ items: [{ str: "Methods" }] }) }),
+      }),
+    });
+    const { extractTextFromPDF } = await import("../text-extraction");
+    const result = await extractTextFromPDF("url");
+    expect(result.pages).toHaveLength(2);
+    expect(result.sectionHeadings).toEqual(expect.arrayContaining(["Abstract", "Methods"]));
+  });
+
+  it("parses page references and builds highlight context", async () => {
+    const { parsePageReferences, buildHighlightsContext } = await import("../navigation");
+    expect(parsePageReferences("see page 4 and p.4 and p 9")).toEqual([4, 9]);
+    const context = buildHighlightsContext([{ pageNumber: 3, selectedText: "Important", color: "yellow", note: "check", targetSection: "Methods" }]);
+    expect(context).toContain("Page 3");
+    expect(context).toContain("User note");
+  });
+
+  it("creates and formats source quotes", async () => {
+    const { createSourceQuote, addUsageToQuote, formatSourceQuoteForDisplay } = await import("../source-quotes");
+    const q = createSourceQuote("p1", 2, "quoted", 1, 4, "Results");
+    const updated = addUsageToQuote(q, "chat", "c1");
+    expect(updated.usedIn).toHaveLength(1);
+    expect(formatSourceQuoteForDisplay(updated)).toContain("Results");
+  });
+
+  it("highlight storage wrappers return booleans/arrays", async () => {
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ highlights: [{ id: "1" }] }) });
+    fetchMock.mockResolvedValue({ ok: true });
+    const mod = await import("../highlight-storage");
+    await expect(mod.fetchHighlights("p", "pr")).resolves.toEqual([{ id: "1" }]);
+    await expect(mod.createHighlight({ id: "h" } as never)).resolves.toBe(true);
+    await expect(mod.updateHighlight("h", { note: "n" })).resolves.toBe(true);
+    await expect(mod.deleteHighlight("h")).resolves.toBe(true);
+  });
+});

--- a/src/lib/recording/__tests__/recording.test.ts
+++ b/src/lib/recording/__tests__/recording.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+import { PresentationRecorder } from "../presentation-recorder";
+
+describe("PresentationRecorder", () => {
+  it("tracks markers and elapsed time while recording", () => {
+    vi.useFakeTimers();
+    const recorder = new PresentationRecorder() as unknown as {
+      _state: string;
+      startTime: number;
+      _totalPausedMs: number;
+      _elapsedMs: number;
+      markSlideTransition: (idx: number) => void;
+      markers: Array<{ slideIndex: number; timestampMs: number }>;
+      elapsedMs: number;
+    };
+
+    recorder._state = "recording";
+    recorder.startTime = Date.now();
+    recorder._totalPausedMs = 0;
+    vi.advanceTimersByTime(1500);
+    recorder.markSlideTransition(2);
+
+    expect(recorder.elapsedMs).toBe(1500);
+    expect(recorder.markers[0].slideIndex).toBe(2);
+  });
+
+  it("pause/resume are no-ops without mediaRecorder", () => {
+    const recorder = new PresentationRecorder();
+    expect(() => recorder.pause()).not.toThrow();
+    expect(() => recorder.resume()).not.toThrow();
+  });
+
+  it("rejects stopRecording when idle", async () => {
+    const recorder = new PresentationRecorder();
+    await expect(recorder.stopRecording()).rejects.toThrow("No active recording");
+  });
+});

--- a/src/lib/references/__tests__/references.test.ts
+++ b/src/lib/references/__tests__/references.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getMock = vi.fn();
+const CiteMock = function (this: any) {
+  this.get = getMock;
+} as unknown as ReturnType<typeof vi.fn>;
+(CiteMock as unknown as { async: unknown }).async = vi.fn();
+
+vi.mock("@citation-js/core", () => ({ Cite: CiteMock }));
+vi.mock("@citation-js/plugin-csl", () => ({}));
+vi.mock("@citation-js/plugin-bibtex", () => ({}));
+vi.mock("@citation-js/plugin-ris", () => ({}));
+vi.mock("@citation-js/plugin-doi", () => ({}));
+
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+
+describe("references module", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("formats references for content ingestion", async () => {
+    const { formatReferencesAsContent } = await import("../format");
+    const text = formatReferencesAsContent([{ id: "1", title: "Paper", authors: ["Doe, J."], year: 2023, type: "article" }]);
+    expect(text).toContain("Reference 1");
+    expect(text).toContain("Doe, J.");
+  });
+
+  it("parses bibtex/ris/json and maps types", async () => {
+    getMock.mockReturnValue([{ id: "x", title: "T", author: [{ family: "Doe", given: "Jane A" }], type: "paper-conference", issued: { "date-parts": [[2021]] } }]);
+    const mod = await import("../import");
+    expect(mod.parseBibTeX("@article{}")[0].type).toBe("conference");
+    expect(mod.parseRIS("TY  - JOUR")[0].authors[0]).toBe("Doe, J. A.");
+    expect(mod.parseCslJson({ title: "A" })[0].title).toBe("A");
+  });
+
+  it("resolveDoiToReference returns null on failure", async () => {
+    (CiteMock as unknown as { async: ReturnType<typeof vi.fn> }).async.mockRejectedValueOnce(new Error("bad"));
+    const mod = await import("../import");
+    await expect(mod.resolveDoiToReference("10.1/x")).resolves.toBeNull();
+  });
+
+  it("fetches zotero library across pages and handles errors", async () => {
+    fetchMock
+      .mockResolvedValueOnce({ ok: true, json: async () => [{ id: "1", title: "A", type: "article-journal" }], headers: { get: () => '<https://api.zotero.org/next>; rel="next"' } })
+      .mockResolvedValueOnce({ ok: true, json: async () => [{ id: "2", title: "B", type: "book" }], headers: { get: () => null } });
+    const { fetchZoteroLibrary } = await import("../zotero");
+    const refs = await fetchZoteroLibrary({ apiKey: "k", userId: "u" });
+    expect(refs.map((r) => r.type)).toEqual(["article", "book"]);
+
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 403, statusText: "Forbidden" });
+    await expect(fetchZoteroLibrary({ apiKey: "k", userId: "u" })).rejects.toThrow("Invalid Zotero API key");
+  });
+});

--- a/src/lib/slides/__tests__/slides.test.ts
+++ b/src/lib/slides/__tests__/slides.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { getRegenerateTonePrompt, REGENERATE_TONE_OPTIONS } from "../regenerate";
+
+describe("slides regenerate helpers", () => {
+  it("returns prompt for known tone", () => {
+    expect(getRegenerateTonePrompt("more_concise")).toBe(
+      REGENERATE_TONE_OPTIONS.find((x) => x.value === "more_concise")?.prompt
+    );
+  });
+
+  it("falls back to default tone for unknown values", () => {
+    expect(getRegenerateTonePrompt("unknown")).toBe(REGENERATE_TONE_OPTIONS[0].prompt);
+  });
+});

--- a/src/lib/storage/__tests__/storage.test.ts
+++ b/src/lib/storage/__tests__/storage.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+let prevCwd = process.cwd();
+let tempDir = "";
+
+async function fresh() {
+  vi.resetModules();
+  return import("../r2");
+}
+
+describe("storage/r2 local fallback", () => {
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), "storage-test-"));
+    prevCwd = process.cwd();
+    process.chdir(tempDir);
+  });
+
+  afterEach(async () => {
+    process.chdir(prevCwd);
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("uploads/downloads/deletes PDFs locally", async () => {
+    const mod = await fresh();
+    const key = await mod.uploadPdf(7, Buffer.from("pdf"));
+    expect(key).toBe("papers/7.pdf");
+    await expect(mod.pdfExists(7)).resolves.toBe(true);
+    await expect(mod.downloadPdf(7)).resolves.toEqual(Buffer.from("pdf"));
+    await mod.deletePdf(7);
+    await expect(mod.downloadPdf(7)).resolves.toBeNull();
+  });
+
+  it("handles recording and audio overview paths", async () => {
+    const mod = await fresh();
+    const recKey = await mod.uploadRecording("deck1", "rec1", Buffer.from("video"));
+    expect(recKey).toBe("recordings/deck1/rec1.webm");
+    await expect(mod.downloadRecording(recKey)).resolves.toEqual(Buffer.from("video"));
+
+    const audioKey = await mod.uploadAudioOverview(3, "a1", Buffer.from("mp3"), "wav");
+    expect(audioKey).toBe("audio-overviews/3/a1.wav");
+    await expect(mod.downloadAudioOverview(audioKey)).resolves.toEqual(Buffer.from("mp3"));
+  });
+
+  it("sanitizes LaTeX image filename and lists project images", async () => {
+    const mod = await fresh();
+    vi.spyOn(globalThis.crypto, "randomUUID").mockReturnValue("uuid-1");
+    const result = await mod.uploadLatexImage("p1", "my fig?.png", Buffer.from("img"), "image/png");
+    expect(result.storageKey).toContain("my_fig_.png");
+
+    const listed = await mod.listLatexImages("p1");
+    expect(listed).toHaveLength(1);
+    expect(listed[0].contentType).toBe("image/png");
+  });
+
+  it("returns null for signed PDF url", async () => {
+    const mod = await fresh();
+    await expect(mod.getSignedPdfUrl(1)).resolves.toBeNull();
+  });
+});

--- a/src/lib/tts/__tests__/tts.test.ts
+++ b/src/lib/tts/__tests__/tts.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { OpenAITTSProvider, synthesizeLongText } from "../openai-tts";
+
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+
+describe("OpenAI TTS", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.OPENAI_API_KEY = "key";
+  });
+
+  it("synthesizes audio with clamped speed and defaults", async () => {
+    fetchMock.mockResolvedValueOnce({ ok: true, arrayBuffer: async () => new Uint8Array([1, 2]).buffer });
+    const provider = new OpenAITTSProvider();
+    const result = await provider.synthesize("hello", { speed: 99, format: "wav" });
+    expect(result.mimeType).toBe("audio/wav");
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.speed).toBe(4);
+  });
+
+  it("throws when API key missing or api fails", async () => {
+    delete process.env.OPENAI_API_KEY;
+    const provider = new OpenAITTSProvider();
+    await expect(provider.synthesize("x")).rejects.toThrow("OPENAI_API_KEY");
+
+    process.env.OPENAI_API_KEY = "key";
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 500, text: async () => "oops" });
+    await expect(provider.synthesize("x")).rejects.toThrow("OpenAI TTS failed (500): oops");
+  });
+
+  it("chunk-synthesizes long mp3 text and concatenates", async () => {
+    const provider = {
+      maxCharacters: 12,
+      name: "x",
+      synthesize: vi.fn(async (chunk: string) => ({
+        audioBuffer: Buffer.from(chunk[0] || "x"),
+        mimeType: "audio/mpeg",
+        extension: "mp3",
+        estimatedDurationSeconds: 1,
+      })),
+    };
+    const result = await synthesizeLongText(provider, "sentence one. sentence two.");
+    expect(result.audioBuffer.length).toBeGreaterThan(1);
+
+    const provider2 = { ...provider, synthesize: vi.fn(provider.synthesize) };
+    await expect(synthesizeLongText(provider2, "very long text here", { format: "wav" })).rejects.toThrow("mp3");
+  });
+});


### PR DESCRIPTION
### Motivation

- Increase unit-test coverage and harden core library modules that lacked tests, prioritizing billing, DB, and storage behaviors.
- Provide deterministic, mock-first tests for modules that interact with external services and runtimes to reduce regressions.

### Description

- Added Vitest suites at `src/lib/<module>/__tests__/<module>.test.ts` for 12 modules: `billing`, `db`, `storage`, `pdf`, `references`, `analytics`, `liveblocks`, `tts`, `recording`, `crypto`, `config`, and `slides`.
- Tests mock external dependencies and runtimes where appropriate (HTTP `fetch`, `pdfjs-dist`, `@citation-js/core` and plugins, Razorpay, Zotero, OpenAI TTS, `postgres` + `drizzle`, Liveblocks client/react, Node filesystem fallbacks, and Web Crypto) and cover happy paths, edge cases, and error handling.
- Key technical assertions include: plan pricing and signature verification for Razorpay (`billing`), lazy DB initialization and connection-string failure (`db`), R2/local-fs upload/download/delete and LaTeX image handling (`storage`), PDF extraction / headings / page parsing and highlight APIs (`pdf`), BibTeX/RIS/CSL parsing and Zotero pagination/errors (`references`), presentation view timing and flush logic (`analytics`), Liveblocks client + room context wiring (`liveblocks`), OpenAI TTS request/clip/chunking and error flows (`tts`), recorder state guards and marker timing (`recording`), password hash/verify and hash-format checking (`crypto`), branding env fallbacks/overrides (`config`), and regenerate-tone prompt selection (`slides`).

### Testing

- Ran module-level test commands with verbose reporting: `npx vitest run src/lib/<module> --reporter=verbose` for each of the 12 modules listed above.
- All targeted module test runs passed on this branch; per-suite passing counts included in commits (billing: 5, db: 2, storage: 4, pdf: 4, references: 4, analytics: 2, liveblocks: 1, tts: 3, recording: 3, crypto: 2, config: 2, slides: 2).
- Tests exercise mocked error cases and runtime fallbacks and succeeded during CI-local runs recorded for this branch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b433bede50832a9326600d95001eeb)