### PR TITLE
Add Vitest unit tests for billing, onboarding, liveblocks and Clerk webhook API routes

### DIFF
--- a/src/app/api/billing/create-order/__tests__/route.test.ts
+++ b/src/app/api/billing/create-order/__tests__/route.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { NextRequest } from "next/server";
+
+const mockGetCurrentUserId = vi.hoisted(() => vi.fn());
+const mockCreateRazorpayOrder = vi.hoisted(() => vi.fn());
+const mockIsConfigured = vi.hoisted(() => vi.fn());
+const mockCheckRateLimit = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/auth", () => ({
+  getCurrentUserId: mockGetCurrentUserId,
+}));
+
+vi.mock("@/lib/billing/razorpay", () => ({
+  createRazorpayOrder: mockCreateRazorpayOrder,
+  isConfigured: mockIsConfigured,
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: mockCheckRateLimit,
+  RATE_LIMITS: {
+    analysis: { limit: 20, windowSeconds: 3600 },
+  },
+}));
+
+import { POST } from "../route";
+
+function makeRequest(body: unknown): NextRequest {
+  return new Request("http://localhost/api/billing/create-order", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }) as NextRequest;
+}
+
+describe("POST /api/billing/create-order", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsConfigured.mockReturnValue(true);
+    mockGetCurrentUserId.mockResolvedValue("user_123");
+    mockCheckRateLimit.mockResolvedValue(null);
+  });
+
+  it("returns order data for valid plan", async () => {
+    mockCreateRazorpayOrder.mockResolvedValue({
+      id: "order_1",
+      amount: 100000,
+      currency: "INR",
+    });
+
+    const res = await POST(makeRequest({ plan: "basic" }));
+
+    expect(res.status).toBe(200);
+    expect(mockGetCurrentUserId).toHaveBeenCalledOnce();
+    expect(mockCreateRazorpayOrder).toHaveBeenCalledWith("basic", "user_123");
+    await expect(res.json()).resolves.toMatchObject({
+      orderId: "order_1",
+      amount: 100000,
+      currency: "INR",
+    });
+  });
+
+  it("enforces auth by calling getCurrentUserId and fails when unauthenticated", async () => {
+    mockGetCurrentUserId.mockRejectedValue(new Error("Not authenticated"));
+
+    const res = await POST(makeRequest({ plan: "basic" }));
+
+    expect(mockGetCurrentUserId).toHaveBeenCalledOnce();
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({ error: "Failed to create payment order" });
+  });
+
+  it("returns 400 for invalid plan", async () => {
+    const res = await POST(makeRequest({ plan: "enterprise" }));
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: "Invalid plan. Must be 'basic' or 'pro'",
+    });
+  });
+
+  it("returns 500 when order creation throws", async () => {
+    mockCreateRazorpayOrder.mockRejectedValue(new Error("Razorpay down"));
+
+    const res = await POST(makeRequest({ plan: "pro" }));
+
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({ error: "Failed to create payment order" });
+  });
+});

--- a/src/app/api/billing/subscription/__tests__/route.test.ts
+++ b/src/app/api/billing/subscription/__tests__/route.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetSubscription = vi.hoisted(() => vi.fn());
+const mockGetUserUsageStats = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/actions/billing", () => ({
+  getSubscription: mockGetSubscription,
+}));
+
+vi.mock("@/lib/actions/user", () => ({
+  getUserUsageStats: mockGetUserUsageStats,
+}));
+
+import { GET } from "../route";
+
+describe("GET /api/billing/subscription", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns subscription and usage details", async () => {
+    mockGetSubscription.mockResolvedValue({
+      plan: "pro",
+      status: "active",
+      currentPeriodStart: new Date("2025-01-01T00:00:00.000Z"),
+      currentPeriodEnd: new Date("2025-02-01T00:00:00.000Z"),
+    });
+    mockGetUserUsageStats.mockResolvedValue({
+      tokens_used: 150,
+      tokens_limit: 50000,
+      searches_used: 3,
+      plagiarism_checks: 1,
+      exports_used: 2,
+      plan: "pro",
+    });
+
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      subscription: { plan: "pro", status: "active" },
+      usage: {
+        tokensUsed: 150,
+        tokensLimit: 50000,
+        searchesUsed: 3,
+        plagiarismChecks: 1,
+        exportsUsed: 2,
+        plan: "pro",
+      },
+    });
+  });
+
+  it("propagates auth-dependent action failures", async () => {
+    mockGetSubscription.mockRejectedValue(new Error("Not authenticated"));
+    mockGetUserUsageStats.mockResolvedValue(null);
+
+    const res = await GET();
+
+    expect(mockGetSubscription).toHaveBeenCalledOnce();
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({ error: "Failed to fetch subscription" });
+  });
+
+  it("returns null sections when subscription and usage are unavailable", async () => {
+    mockGetSubscription.mockResolvedValue(null);
+    mockGetUserUsageStats.mockResolvedValue(null);
+
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      subscription: null,
+      usage: null,
+    });
+  });
+
+  it("returns 500 when usage fetch throws", async () => {
+    mockGetSubscription.mockResolvedValue(null);
+    mockGetUserUsageStats.mockRejectedValue(new Error("DB failed"));
+
+    const res = await GET();
+
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({ error: "Failed to fetch subscription" });
+  });
+});

--- a/src/app/api/billing/verify-payment/__tests__/route.test.ts
+++ b/src/app/api/billing/verify-payment/__tests__/route.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { NextRequest } from "next/server";
+
+const mockGetCurrentUserId = vi.hoisted(() => vi.fn());
+const mockVerifyPaymentSignature = vi.hoisted(() => vi.fn());
+const mockCreateSubscription = vi.hoisted(() => vi.fn());
+const mockCheckRateLimit = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/auth", () => ({
+  getCurrentUserId: mockGetCurrentUserId,
+}));
+
+vi.mock("@/lib/billing/razorpay", () => ({
+  verifyPaymentSignature: mockVerifyPaymentSignature,
+  PLAN_PRICES: { free: 0, basic: 100000, pro: 200000 },
+}));
+
+vi.mock("@/lib/actions/billing", () => ({
+  createSubscription: mockCreateSubscription,
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: mockCheckRateLimit,
+  RATE_LIMITS: {
+    analysis: { limit: 20, windowSeconds: 3600 },
+  },
+}));
+
+import { POST } from "../route";
+
+function makeRequest(body: unknown): NextRequest {
+  return new Request("http://localhost/api/billing/verify-payment", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }) as NextRequest;
+}
+
+describe("POST /api/billing/verify-payment", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetCurrentUserId.mockResolvedValue("user_123");
+    mockCheckRateLimit.mockResolvedValue(null);
+    mockVerifyPaymentSignature.mockResolvedValue(true);
+    mockCreateSubscription.mockResolvedValue({
+      plan: "pro",
+      status: "active",
+      currentPeriodEnd: new Date("2026-01-01T00:00:00.000Z"),
+    });
+  });
+
+  it("returns success payload for valid payment details", async () => {
+    const res = await POST(
+      makeRequest({
+        orderId: "order_1",
+        paymentId: "pay_1",
+        signature: "sig_1",
+        plan: "pro",
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockGetCurrentUserId).toHaveBeenCalledOnce();
+    expect(mockVerifyPaymentSignature).toHaveBeenCalledWith("order_1", "pay_1", "sig_1");
+    expect(mockCreateSubscription).toHaveBeenCalledWith({
+      plan: "pro",
+      razorpaySubscriptionId: "pay_1",
+      razorpayCustomerId: "order_1",
+    });
+  });
+
+  it("enforces auth by calling getCurrentUserId and fails when unauthenticated", async () => {
+    mockGetCurrentUserId.mockRejectedValue(new Error("Not authenticated"));
+
+    const res = await POST(
+      makeRequest({
+        orderId: "order_1",
+        paymentId: "pay_1",
+        signature: "sig_1",
+        plan: "pro",
+      })
+    );
+
+    expect(mockGetCurrentUserId).toHaveBeenCalledOnce();
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({ error: "Payment verification failed" });
+  });
+
+  it("returns 400 for missing required fields", async () => {
+    const res = await POST(
+      makeRequest({
+        orderId: "order_1",
+        paymentId: "pay_1",
+        signature: "sig_1",
+      })
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: "Missing required fields: orderId, paymentId, signature, plan",
+    });
+  });
+
+  it("returns 500 when subscription creation throws", async () => {
+    mockCreateSubscription.mockRejectedValue(new Error("db failed"));
+
+    const res = await POST(
+      makeRequest({
+        orderId: "order_1",
+        paymentId: "pay_1",
+        signature: "sig_1",
+        plan: "basic",
+      })
+    );
+
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({ error: "Payment verification failed" });
+  });
+});

--- a/src/app/api/billing/webhook/__tests__/route.test.ts
+++ b/src/app/api/billing/webhook/__tests__/route.test.ts
@@ -1,0 +1,96 @@
+import crypto from "crypto";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { NextRequest } from "next/server";
+
+const mockDb = vi.hoisted(() => ({
+  update: vi.fn(),
+}));
+const mockEq = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/db", () => ({
+  db: mockDb,
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: mockEq,
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  subscriptions: {
+    razorpaySubscriptionId: "subscriptions.razorpaySubscriptionId",
+    id: "subscriptions.id",
+    userId: "subscriptions.userId",
+  },
+  users: {
+    id: "users.id",
+  },
+}));
+
+import { POST } from "../route";
+
+function signPayload(secret: string, body: string): string {
+  return crypto.createHmac("sha256", secret).update(body).digest("hex");
+}
+
+function makeRequest(payload: unknown, signature?: string): NextRequest {
+  const body = JSON.stringify(payload);
+  const headers = new Headers({ "Content-Type": "application/json" });
+  if (signature) headers.set("x-razorpay-signature", signature);
+
+  return new Request("http://localhost/api/billing/webhook", {
+    method: "POST",
+    headers,
+    body,
+  }) as NextRequest;
+}
+
+describe("POST /api/billing/webhook", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.RAZORPAY_WEBHOOK_SECRET = "test_webhook_secret";
+  });
+
+  it("returns received true for valid signed webhook", async () => {
+    const payload = { event: "payment.captured", payload: {} };
+    const signature = signPayload(process.env.RAZORPAY_WEBHOOK_SECRET!, JSON.stringify(payload));
+
+    const res = await POST(makeRequest(payload, signature));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ received: true });
+  });
+
+  it("returns 401 when signature header is missing", async () => {
+    const res = await POST(makeRequest({ event: "payment.captured" }));
+
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toEqual({ error: "Missing signature" });
+  });
+
+  it("returns 401 for invalid signatures", async () => {
+    const payload = { event: "payment.captured" };
+    const res = await POST(makeRequest(payload, "bad-signature"));
+
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toEqual({ error: "Invalid signature" });
+  });
+
+  it("returns 500 when db update throws during cancellation event", async () => {
+    const payload = {
+      event: "subscription.cancelled",
+      payload: { subscription: { entity: { id: "sub_123" } } },
+    };
+    const signature = signPayload(process.env.RAZORPAY_WEBHOOK_SECRET!, JSON.stringify(payload));
+
+    mockEq.mockReturnValue("eq-filter");
+    const returning = vi.fn().mockRejectedValue(new Error("db down"));
+    const where = vi.fn().mockReturnValue({ returning });
+    const set = vi.fn().mockReturnValue({ where });
+    mockDb.update.mockReturnValue({ set });
+
+    const res = await POST(makeRequest(payload, signature));
+
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({ error: "Webhook processing failed" });
+  });
+});

--- a/src/app/api/liveblocks-auth/__tests__/route.test.ts
+++ b/src/app/api/liveblocks-auth/__tests__/route.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetCurrentUserId = vi.hoisted(() => vi.fn());
+const mockGetCurrentUser = vi.hoisted(() => vi.fn());
+const mockAuthorize = vi.hoisted(() => vi.fn());
+const mockAllow = vi.hoisted(() => vi.fn());
+const mockPrepareSession = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/auth", () => ({
+  getCurrentUserId: mockGetCurrentUserId,
+  getCurrentUser: mockGetCurrentUser,
+}));
+
+vi.mock("@liveblocks/node", () => ({
+  Liveblocks: class {
+    prepareSession = mockPrepareSession;
+  },
+}));
+
+import { POST } from "../route";
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost/api/liveblocks-auth", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/liveblocks-auth", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.LIVEBLOCKS_SECRET_KEY = "liveblocks_secret";
+
+    mockGetCurrentUserId.mockResolvedValue("user_123");
+    mockGetCurrentUser.mockResolvedValue({
+      firstName: "Ada",
+      lastName: "Lovelace",
+      imageUrl: "https://avatar",
+    });
+
+    mockAuthorize.mockResolvedValue({ status: 200, body: "authorized-token" });
+    mockPrepareSession.mockReturnValue({
+      FULL_ACCESS: "full",
+      allow: mockAllow,
+      authorize: mockAuthorize,
+    });
+  });
+
+  it("returns authorized liveblocks token for valid request", async () => {
+    const res = await POST(makeRequest({ room: "presentation:deck_1" }));
+
+    expect(res.status).toBe(200);
+    await expect(res.text()).resolves.toBe("authorized-token");
+    expect(mockGetCurrentUserId).toHaveBeenCalledOnce();
+    expect(mockAllow).toHaveBeenCalledWith("presentation:deck_1", "full");
+  });
+
+  it("returns 401 when user is not authenticated", async () => {
+    mockGetCurrentUserId.mockRejectedValue(new Error("Not authenticated"));
+
+    const res = await POST(makeRequest({ room: "presentation:deck_1" }));
+
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toEqual({ error: "Unauthorized" });
+  });
+
+  it("still authorizes when room is missing (current behavior)", async () => {
+    const res = await POST(makeRequest({}));
+
+    expect(res.status).toBe(200);
+    expect(mockAllow).toHaveBeenCalledWith(undefined, "full");
+  });
+
+  it("returns 500 when user profile lookup fails", async () => {
+    mockGetCurrentUser.mockRejectedValue(new Error("clerk down"));
+
+    const res = await POST(makeRequest({ room: "presentation:deck_1" }));
+
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({ error: "Auth service error" });
+  });
+});

--- a/src/app/api/onboarding/complete/__tests__/route.test.ts
+++ b/src/app/api/onboarding/complete/__tests__/route.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetCurrentUserId = vi.hoisted(() => vi.fn());
+const mockDb = vi.hoisted(() => ({
+  update: vi.fn(),
+}));
+const mockEq = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/auth", () => ({
+  getCurrentUserId: mockGetCurrentUserId,
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: mockDb,
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: mockEq,
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  users: {
+    id: "users.id",
+  },
+}));
+
+import { POST } from "../route";
+
+describe("POST /api/onboarding/complete", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetCurrentUserId.mockResolvedValue("user_123");
+    mockEq.mockReturnValue("eq-filter");
+    const where = vi.fn().mockResolvedValue(undefined);
+    const set = vi.fn().mockReturnValue({ where });
+    mockDb.update.mockReturnValue({ set });
+  });
+
+  it("marks onboarding as complete for authenticated user", async () => {
+    const res = await POST();
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ success: true });
+    expect(mockGetCurrentUserId).toHaveBeenCalledOnce();
+  });
+
+  it("enforces auth by requiring getCurrentUserId", async () => {
+    mockGetCurrentUserId.mockRejectedValue(new Error("Not authenticated"));
+
+    const res = await POST();
+
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({ error: "Failed to complete onboarding" });
+  });
+
+  it("returns 500 when db update throws", async () => {
+    const where = vi.fn().mockRejectedValue(new Error("db failed"));
+    const set = vi.fn().mockReturnValue({ where });
+    mockDb.update.mockReturnValue({ set });
+
+    const res = await POST();
+
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({ error: "Failed to complete onboarding" });
+  });
+
+  it("returns 500 when query builder throws before DB write", async () => {
+    mockEq.mockImplementation(() => {
+      throw new Error("bad condition");
+    });
+
+    const res = await POST();
+
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({ error: "Failed to complete onboarding" });
+  });
+});

--- a/src/app/api/webhooks/clerk/__tests__/route.test.ts
+++ b/src/app/api/webhooks/clerk/__tests__/route.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { NextRequest } from "next/server";
+
+const mockDb = vi.hoisted(() => ({
+  insert: vi.fn(),
+  update: vi.fn(),
+}));
+const mockLoggerWithRequestId = vi.hoisted(() => vi.fn());
+const mockLogError = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/db", () => ({ db: mockDb }));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    withRequestId: mockLoggerWithRequestId,
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  users: {
+    id: "users.id",
+  },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn(() => "eq-filter"),
+}));
+
+import { POST } from "../route";
+
+function makeRequest(payload: unknown): NextRequest {
+  return new Request("http://localhost/api/webhooks/clerk", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  }) as NextRequest;
+}
+
+describe("POST /api/webhooks/clerk", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLoggerWithRequestId.mockReturnValue({ error: mockLogError });
+
+    const onConflictDoUpdate = vi.fn().mockResolvedValue(undefined);
+    const values = vi.fn().mockReturnValue({ onConflictDoUpdate });
+    mockDb.insert.mockReturnValue({ values });
+
+    const where = vi.fn().mockResolvedValue(undefined);
+    const set = vi.fn().mockReturnValue({ where });
+    mockDb.update.mockReturnValue({ set });
+  });
+
+  it("upserts user data for user.created event", async () => {
+    const res = await POST(
+      makeRequest({
+        type: "user.created",
+        data: {
+          id: "user_1",
+          first_name: "Ada",
+          last_name: "Lovelace",
+          image_url: "https://avatar",
+          email_addresses: [{ email_address: "ada@example.com" }],
+        },
+      })
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ success: true });
+    expect(mockDb.insert).toHaveBeenCalledOnce();
+  });
+
+  it("returns 500 when required payload shape is missing", async () => {
+    const res = await POST(makeRequest({ type: "user.created", data: null }));
+
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({ error: "Webhook processing failed" });
+  });
+
+  it("returns 500 when body is invalid json", async () => {
+    const req = new Request("http://localhost/api/webhooks/clerk", {
+      method: "POST",
+      body: "not-json",
+      headers: { "Content-Type": "application/json" },
+    }) as NextRequest;
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({ error: "Webhook processing failed" });
+  });
+
+  it("returns 500 when database operation fails", async () => {
+    const onConflictDoUpdate = vi.fn().mockRejectedValue(new Error("db failed"));
+    const values = vi.fn().mockReturnValue({ onConflictDoUpdate });
+    mockDb.insert.mockReturnValue({ values });
+
+    const res = await POST(
+      makeRequest({
+        type: "user.updated",
+        data: { id: "user_1", email_addresses: [] },
+      })
+    );
+
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({ error: "Webhook processing failed" });
+  });
+});


### PR DESCRIPTION
### Motivation

- Add comprehensive unit tests to validate API route behavior for billing, onboarding, Liveblocks auth, and Clerk webhooks to catch regressions and enforce expected error handling.
- Ensure external integrations (Razorpay, database, Clerk, Liveblocks, rate limiting, and auth) are correctly handled via mocks so edge cases are covered. 

### Description

- Introduce tests for `POST /api/billing/create-order` covering success path, authentication enforcement, invalid plans, and Razorpay errors with mocks for `@/lib/auth`, `@/lib/billing/razorpay`, and rate limiting.
- Add `POST /api/billing/verify-payment` tests for signature verification, required fields validation, auth enforcement, and subscription creation failures using mocks for `@/lib/auth`, `@/lib/billing/razorpay`, and billing actions.
- Add `GET /api/billing/subscription` tests covering subscription/usage retrieval, auth-dependent failures, missing data, and usage fetch errors with mocked billing and user action modules.
- Add webhook tests for `POST /api/billing/webhook` verifying HMAC signature validation and DB update error handling with mocked `@/lib/db`, `drizzle-orm`, and webhook secret handling.
- Add `POST /api/liveblocks-auth` tests to validate authorization flow, missing room behavior, auth failures, and profile lookup errors with a mocked Liveblocks client and auth helpers.
- Add `POST /api/onboarding/complete` tests to verify onboarding completion, auth enforcement, DB update errors, and query builder exceptions with mocked `@/lib/db` and `drizzle-orm`.
- Add `POST /api/webhooks/clerk` tests to cover user upsert behavior, malformed payloads, invalid JSON, and DB failures with mocked `@/lib/db` and `@/lib/logger`.

### Testing

- Ran the test suite using `vitest` for the new test files covering the API routes above and all new tests completed successfully. 
- Each endpoint test exercised success paths and relevant failure modes including auth failures, invalid inputs, signature validation, and simulated DB errors and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b433dee574832a8e2adf2ae9551f64)