### PR TITLE
Add Vitest unit tests for multiple UI components

### DIFF
--- a/src/components/deep-research/__tests__/SaveToLibraryButton.test.tsx
+++ b/src/components/deep-research/__tests__/SaveToLibraryButton.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SaveToLibraryButton } from "../SaveToLibraryButton";
+
+const baseProps = {
+  topic: "Cancer biomarkers",
+  mode: "standard",
+  markdownReport: "# Report",
+  sources: [],
+  keyFindings: ["Finding A"],
+  gaps: ["Gap A"],
+  isComplete: true,
+  isLoggedIn: true,
+};
+
+describe("SaveToLibraryButton", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("renders disabled state for incomplete research", () => {
+    act(() => {
+      root.render(<SaveToLibraryButton {...baseProps} isComplete={false} />);
+    });
+
+    const button = container.querySelector("button");
+    expect(button?.textContent).toContain("Save to Library");
+    expect(button?.disabled).toBe(true);
+    expect(button?.getAttribute("title")).toContain("must be complete");
+  });
+
+  it("submits and transitions to saved state", async () => {
+    const fetchMock = vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    } as Response);
+
+    act(() => {
+      root.render(<SaveToLibraryButton {...baseProps} />);
+    });
+
+    const button = container.querySelector("button")!;
+    await act(async () => {
+      button.click();
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(container.textContent).toContain("Saved");
+  });
+
+  it("shows error and retry label when request fails", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: "Backend unavailable" }),
+    } as Response);
+
+    act(() => {
+      root.render(<SaveToLibraryButton {...baseProps} />);
+    });
+
+    await act(async () => {
+      container.querySelector("button")?.click();
+    });
+
+    expect(container.textContent).toContain("Retry");
+    expect(container.textContent).toContain("Backend unavailable");
+  });
+});

--- a/src/components/feeds/__tests__/AddFeedModal.test.tsx
+++ b/src/components/feeds/__tests__/AddFeedModal.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AddFeedModal } from "../add-feed-modal";
+
+const subscribeMock = vi.hoisted(() => vi.fn());
+const subscribePubMedMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/stores/feed-store", () => ({
+  useFeedStore: (selector: (state: { subscribe: typeof subscribeMock; subscribePubMed: typeof subscribePubMedMock }) => unknown) =>
+    selector({ subscribe: subscribeMock, subscribePubMed: subscribePubMedMock }),
+}));
+
+vi.mock("@/components/ui/modal", () => ({
+  Modal: ({ open, title, children }: { open: boolean; title: string; children: React.ReactNode }) =>
+    open ? (
+      <div>
+        <h2>{title}</h2>
+        {children}
+      </div>
+    ) : null,
+}));
+
+vi.mock("@/components/ui/tabs", () => ({
+  Tabs: ({ tabs, activeTab, onChange }: { tabs: Array<{ key: string; label: string }>; activeTab: string; onChange: (tab: string) => void }) => (
+    <div>
+      {tabs.map((tab) => (
+        <button key={tab.key} data-active={activeTab === tab.key} onClick={() => onChange(tab.key)}>
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock("@/components/feeds/journal-browser", () => ({
+  JournalBrowser: () => <div>Journal Browser Content</div>,
+}));
+
+describe("AddFeedModal", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const onClose = vi.fn();
+
+  beforeEach(() => {
+    subscribeMock.mockReset();
+    subscribePubMedMock.mockReset();
+    onClose.mockReset();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function setInputValue(input: HTMLInputElement, value: string) {
+    const valueSetter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      "value",
+    )?.set;
+    valueSetter?.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  }
+
+  it("renders modal and disables add button initially", () => {
+    act(() => root.render(<AddFeedModal open onClose={onClose} />));
+    expect(container.textContent).toContain("Add Feed");
+    const addButton = Array.from(container.querySelectorAll("button")).find((b) => b.textContent === "Add");
+    expect(addButton?.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("subscribes by URL and closes modal", async () => {
+    subscribeMock.mockResolvedValue(undefined);
+    act(() => root.render(<AddFeedModal open onClose={onClose} />));
+
+    const input = container.querySelector('input[type="url"]') as HTMLInputElement;
+    await act(async () => {
+      setInputValue(input, "https://example.com/feed.xml");
+    });
+
+    const addButton = Array.from(container.querySelectorAll("button")).find((b) => b.textContent === "Add")!;
+    await act(async () => {
+      addButton.click();
+    });
+
+    expect(subscribeMock).toHaveBeenCalledWith("https://example.com/feed.xml");
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("shows error and can switch to browse tab", async () => {
+    subscribeMock.mockRejectedValue(new Error("Invalid feed"));
+    act(() => root.render(<AddFeedModal open onClose={onClose} />));
+
+    const input = container.querySelector('input[type="url"]') as HTMLInputElement;
+    await act(async () => {
+      setInputValue(input, "https://bad.example");
+    });
+    await act(async () => {
+      Array.from(container.querySelectorAll("button")).find((b) => b.textContent === "Add")?.click();
+    });
+
+    expect(container.textContent).toContain("Invalid feed");
+
+    await act(async () => {
+      Array.from(container.querySelectorAll("button")).find((b) => b.textContent === "Browse Journals")?.click();
+    });
+    expect(container.textContent).toContain("Journal Browser Content");
+  });
+
+  it("subscribes using PubMed query", async () => {
+    subscribePubMedMock.mockResolvedValue(undefined);
+    act(() => root.render(<AddFeedModal open onClose={onClose} />));
+
+    const inputs = Array.from(container.querySelectorAll("input")) as HTMLInputElement[];
+    const pubmedInput = inputs.find((i) => i.type === "text")!;
+    await act(async () => {
+      setInputValue(pubmedInput, "oncology AND trial");
+    });
+
+    await act(async () => {
+      Array.from(container.querySelectorAll("button")).find((b) => b.textContent === "Create Feed")?.click();
+    });
+
+    expect(subscribePubMedMock).toHaveBeenCalledWith("oncology AND trial");
+    expect(onClose).toHaveBeenCalled();
+  });
+
+});

--- a/src/components/integrity/__tests__/IntegrityPanel.test.tsx
+++ b/src/components/integrity/__tests__/IntegrityPanel.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { IntegrityPanel } from "../IntegrityPanel";
+
+vi.mock("@/components/ui/circular-gauge", () => ({
+  CircularGauge: ({ value, label }: { value: number; label: string }) => (
+    <div>{label}:{value}</div>
+  ),
+}));
+
+const successResult = {
+  tier: "free",
+  aiDetection: {
+    humanScore: 82,
+    aiScore: 18,
+    overallRisk: "low",
+    engine: "binoculars",
+    stats: {
+      avgSentenceLength: 10,
+      sentenceLengthStdDev: 2,
+      typeTokenRatio: 0.5,
+      passiveVoicePercent: 5,
+      readabilityGrade: 8,
+      hedgingPhraseCount: 1,
+      formulaicTransitionDensity: 0.1,
+      paragraphLengthStdDev: 4,
+      repetitiveSentenceOpeningRatio: 0.1,
+      markdownHeadingCount: 0,
+    },
+    paragraphs: [],
+  },
+  plagiarism: { similarityScore: 0, sourcesScanned: 10, matches: [], engine: "shingling-scholarly" },
+  citationAudit: { totalCitations: 0, verifiedCitations: 0, issues: [], verifiedReferences: [] },
+  writingQuality: { passiveVoiceCount: 1, averageSentenceLength: 10, readabilityGrade: 8, suggestions: [] },
+  checkedAt: new Date().toISOString(),
+};
+
+describe("IntegrityPanel", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("renders initial idle state", () => {
+    act(() => {
+      root.render(<IntegrityPanel getEditorText={() => "a".repeat(100)} />);
+    });
+
+    expect(container.textContent).toContain("Integrity Check");
+    expect(container.textContent).toContain("Run Integrity Check");
+  });
+
+  it("shows validation error for short text", async () => {
+    act(() => {
+      root.render(<IntegrityPanel getEditorText={() => "too short"} />);
+    });
+
+    await act(async () => {
+      (Array.from(container.querySelectorAll("button")).find((b) => b.textContent?.includes("Run Integrity Check")) as HTMLButtonElement).click();
+    });
+
+    expect(container.textContent).toContain("at least 50 characters");
+    expect(container.textContent).toContain("Retry");
+  });
+
+  it("shows running and then success report", async () => {
+    let resolveFetch: (value: Response) => void = () => {};
+    vi.spyOn(global, "fetch").mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        }) as Promise<Response>,
+    );
+
+    act(() => {
+      root.render(<IntegrityPanel getEditorText={() => "a".repeat(120)} />);
+    });
+
+    await act(async () => {
+      (Array.from(container.querySelectorAll("button")).find((b) => b.textContent?.includes("Run Integrity Check")) as HTMLButtonElement).click();
+    });
+
+    expect(container.textContent).toContain("Analyzing Document");
+
+    await act(async () => {
+      resolveFetch({ ok: true, json: async () => successResult } as Response);
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("Integrity Report");
+    expect(container.textContent).toContain("Human Score:82");
+  });
+
+  it("shows API error state when request fails", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: "service down" }),
+    } as Response);
+
+    act(() => {
+      root.render(<IntegrityPanel getEditorText={() => "a".repeat(120)} />);
+    });
+
+    await act(async () => {
+      (Array.from(container.querySelectorAll("button")).find((b) => b.textContent?.includes("Run Integrity Check")) as HTMLButtonElement).click();
+    });
+
+    expect(container.textContent).toContain("service down");
+    expect(container.textContent).toContain("Retry");
+  });
+
+});

--- a/src/components/latex-editor/__tests__/ImageBrowser.test.tsx
+++ b/src/components/latex-editor/__tests__/ImageBrowser.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ImageBrowser } from "../image-browser";
+
+vi.mock("next/image", () => ({
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => <img {...props} alt={props.alt || "image"} />,
+}));
+
+describe("ImageBrowser", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const onInsertImage = vi.fn();
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    onInsertImage.mockReset();
+    Object.defineProperty(globalThis, "navigator", {
+      value: { clipboard: { writeText: vi.fn() } },
+      configurable: true,
+    });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("renders empty state after loading", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({ ok: true, json: async () => ({ images: [] }) } as Response);
+
+    await act(async () => {
+      root.render(<ImageBrowser projectId="p1" onInsertImage={onInsertImage} />);
+    });
+
+    await act(async () => {
+      (container.querySelector("div.flex.flex-col.h-full") as HTMLDivElement)?.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    });
+
+    expect(container.textContent).toContain("Drag & drop images here");
+  });
+
+  it("renders loaded images list state", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        images: [
+          {
+            id: "1",
+            filename: "figure-one.png",
+            storageKey: "k1",
+            sizeBytes: 1200,
+            contentType: "image/png",
+            url: "https://example.com/figure-one.png",
+          },
+        ],
+      }),
+    } as Response);
+
+    await act(async () => {
+      root.render(<ImageBrowser projectId="p1" onInsertImage={onInsertImage} />);
+    });
+
+    await act(async () => {
+      (container.querySelector("div.flex.flex-col.h-full") as HTMLDivElement)?.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("figure-one.png");
+    expect(container.textContent).toContain("Click to insert");
+  });
+
+  it("shows validation error for invalid file type", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({ ok: true, json: async () => ({ images: [] }) } as Response);
+
+    await act(async () => {
+      root.render(<ImageBrowser projectId="p1" onInsertImage={onInsertImage} />);
+    });
+
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const badFile = new File(["x"], "notes.txt", { type: "text/plain" });
+
+    await act(async () => {
+      Object.defineProperty(input, "files", { value: [badFile], configurable: true });
+      input.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+
+    expect(container.textContent).toContain("Invalid file type");
+  });
+});

--- a/src/components/latex-editor/__tests__/version-history-panel.test.tsx
+++ b/src/components/latex-editor/__tests__/version-history-panel.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { VersionHistoryPanel } from "../version-history-panel";
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+describe("VersionHistoryPanel", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.stubGlobal("confirm", vi.fn(() => true));
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("renders loading then empty state", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({ ok: true, json: async () => ({ versions: [] }) } as Response);
+
+    await act(async () => {
+      root.render(<VersionHistoryPanel fileId="f1" onRestore={vi.fn()} />);
+    });
+
+    expect(container.textContent).toContain("No saved versions yet");
+    expect(container.textContent).toContain("Save Current Version");
+  });
+
+  it("saves a new version and reloads list", async () => {
+    const fetchMock = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ versions: [] }) } as Response)
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ versions: [{ id: "v1", description: "snapshot", createdAt: new Date().toISOString() }] }),
+      } as Response);
+
+    await act(async () => {
+      root.render(<VersionHistoryPanel fileId="f1" onRestore={vi.fn()} onBeforeSave={vi.fn()} />);
+    });
+
+    await act(async () => {
+      Array.from(container.querySelectorAll("button")).find((b) => b.textContent?.includes("Save Current Version"))?.click();
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/latex/versions", expect.objectContaining({ method: "POST" }));
+    expect(container.textContent).toContain("snapshot");
+  });
+
+  it("shows error banner when loading fails", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({ ok: false } as Response);
+
+    await act(async () => {
+      root.render(<VersionHistoryPanel fileId="f1" onRestore={vi.fn()} />);
+    });
+
+    expect(container.textContent).toContain("Failed to load versions");
+  });
+});

--- a/src/components/layout/__tests__/app-shell.test.tsx
+++ b/src/components/layout/__tests__/app-shell.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppShell } from "../app-shell";
+
+const sidebarSpy = vi.hoisted(() => vi.fn());
+
+vi.mock("../app-sidebar", () => ({
+  AppSidebar: ({ open, onClose }: { open: boolean; onClose: () => void }) => {
+    sidebarSpy(open);
+    return <button onClick={onClose}>sidebar-{open ? "open" : "closed"}</button>;
+  },
+}));
+
+vi.mock("../app-header", () => ({
+  AppHeader: ({ onMenuClick }: { onMenuClick: () => void }) => (
+    <button onClick={onMenuClick}>open-menu</button>
+  ),
+}));
+
+vi.mock("@/components/ui/command-palette", () => ({
+  CommandPalette: () => <div>command-palette</div>,
+}));
+
+describe("AppShell", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    sidebarSpy.mockReset();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("renders children and command palette", () => {
+    act(() => {
+      root.render(<AppShell><div>child-content</div></AppShell>);
+    });
+
+    expect(container.textContent).toContain("child-content");
+    expect(container.textContent).toContain("command-palette");
+    expect(sidebarSpy).toHaveBeenCalledWith(false);
+  });
+
+  it("opens and closes sidebar through header and sidebar callbacks", async () => {
+    act(() => {
+      root.render(<AppShell><div>child</div></AppShell>);
+    });
+
+    await act(async () => {
+      Array.from(container.querySelectorAll("button")).find((b) => b.textContent === "open-menu")?.click();
+    });
+    expect(container.textContent).toContain("sidebar-open");
+
+    await act(async () => {
+      Array.from(container.querySelectorAll("button")).find((b) => b.textContent === "sidebar-open")?.click();
+    });
+    expect(container.textContent).toContain("sidebar-closed");
+  });
+});

--- a/src/components/notebook/__tests__/NotebookPasswordGate.test.tsx
+++ b/src/components/notebook/__tests__/NotebookPasswordGate.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NotebookPasswordGate } from "../NotebookPasswordGate";
+
+const verifyPasswordMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/actions/notebook-share", () => ({
+  verifyNotebookSharePassword: verifyPasswordMock,
+}));
+
+vi.mock("../SharedNotebookViewer", () => ({
+  SharedNotebookViewer: ({ title }: { title: string }) => <div>viewer:{title}</div>,
+}));
+
+const notebook = {
+  title: "Shared notes",
+  ownerName: "Alice",
+  mode: "view",
+  createdAt: new Date(),
+  messages: [],
+};
+
+describe("NotebookPasswordGate", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    verifyPasswordMock.mockReset();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function setPassword(value: string) {
+    const input = container.querySelector('input[type="password"]') as HTMLInputElement;
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+    setter?.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  }
+
+  it("renders locked form", () => {
+    act(() => root.render(<NotebookPasswordGate token="t1" notebook={notebook} />));
+    expect(container.textContent).toContain("Password Protected");
+    expect(container.textContent).toContain("View Notebook");
+  });
+
+  it("shows loading and error for invalid password", async () => {
+    verifyPasswordMock.mockResolvedValue(false);
+    act(() => root.render(<NotebookPasswordGate token="t1" notebook={notebook} />));
+
+    await act(async () => {
+      setPassword("wrong-pass");
+    });
+
+    await act(async () => {
+      container.querySelector("form")?.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    });
+
+    expect(verifyPasswordMock).toHaveBeenCalledWith("t1", "wrong-pass");
+    expect(container.textContent).toContain("Incorrect password");
+  });
+
+  it("renders shared viewer when password is valid", async () => {
+    verifyPasswordMock.mockResolvedValue(true);
+    act(() => root.render(<NotebookPasswordGate token="t1" notebook={notebook} />));
+
+    await act(async () => {
+      setPassword("correct");
+      container.querySelector("form")?.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    });
+
+    expect(container.textContent).toContain("viewer:Shared notes");
+  });
+});

--- a/src/components/pdf-viewer/__tests__/PDFChatPanel.test.tsx
+++ b/src/components/pdf-viewer/__tests__/PDFChatPanel.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PDFChatPanel } from "../PDFChatPanel";
+
+const storeState = vi.hoisted(() => ({
+  chatMessages: [] as Array<{ id: string; role: string; content: string }> ,
+  isChatLoading: false,
+  highlights: [] as Array<{ paperId: string; pageNumber: number; selectedText: string; note?: string; color?: string; targetSection?: string }>,
+}));
+const addChatMessageMock = vi.hoisted(() => vi.fn());
+const setChatLoadingMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/stores/pdf-store", () => ({
+  usePDFStore: () => ({
+    ...storeState,
+    addChatMessage: addChatMessageMock,
+    setChatLoading: setChatLoadingMock,
+  }),
+}));
+
+vi.mock("../PDFChatMessage", () => ({
+  PDFChatMessageComponent: ({ message }: { message: { content: string } }) => <div>{message.content}</div>,
+}));
+
+vi.mock("../PDFSuggestedQuestions", () => ({
+  PDFSuggestedQuestions: ({ questions, onSelect }: { questions: string[]; onSelect: (q: string) => void }) => (
+    <div>
+      <span>suggested</span>
+      <button onClick={() => onSelect(questions[0])}>ask-first</button>
+    </div>
+  ),
+}));
+
+describe("PDFChatPanel", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    addChatMessageMock.mockReset();
+    setChatLoadingMock.mockReset();
+    storeState.chatMessages = [];
+    storeState.isChatLoading = false;
+    storeState.highlights = [];
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("renders suggested questions when there are no messages", () => {
+    act(() => {
+      root.render(<PDFChatPanel paperId="p1" paperMetadata={null} onNavigateToPage={vi.fn()} />);
+    });
+
+    expect(container.textContent).toContain("suggested");
+    expect(container.textContent).toContain("Ask about this paper");
+  });
+
+  it("sends message and appends assistant response", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({ ok: true, json: async () => ({ content: "assistant answer", sourceQuotes: [] }) } as Response);
+
+    act(() => {
+      root.render(<PDFChatPanel paperId="p1" paperMetadata={{ title: "Trial paper" } as never} onNavigateToPage={vi.fn()} />);
+    });
+
+    const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, "value")?.set;
+
+    await act(async () => {
+      setter?.call(textarea, "What is outcome?");
+      textarea.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    await act(async () => {
+      container.querySelector('button[aria-label="Send message"]')?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(addChatMessageMock).toHaveBeenCalled();
+    expect(setChatLoadingMock).toHaveBeenCalledWith(true);
+    expect(setChatLoadingMock).toHaveBeenLastCalledWith(false);
+  });
+
+  it("shows selection attachment context", () => {
+    act(() => {
+      root.render(
+        <PDFChatPanel
+          paperId="p1"
+          paperMetadata={null}
+          currentSelection={{ pageNumber: 3, text: "selected text" } as never}
+          onNavigateToPage={vi.fn()}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain("Selection from p.3 attached");
+  });
+});

--- a/src/components/pdf-viewer/__tests__/PDFSearchBar.test.tsx
+++ b/src/components/pdf-viewer/__tests__/PDFSearchBar.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PDFSearchBar } from "../PDFSearchBar";
+
+describe("PDFSearchBar", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  const onClose = vi.fn();
+  const onSearch = vi.fn();
+  const onNextMatch = vi.fn();
+  const onPrevMatch = vi.fn();
+
+  beforeEach(() => {
+    onClose.mockReset();
+    onSearch.mockReset();
+    onNextMatch.mockReset();
+    onPrevMatch.mockReset();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("does not render when closed", () => {
+    act(() => {
+      root.render(
+        <PDFSearchBar
+          isOpen={false}
+          onClose={onClose}
+          onSearch={onSearch}
+          onNextMatch={onNextMatch}
+          onPrevMatch={onPrevMatch}
+          matchCount={0}
+          currentMatch={0}
+        />,
+      );
+    });
+
+    expect(container.textContent).toBe("");
+  });
+
+  it("updates query and search callbacks", async () => {
+    act(() => {
+      root.render(
+        <PDFSearchBar
+          isOpen
+          onClose={onClose}
+          onSearch={onSearch}
+          onNextMatch={onNextMatch}
+          onPrevMatch={onPrevMatch}
+          matchCount={3}
+          currentMatch={1}
+        />,
+      );
+    });
+
+    const input = container.querySelector("input") as HTMLInputElement;
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+    await act(async () => {
+      setter?.call(input, "aspirin");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    expect(onSearch).toHaveBeenCalledWith("aspirin");
+    expect(container.textContent).toContain("1/3");
+  });
+
+  it("handles keyboard and navigation actions", async () => {
+    act(() => {
+      root.render(
+        <PDFSearchBar
+          isOpen
+          onClose={onClose}
+          onSearch={onSearch}
+          onNextMatch={onNextMatch}
+          onPrevMatch={onPrevMatch}
+          matchCount={2}
+          currentMatch={1}
+        />,
+      );
+    });
+
+    const input = container.querySelector("input") as HTMLInputElement;
+    await act(async () => {
+      input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+      input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", shiftKey: true, bubbles: true }));
+      input.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+
+    expect(onNextMatch).toHaveBeenCalled();
+    expect(onPrevMatch).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/components/research/__tests__/ResearchPlan.test.tsx
+++ b/src/components/research/__tests__/ResearchPlan.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ResearchPlan } from "../ResearchPlan";
+
+const plan = {
+  originalQuery: "Does aspirin help prevent stroke?",
+  pubmedQuery: "aspirin AND stroke prevention",
+  meshTerms: ["Aspirin", "Stroke"],
+  synonyms: {},
+  suggestedFilters: { dateFrom: 2018, dateTo: 2024, studyTypes: ["RCT"] },
+  estimatedResults: "120",
+  rationale: "Focus on modern randomized evidence",
+};
+
+describe("ResearchPlan", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  const onRunSearch = vi.fn();
+  const onCancel = vi.fn();
+  const onUpdatePlan = vi.fn();
+
+  beforeEach(() => {
+    onRunSearch.mockReset();
+    onCancel.mockReset();
+    onUpdatePlan.mockReset();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("renders loading state", () => {
+    act(() => {
+      root.render(
+        <ResearchPlan
+          plan={plan as never}
+          isLoading
+          onRunSearch={onRunSearch}
+          onCancel={onCancel}
+          onUpdatePlan={onUpdatePlan}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain("Generating search plan");
+  });
+
+  it("renders plan details and handles run/cancel actions", async () => {
+    act(() => {
+      root.render(
+        <ResearchPlan
+          plan={plan as never}
+          isLoading={false}
+          onRunSearch={onRunSearch}
+          onCancel={onCancel}
+          onUpdatePlan={onUpdatePlan}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain("Research Plan");
+    expect(container.textContent).toContain("MeSH Terms");
+
+    await act(async () => {
+      Array.from(container.querySelectorAll("button")).find((b) => b.textContent?.includes("Run Search"))?.click();
+      Array.from(container.querySelectorAll("button")).find((b) => b.textContent === "Cancel")?.click();
+    });
+
+    expect(onRunSearch).toHaveBeenCalled();
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it("toggles query edit mode", async () => {
+    act(() => {
+      root.render(
+        <ResearchPlan
+          plan={plan as never}
+          isLoading={false}
+          onRunSearch={onRunSearch}
+          onCancel={onCancel}
+          onUpdatePlan={onUpdatePlan}
+        />,
+      );
+    });
+
+    expect(container.querySelector("textarea")).toBeNull();
+
+    await act(async () => {
+      Array.from(container.querySelectorAll("button")).find((b) => b.textContent?.includes("Edit"))?.click();
+    });
+    expect(container.querySelector("textarea")).toBeTruthy();
+
+    await act(async () => {
+      Array.from(container.querySelectorAll("button")).find((b) => b.textContent?.includes("Done"))?.click();
+    });
+    expect(container.querySelector("textarea")).toBeNull();
+  });
+
+});

--- a/src/components/research/__tests__/SearchInput.test.tsx
+++ b/src/components/research/__tests__/SearchInput.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SearchInput } from "../SearchInput";
+
+vi.mock("../FilterPanel", () => ({
+  FilterPanel: () => <div>filter-panel</div>,
+}));
+
+describe("SearchInput", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  const onQueryChange = vi.fn();
+  const onFiltersChange = vi.fn();
+  const onRemoveChip = vi.fn();
+  const onSearch = vi.fn();
+
+  const baseProps = {
+    query: "gene therapy",
+    onQueryChange,
+    filters: {},
+    onFiltersChange,
+    parsedChips: [{ label: "year:2020+" }],
+    onRemoveChip,
+    onSearch,
+    isSearching: false,
+  };
+
+  beforeEach(() => {
+    onQueryChange.mockReset();
+    onFiltersChange.mockReset();
+    onRemoveChip.mockReset();
+    onSearch.mockReset();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("renders input and parsed chips", () => {
+    act(() => {
+      root.render(<SearchInput {...baseProps} />);
+    });
+
+    expect(container.textContent).toContain("year:2020+");
+    expect(container.textContent).toContain("Search");
+  });
+
+  it("triggers query updates and search action", async () => {
+    act(() => {
+      root.render(<SearchInput {...baseProps} />);
+    });
+
+    const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, "value")?.set;
+
+    await act(async () => {
+      setter?.call(textarea, "new query");
+      textarea.dispatchEvent(new Event("input", { bubbles: true }));
+      textarea.dispatchEvent(new Event("change", { bubbles: true }));
+      textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    });
+
+    expect(onQueryChange).toHaveBeenCalledWith("new query");
+    expect(onSearch).toHaveBeenCalled();
+  });
+
+  it("shows loading label and toggles filter panel", async () => {
+    act(() => {
+      root.render(<SearchInput {...baseProps} isSearching />);
+    });
+
+    expect(container.textContent).toContain("Searching...");
+
+    await act(async () => {
+      Array.from(container.querySelectorAll("button")).find((b) => b.textContent?.includes("Filters"))?.click();
+    });
+
+    expect(container.textContent).toContain("filter-panel");
+  });
+});

--- a/src/components/systematic-review/__tests__/PaperImportPanel.test.tsx
+++ b/src/components/systematic-review/__tests__/PaperImportPanel.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PaperImportPanel } from "../PaperImportPanel";
+
+vi.mock("@/components/ui/glass-panel", () => ({
+  GlassPanel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/stores/systematic-review-store", () => ({
+  useSystematicReviewStore: () => ({
+    generatedStrategy: { fullSearchString: "cancer AND trial", estimatedResults: 25 },
+  }),
+}));
+
+describe("PaperImportPanel", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("renders import controls and loads papers", async () => {
+    const fetchMock = vi.spyOn(global, "fetch").mockResolvedValue({ ok: true, json: async () => ({ papers: [] }) } as Response);
+
+    await act(async () => {
+      root.render(<PaperImportPanel projectId={7} />);
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/systematic-review/import?projectId=7");
+    expect(container.textContent).toContain("Import from Databases");
+    expect(container.textContent).toContain("Import Papers");
+  });
+
+  it("imports papers and shows success state", async () => {
+    vi.spyOn(global, "fetch")
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ papers: [] }) } as Response)
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ imported: 3, duplicatesSkipped: 1, totalFound: 9 }) } as Response)
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ papers: [] }) } as Response);
+
+    await act(async () => {
+      root.render(<PaperImportPanel projectId={7} />);
+    });
+
+    await act(async () => {
+      Array.from(container.querySelectorAll("button")).find((b) => b.textContent?.includes("Import Papers"))?.click();
+    });
+
+    expect(container.textContent).toContain("Imported");
+    expect(container.textContent).toContain("3");
+    expect(container.textContent).toContain("duplicates skipped");
+  });
+
+  it("shows error banner when initial load throws", async () => {
+    vi.spyOn(global, "fetch").mockRejectedValue(new Error("network"));
+
+    await act(async () => {
+      root.render(<PaperImportPanel projectId={7} />);
+    });
+
+    expect(container.textContent).toContain("Failed to load papers");
+  });
+
+  it("disables import when all sources are deselected", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({ ok: true, json: async () => ({ papers: [] }) } as Response);
+
+    await act(async () => {
+      root.render(<PaperImportPanel projectId={7} />);
+    });
+
+    await act(async () => {
+      Array.from(container.querySelectorAll("button")).find((b) => b.textContent === "PubMed")?.click();
+    });
+
+    const importButton = Array.from(container.querySelectorAll("button")).find((b) => b.textContent?.includes("Import Papers"));
+    expect(importButton?.hasAttribute("disabled")).toBe(true);
+  });
+
+});


### PR DESCRIPTION
### Motivation

- Increase test coverage for UI components across the app by adding focused component tests using a headless DOM environment.
- Exercise network interactions, store hooks, and UI flows to catch regressions in rendering, user interactions, and API error handling.
- Provide deterministic component behavior by mocking stores, child components, and global APIs like `fetch` and `navigator.clipboard`.

### Description

- Added new Vitest test files under `src/components/*/__tests__` for components including `SaveToLibraryButton`, `AddFeedModal`, `IntegrityPanel`, `ImageBrowser`, `VersionHistoryPanel`, `AppShell`, `NotebookPasswordGate`, `PDFChatPanel`, `PDFSearchBar`, `ResearchPlan`, `SearchInput`, and `PaperImportPanel`.
- Tests run in the `jsdom` environment and use `react-dom/client`'s `createRoot` with `act` to mount/unmount components and simulate user interactions.
- Mocked dependencies and platform features such as store hooks (`use*Store`), UI primitives, `next/image`, modal/tabs components, and global APIs like `fetch`, `confirm`, and `navigator.clipboard` to control responses and error paths.
- Included helpers to manipulate input values and file inputs, and assert on UI states for loading, success, error, and interaction flows.

### Testing

- Executed the test suite with `vitest` targeting the newly added files under `src/components/*/__tests__`.
- The tests cover success and failure API responses via mocked `fetch` calls and validate UI transitions for loading, error, and saved states.
- All new unit tests completed successfully when run locally with `vitest` against the `jsdom` environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b43bae28f0832a8f389a19ac0a5fdf)