### PR TITLE
test(security): add form hardening and API security e2e tests

### DIFF
--- a/e2e/forms/project-creation-form.test.ts
+++ b/e2e/forms/project-creation-form.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+const projectsPath = path.resolve("src/app/(app)/projects/page.tsx");
+const source = fs.readFileSync(projectsPath, "utf8");
+
+describe("project creation form hardening", () => {
+  it("blocks empty required project name", () => {
+    expect(source).toContain("if (!newName.trim() || creating) return;");
+    expect(source).toContain("disabled={creating || !newName.trim()}");
+  });
+
+  it("handles special characters without unsafe interpolation", () => {
+    expect(source).toContain("title: newName.trim()");
+    expect(source).toContain("target_journal: newTargetJournal.trim() || undefined");
+  });
+
+  it("prevents double-click submit by checking creating state", () => {
+    expect(source).toContain("if (!newName.trim() || creating) return;");
+    expect(source).toContain("setCreating(true);");
+    expect(source).toContain("setCreating(false);");
+  });
+});

--- a/e2e/forms/search-form.test.ts
+++ b/e2e/forms/search-form.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+const searchPath = path.resolve("src/components/research/SearchInput.tsx");
+const source = fs.readFileSync(searchPath, "utf8");
+
+describe("search form hardening", () => {
+  it("blocks empty required query submissions", () => {
+    expect(source).toContain("disabled={isSearching || !query.trim()}");
+  });
+
+  it("accepts special characters by forwarding raw query input", () => {
+    expect(source).toContain("onQueryChange(e.target.value)");
+    expect(source).toContain("onSearch();");
+  });
+
+  it("prevents double-submit while searching", () => {
+    expect(source).toContain("disabled={isSearching || !query.trim()}");
+    expect(source).toContain('{isSearching ? "Searching..." : "Search"}');
+  });
+});

--- a/e2e/forms/settings-form.test.ts
+++ b/e2e/forms/settings-form.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+const settingsPath = path.resolve("src/app/(app)/settings/page.tsx");
+const source = fs.readFileSync(settingsPath, "utf8");
+
+describe("settings form hardening", () => {
+  it("handles empty required-ish input via trimmed guard for research interests", () => {
+    expect(source).toContain("const trimmed = interestInput.trim();");
+    expect(source).toContain("if (trimmed && !researchInterests.includes(trimmed))");
+  });
+
+  it("preserves special characters in profile fields by submitting raw values", () => {
+    expect(source).toContain("full_name: profileName");
+    expect(source).toContain("specialty,");
+    expect(source).toContain("country,");
+    expect(source).toContain("bio,");
+  });
+
+  it("prevents double-submit by disabling save controls while request is in-flight", () => {
+    expect(source).toContain("setSaving(true);");
+    expect(source).toContain("setSaving(false);");
+    expect(source).toContain("disabled={saving}");
+  });
+});

--- a/e2e/security/auth-bypass.test.ts
+++ b/e2e/security/auth-bypass.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+function walk(dir: string): string[] {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) files.push(...walk(full));
+    else if (entry.isFile() && entry.name === "route.ts") files.push(full);
+  }
+  return files;
+}
+
+const apiRoot = path.resolve("src/app/api");
+const routeFiles = walk(apiRoot);
+
+const protectedSignals = [/getCurrentUserId\(/, /supabase\.auth\.getUser\(/, /auth\.getUser\(/];
+
+describe("auth bypass protection", () => {
+  it("protected API routes either return explicit 401 or delegate auth to shared helper", () => {
+    const protectedRoutes = routeFiles.filter((file) => {
+      const source = fs.readFileSync(file, "utf8");
+      return protectedSignals.some((p) => p.test(source));
+    });
+
+    expect(protectedRoutes.length).toBeGreaterThan(0);
+
+    const missingAuthDefense = protectedRoutes.filter((file) => {
+      const source = fs.readFileSync(file, "utf8");
+      const has401Path = /\b401\b|status:\s*401|Unauthorized|Authentication required/i.test(source);
+      const delegatesToHelper = /getCurrentUserId\(/.test(source);
+      return !has401Path && !delegatesToHelper;
+    });
+
+    expect(missingAuthDefense, `Protected routes without detectable auth defense:\n${missingAuthDefense.join("\n")}`).toEqual([]);
+  });
+});

--- a/e2e/security/data-exposure.test.ts
+++ b/e2e/security/data-exposure.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+function walkTsx(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walkTsx(full));
+    else if (entry.isFile() && entry.name.endsWith(".tsx")) out.push(full);
+  }
+  return out;
+}
+
+const root = path.resolve("src");
+const tsxFiles = walkTsx(root);
+
+const secretLiteralPattern = /(password|passwd|secret|api[_-]?key|token)\s*[:=]\s*["'`](?!\s*(?:\$\{|\)|\}|\]|,))(?!\s*(?:""|''|``))[^"'`]{6,}["'`]/i;
+const envPattern = /process\.env\.([A-Z0-9_]+)/g;
+
+describe("data exposure safeguards", () => {
+  it("finds no hardcoded password/secret literals in .tsx files", () => {
+    const offenders: string[] = [];
+
+    for (const file of tsxFiles) {
+      const rel = path.relative(process.cwd(), file);
+      const source = fs.readFileSync(file, "utf8");
+      if (secretLiteralPattern.test(source)) offenders.push(rel);
+    }
+
+    expect(offenders, `Possible hardcoded secrets in:\n${offenders.join("\n")}`).toEqual([]);
+  });
+
+  it("uses only NEXT_PUBLIC_ env vars in client components", () => {
+    const offenders: string[] = [];
+
+    for (const file of tsxFiles) {
+      const rel = path.relative(process.cwd(), file);
+      const source = fs.readFileSync(file, "utf8");
+      if (!source.startsWith('"use client"') && !source.startsWith("'use client'")) continue;
+
+      for (const match of source.matchAll(envPattern)) {
+        const key = match[1];
+        if (!key.startsWith("NEXT_PUBLIC_") && key !== "NODE_ENV") {
+          offenders.push(`${rel} -> ${key}`);
+        }
+      }
+    }
+
+    expect(offenders, `Client components using non-public env vars:\n${offenders.join("\n")}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
### Motivation
- Add targeted end-to-end tests to harden form handling (validation, special-character inputs, double-submit prevention) for key UX flows (settings, project creation, search). 
- Add lightweight security scans to detect auth-bypass risks on API routes and to prevent accidental data exposure from client code.

### Description
- Added new form hardening tests under `e2e/forms/`: `settings-form.test.ts`, `project-creation-form.test.ts`, and `search-form.test.ts` that check empty/trimmed guards, acceptance of special characters, and submit de-duplication guards.
- Added security tests under `e2e/security/`: `auth-bypass.test.ts` which scans `src/app/api/**/route.ts` for auth-related signals and ensures either an explicit 401 path or delegation to a shared auth helper, and `data-exposure.test.ts` which scans `.tsx` sources for hardcoded secret-like literals and verifies client components only reference `NEXT_PUBLIC_` env vars (with a `NODE_ENV` allowlist).
- Created the directories `e2e/forms/` and `e2e/security/` and added only new test files (no changes to `qa/`, `qa/module-assertions/`, or `qa/generated/`).

### Testing
- Ran each new test file individually using Vitest with a temporary config: `npx vitest run --config .tmp-vitest-e2e.config.ts e2e/forms/settings-form.test.ts`, `.../project-creation-form.test.ts`, `.../search-form.test.ts`, `.../security/auth-bypass.test.ts`, and `.../security/data-exposure.test.ts`.
- All added tests passed when executed (total: 12 tests passing across the five new test files).
- Tests are file-based inspections (static checks against source files) and executed under the repo's test runtime to validate the presence of the intended guards and patterns.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4c10340e48321b5d984e9a384f829)