### PR TITLE
perf(search): global fan-out deadline + partial results (cap p95 latency tail)

### DIFF
--- a/src/lib/search/__tests__/deadline.test.ts
+++ b/src/lib/search/__tests__/deadline.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { settleWithinDeadline } from "../run-search";
+import type { UnifiedSearchResult } from "@/types/search";
+
+const ok = (source: string) => ({
+  source,
+  results: [] as UnifiedSearchResult[],
+  total: 1,
+  status: { status: "ok" as const },
+});
+
+describe("settleWithinDeadline", () => {
+  it("returns lanes that resolve before the deadline as-is", async () => {
+    const fast = Promise.resolve(ok("pubmed"));
+    const res = await settleWithinDeadline([fast], ["pubmed"], 100);
+    expect(res[0].source).toBe("pubmed");
+    expect(res[0].total).toBe(1);
+    expect(res[0].status.status).toBe("ok");
+  });
+
+  it("drops lanes still pending at the deadline (partial results, labelled timeout)", async () => {
+    const fast = Promise.resolve(ok("pubmed"));
+    const slow = new Promise<ReturnType<typeof ok>>((r) => setTimeout(() => r(ok("openalex")), 300));
+    const res = await settleWithinDeadline([fast, slow], ["pubmed", "openalex"], 50);
+    expect(res[0].source).toBe("pubmed"); // resolved in time
+    // slow lane dropped but labelled + marked degraded (partial-not-empty contract)
+    expect(res[1].source).toBe("openalex");
+    expect(res[1].total).toBe(0);
+    expect(res[1].status.status).toBe("timeout");
+  });
+
+  it("never blocks past the deadline even if all lanes are slow", async () => {
+    const slow = () => new Promise<ReturnType<typeof ok>>((r) => setTimeout(() => r(ok("x")), 1000));
+    const start = Date.now();
+    const res = await settleWithinDeadline([slow(), slow()], ["a", "b"], 40);
+    expect(Date.now() - start).toBeLessThan(400); // returned ~at deadline, not 1000ms
+    expect(res.every((r) => r.status.status === "timeout")).toBe(true);
+  });
+});

--- a/src/lib/search/run-search.ts
+++ b/src/lib/search/run-search.ts
@@ -122,6 +122,54 @@ function withSourceTimeout<T>(
   });
 }
 
+/**
+ * Global fan-out deadline (ms). A single stuck/throttled lane must not hold the
+ * whole query — at the deadline we proceed with whatever lanes have resolved
+ * (partial results), marking the rest as dropped. Caps the p95 tail.
+ */
+export const FANOUT_DEADLINE_MS = 5000;
+
+const DEADLINE = Symbol("fanout-deadline");
+
+/**
+ * Await source lanes up to a global deadline, returning PARTIAL results: lanes
+ * that resolved are used as-is; lanes still pending at the deadline are recorded
+ * as a "timeout" outcome (so they never block the query, and `sourceStatuses`
+ * shows them degraded rather than a false "ok with 0 results"). Each input
+ * promise already resolves to a SourceOutcome (never rejects).
+ */
+export async function settleWithinDeadline(
+  outcomes: Promise<SourceOutcome>[],
+  labels: string[],
+  deadlineMs: number
+): Promise<SourceOutcome[]> {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const deadline = new Promise<typeof DEADLINE>((resolve) => {
+    timer = setTimeout(() => resolve(DEADLINE), deadlineMs);
+  });
+  try {
+    return await Promise.all(
+      outcomes.map(async (p, i) => {
+        const res = await Promise.race([p, deadline]);
+        if (res === DEADLINE) {
+          return {
+            source: labels[i] ?? `lane_${i}`,
+            results: [],
+            total: 0,
+            status: {
+              status: "timeout" as const,
+              message: `dropped: fan-out exceeded ${deadlineMs}ms`,
+            },
+          };
+        }
+        return res;
+      })
+    );
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 const STUDY_TYPE_MAP: Record<string, string> = {
   "Randomized Controlled Trial": "rct",
   systematic_review: "systematic_review",
@@ -277,9 +325,15 @@ async function runLiteratureSearchUncached(
   const pmBroadened = params.pubmedQuery ? null : plan.pubmedBroadened;
 
   const promises: Promise<SourceOutcome>[] = [];
+  const laneLabels: string[] = [];
+  const pushLane = (label: string, p: Promise<SourceOutcome>) => {
+    promises.push(p);
+    laneLabels.push(label);
+  };
 
   if (sources.includes("pubmed")) {
-    promises.push(
+    pushLane(
+      "pubmed",
       withSourceTimeout(
         "PubMed",
         searchPubMedPlanned(
@@ -297,7 +351,8 @@ async function runLiteratureSearchUncached(
   }
 
   if (sources.includes("openalex")) {
-    promises.push(
+    pushLane(
+      "openalex",
       withSourceTimeout(
         "OpenAlex",
         searchOpenAlex(searchQuery, {
@@ -313,7 +368,8 @@ async function runLiteratureSearchUncached(
     // Dense semantic lane (OpenAlex search.semantic) — the corpus-free fix for the
     // lexical recall gap. Retrieves by meaning, surfacing landmarks with no shared
     // surface terms. Fused into the pool before RRF; fails open like any source.
-    promises.push(
+    pushLane(
+      "openalex_semantic",
       withSourceTimeout(
         "OpenAlex Semantic",
         searchOpenAlexSemantic(searchQuery, {
@@ -335,7 +391,8 @@ async function runLiteratureSearchUncached(
   // Semantic Scholar is opt-in only (never required). Used purely as an extra
   // citation/metadata signal when explicitly requested and reachable.
   if (sources.includes("semantic_scholar")) {
-    promises.push(
+    pushLane(
+      "semantic_scholar",
       withSourceTimeout(
         "Semantic Scholar",
         searchSemanticScholar(searchQuery, {
@@ -357,7 +414,8 @@ async function runLiteratureSearchUncached(
 
   // ClinicalTrials.gov linking for trial-acronym / NCT / explicit-trial queries.
   if (plan.wantsTrials) {
-    promises.push(
+    pushLane(
+      "clinical_trials",
       withSourceTimeout(
         "ClinicalTrials",
         searchClinicalTrials(searchQuery, { limit: Math.min(5, perPage) }).then(
@@ -373,7 +431,8 @@ async function runLiteratureSearchUncached(
   // TAVILY_API_KEY. Restricted to trusted biomedical/guideline domains and
   // trust-tiered so it can never out-rank stable primary literature.
   if (plan.wantsWeb && process.env.TAVILY_API_KEY) {
-    promises.push(
+    pushLane(
+      "web",
       withSourceTimeout(
         "Tavily",
         searchTavily(searchQuery, { maxResults: 5, topic: plan.recency ? "news" : "general" }).then(
@@ -383,7 +442,9 @@ async function runLiteratureSearchUncached(
     );
   }
 
-  const sourceResults = await Promise.all(promises);
+  // Await lanes up to a global deadline → partial results (a stuck/throttled lane
+  // never holds the whole query; dropped lanes are marked "timeout", not "ok").
+  const sourceResults = await settleWithinDeadline(promises, laneLabels, FANOUT_DEADLINE_MS);
 
   // Wave 2 (opt-in): neighbour/citation expansion on the top seeds — a corpus-free
   // recall booster that pulls PubMed related-articles (PMRA) of the best wave-1
@@ -433,7 +494,7 @@ async function runLiteratureSearchUncached(
   //  - enrich: OpenAlex citation/PMID/DOI backfill — the S2-independent landmark signal.
   //  - rerank: Cohere cross-encoder relevance score (dominant relevance signal).
   await Promise.all([
-    withSourceTimeout("OpenAlex enrich", enrichCitationsByIds(fused), 9000).catch(() => 0),
+    withSourceTimeout("OpenAlex enrich", enrichCitationsByIds(fused), 3500).catch(() => 0),
     withSourceTimeout("Cohere rerank", attachRerankScores(searchQuery, fused, 50), 4000).catch(
       () => fused
     ),


### PR DESCRIPTION
## What & why
PR-C of the latency work (`docs/literature-search/LATENCY-COUNCIL.md`). After PR-A
(rate limiting) + PR-B (cache), the remaining gap was the **cold-query p95 tail**: a
single stuck/throttled lane could hold the whole query to the 8s per-lane timeout.

## Changes
- **Global fan-out deadline** (`settleWithinDeadline`, 5s): lanes that resolve are
  used as-is; lanes still pending at the deadline are dropped and recorded as
  `timeout` — the **partial-not-empty** contract (never a false "ok with 0 results";
  `sourceStatuses` shows which lane was degraded).
- **Tightened post-fusion enrich cap** (9s→3.5s) so the whole pipeline is bounded.

## Impact
- Caps the p95 tail — a stuck lane no longer hangs the query; you get partial
  results from the lanes that finished.
- Cascade-to-empty is now **doubly guarded**: PR-A's outbound rate limiting prevents
  the self-inflicted 429s, and this returns partial results if a lane is dropped.
- **Normal queries unaffected** (validated: DAPA-HF/lecanemab recall 100% ~4s; TAVR
  ~6.5s) — the deadline truncates only the tail, never normal lanes.

## Testing
- `settleWithinDeadline` unit-tested (resolved-as-is / dropped-as-timeout / never-blocks-past-deadline); tsc + `eslint --max-warnings 0` clean; full search/mcp suite (235) passes.

## Follow-ups (PR-D)
- Error-rate circuit breaker + bulkhead (cockatiel) — app-wide; PR-A's rate limiting
  + this deadline already de-risk the cascade.
- **Streaming results** (NDJSON/SSE) — return fast lanes <1s, fill the rest async —
  the lever for cold-query *perceived* p50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added tests for deadline handling behavior in search operations

* **Refactor**
  * Implemented global deadline enforcement for search sources to prevent indefinite blocking and ensure queries complete in a timely manner
  * Adjusted external service timeout values to improve overall search responsiveness
  * Searches now return partial results from available sources when deadlines are reached rather than waiting for all sources to complete

<!-- end of auto-generated comment: release notes by coderabbit.ai -->