### PR TITLE
test(eval): reproducible harness — freeze candidate pool, rerank offline

### DIFF
--- a/docs/literature-search/REPRODUCIBLE-HARNESS.md
+++ b/docs/literature-search/REPRODUCIBLE-HARNESS.md
@@ -1,0 +1,47 @@
+# Reproducible eval harness (candidate freeze → offline rerank)
+
+## Why
+The live eval (`run.ts`) hits PubMed/OpenAlex/Cohere, so two runs differ even on
+queries a change never touches. Cycle 3 proved this is not academic: a full run
+showed an **8-point aggregate "regression"** that fully recovered on re-run with
+identical code — transient upstream throttling, not a real change. Comparing two
+live runs is therefore an **unsound** basis for per-cycle keep/revert.
+
+## How
+Split retrieval from ranking so the noisy half runs ONCE and the deterministic half
+is replayable:
+
+1. **`run-search.ts`** gains an eval-only `includeRawCandidates` flag → returns the
+   post-enrichment/rerank candidate POOL (`rawCandidates`) before final ranking. The
+   live web/MCP path never sets it (zero overhead, untouched behavior).
+2. **`capture-candidates.ts`** freezes each query's pool once →
+   `runs/<label>/candidates/<id>.json`.
+3. **`rerank-offline.ts`** replays `rankAndAnnotate` (a pure function) over the frozen
+   pools — NO network — computing the same deterministic metrics.
+
+Verified: re-running `rerank-offline` twice produces byte-identical rankings.
+
+## Paired A/B (isolates a ranking change from all noise)
+```bash
+git stash                                                   # park the ranking change
+op-run -- npx tsx eval/literature-search/capture-candidates.ts --label pool   # freeze once
+npx tsx eval/literature-search/rerank-offline.ts --pool pool --label before
+git stash pop                                               # restore the change
+npx tsx eval/literature-search/rerank-offline.ts --pool pool --label after
+# delta between rerank-before.json and rerank-after.json is 100% attributable to
+# the ranking change — same frozen candidates, no retrieval/throttling noise.
+```
+
+## Scope & limits
+- **Ranking-stage cycles** (entity-drift, trial-primary, future rerank/quality
+  changes) are now cleanly measurable and councils can be paired on a fixed pool.
+- **Retrieval-stage changes** (query-planner, source fan-out, the empty-relaxation
+  fix) change WHICH candidates are retrieved, so they require a fresh capture — the
+  frozen pool reflects the retrieval code at capture time.
+- Pools live under gitignored `runs/`; re-capture as needed. The capture still has
+  one-time live-retrieval noise, so capture during a healthy window (no 429 storm).
+
+## Use going forward
+Every ranking cycle: freeze a pool once on current `main`, then A/B before/after the
+change offline. Reserve live `run.ts` + blinded council for the cross-engine
+(Manan-vs-Elicit) verdict, not for measuring small intra-Manan ranking deltas.

--- a/eval/literature-search/capture-candidates.ts
+++ b/eval/literature-search/capture-candidates.ts
@@ -1,0 +1,95 @@
+/**
+ * Freeze the upstream candidate POOL per benchmark query, ONCE, so ranking-stage
+ * changes can be evaluated deterministically (offline, no network) and councils
+ * can be PAIRED (old ranker vs new ranker on the identical pool).
+ *
+ * Why this exists: the live eval (`run.ts`) hits PubMed/OpenAlex/Cohere, so two
+ * runs differ even on queries a code change never touches (transient throttling,
+ * pool drift). That makes per-cycle keep/revert on the aggregate unsound (a
+ * cycle-3 run showed ±8pt phantom swings that recovered on re-run). Capturing the
+ * enriched pre-ranking pool removes the retrieval noise for ranking cycles.
+ *
+ * Usage:
+ *   op-run -- npx tsx eval/literature-search/capture-candidates.ts --label pool-A
+ *   op-run -- npx tsx eval/literature-search/capture-candidates.ts --label pool-A --only acronym-sprint,broad-hfref-management
+ *   → writes eval/literature-search/runs/<label>/candidates/<id>.json
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { BENCHMARK_QUERIES } from "./queries";
+import { runLiteratureSearch } from "@/lib/search/run-search";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+function loadEnv(): void {
+  for (const f of [".env.local", ".env"]) {
+    try {
+      (process as unknown as { loadEnvFile: (p: string) => void }).loadEnvFile(
+        join(process.cwd(), f)
+      );
+    } catch {
+      /* env file absent — providers fall back to keyless/public access */
+    }
+  }
+}
+
+function parseArgs(argv: string[]): { label: string; only?: string[] } {
+  let label = "pool";
+  let only: string[] | undefined;
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--label") label = argv[++i];
+    else if (argv[i] === "--only") only = argv[++i].split(",").map((s) => s.trim());
+  }
+  return { label, only };
+}
+
+async function main() {
+  loadEnv();
+  const { label, only } = parseArgs(process.argv.slice(2));
+  const selected = only
+    ? BENCHMARK_QUERIES.filter((q) => only.includes(q.id))
+    : BENCHMARK_QUERIES;
+  if (selected.length === 0) {
+    console.error("No queries selected. Check --only ids.");
+    process.exit(1);
+  }
+
+  const outDir = join(HERE, "runs", label, "candidates");
+  mkdirSync(outDir, { recursive: true });
+  console.log(`[capture] label=${label} queries=${selected.length}`);
+
+  let ok = 0;
+  for (const q of selected) {
+    try {
+      const res = await runLiteratureSearch({
+        query: q.query,
+        perPage: 10,
+        includeRawCandidates: true,
+      });
+      const candidates = res.rawCandidates ?? [];
+      writeFileSync(
+        join(outDir, `${q.id}.json`),
+        JSON.stringify(
+          { id: q.id, query: q.query, recency: res.plan.recency, candidates },
+          null,
+          2
+        )
+      );
+      ok++;
+      const zero = candidates.length === 0 ? " [EMPTY POOL]" : "";
+      console.log(`  ✓ ${q.id.padEnd(34)} pool=${String(candidates.length).padStart(3)}${zero}`);
+    } catch (e) {
+      console.log(`  ✗ ${q.id.padEnd(34)} ${e instanceof Error ? e.message : e}`);
+    }
+    await sleep(700); // be gentle on keyless PubMed (3 req/s)
+  }
+  console.log(`\n[capture] froze ${ok}/${selected.length} pools → ${outDir}`);
+}
+
+main().catch((err) => {
+  console.error("[capture] fatal:", err);
+  process.exit(1);
+});

--- a/eval/literature-search/rerank-offline.ts
+++ b/eval/literature-search/rerank-offline.ts
@@ -1,0 +1,105 @@
+/**
+ * DETERMINISTIC offline rerank over a frozen candidate pool (see
+ * capture-candidates.ts). Loads the cached pools and applies the CURRENT ranking
+ * code (`rankAndAnnotate`, a pure function) — NO network — so a ranking-stage
+ * change can be A/B-ed on the identical pool without live-retrieval noise.
+ *
+ * Paired A/B (old ranker vs new ranker on the same pool):
+ *   git stash                 # park the ranking change
+ *   op-run -- npx tsx eval/literature-search/capture-candidates.ts --label pool   # freeze once
+ *   npx tsx eval/literature-search/rerank-offline.ts --pool pool --label before
+ *   git stash pop             # restore the ranking change
+ *   npx tsx eval/literature-search/rerank-offline.ts --pool pool --label after
+ *   # compare runs/<pool>/rerank-before.json vs rerank-after.json — any delta is
+ *   # 100% attributable to the ranking change (same frozen candidates).
+ *
+ * Usage:
+ *   npx tsx eval/literature-search/rerank-offline.ts --pool pool-A [--label after]
+ *   → writes eval/literature-search/runs/<pool>/rerank-<label>.{json,md}
+ */
+
+import { readFileSync, writeFileSync, readdirSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { BENCHMARK_QUERIES } from "./queries";
+import { planQuery } from "@/lib/search/query-planner";
+import { rankAndAnnotate } from "@/lib/search/pipeline";
+import { computeQueryMetrics } from "@/lib/search/eval/metrics";
+import type { UnifiedSearchResult } from "@/types/search";
+import { buildSummaryMd, buildSummaryJson, type QueryRun } from "./report";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const byId = new Map(BENCHMARK_QUERIES.map((q) => [q.id, q]));
+
+function parseArgs(argv: string[]): { pool: string; label: string } {
+  let pool = "pool";
+  let label = "rerank";
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--pool") pool = argv[++i];
+    else if (argv[i] === "--label") label = argv[++i];
+  }
+  return { pool, label };
+}
+
+function toEvalItems(results: UnifiedSearchResult[]) {
+  return results.map((r) => ({
+    title: String(r.title ?? ""),
+    doi: r.doi || undefined,
+    pmid: r.pmid || undefined,
+    year: typeof r.year === "number" ? r.year : undefined,
+    journal: r.journal || undefined,
+    studyType: r.studyType || undefined,
+    abstract: r.abstract || undefined,
+  }));
+}
+
+function main() {
+  const { pool, label } = parseArgs(process.argv.slice(2));
+  const dir = join(HERE, "runs", pool, "candidates");
+  if (!existsSync(dir)) {
+    console.error(`No frozen pools at ${dir}. Run capture-candidates.ts --label ${pool} first.`);
+    process.exit(1);
+  }
+  const files = readdirSync(dir).filter((f) => f.endsWith(".json"));
+  const runs: QueryRun[] = [];
+
+  for (const f of files) {
+    const cached = JSON.parse(readFileSync(join(dir, f), "utf8")) as {
+      id: string;
+      query: string;
+      recency: boolean;
+      candidates: UnifiedSearchResult[];
+    };
+    const bq = byId.get(cached.id);
+    if (!bq) continue;
+    const plan = planQuery(cached.query);
+    // Re-rank the FROZEN pool with the current code (deterministic).
+    const ranked = rankAndAnnotate(cached.candidates, {
+      query: cached.query,
+      recency: plan.recency,
+      isTrialLookup: plan.isTrialLookup,
+    });
+    const items = toEvalItems(ranked.slice(0, 10));
+    runs.push({
+      id: cached.id,
+      query: cached.query,
+      category: bq.category,
+      latencyMs: 0,
+      sourceCounts: {},
+      zeroSources: [],
+      results: items,
+      metrics: computeQueryMetrics(items, { mustHaves: bq.mustHaves, query: cached.query }),
+    });
+  }
+
+  runs.sort((a, b) => a.id.localeCompare(b.id));
+  const outDir = join(HERE, "runs", pool);
+  writeFileSync(
+    join(outDir, `rerank-${label}.json`),
+    JSON.stringify(buildSummaryJson(`${pool}:${label}`, runs, "offline"), null, 2)
+  );
+  writeFileSync(join(outDir, `rerank-${label}.md`), buildSummaryMd(`${pool}:${label}`, runs));
+  console.log(`[rerank-offline] pool=${pool} label=${label} queries=${runs.length} → ${outDir}/rerank-${label}.{json,md}`);
+}
+
+main();

--- a/src/lib/search/run-search.ts
+++ b/src/lib/search/run-search.ts
@@ -72,6 +72,12 @@ export interface RunLiteratureSearchParams {
    * fast — the OpenAlex dense semantic lane already provides corpus-free recall.
    */
   expandCitations?: boolean;
+  /**
+   * Eval-only: also return the post-enrichment/rerank candidate POOL (pre-final-
+   * ranking), so the offline harness can freeze it and re-rank deterministically.
+   * Off by default; never set on the live web/MCP path.
+   */
+  includeRawCandidates?: boolean;
 }
 
 export type LiteraturePaper = UnifiedSearchResult & {
@@ -102,6 +108,12 @@ export interface LiteratureSearchResult {
     trialAcronyms: string[];
     wantsTrials: boolean;
   };
+  /**
+   * Eval-only: the frozen post-enrichment/rerank candidate pool (present only when
+   * `includeRawCandidates` was set). Lets the offline harness re-rank a fixed pool
+   * deterministically, isolating ranking changes from live-retrieval noise.
+   */
+  rawCandidates?: UnifiedSearchResult[];
 }
 
 function withSourceTimeout<T>(
@@ -516,6 +528,12 @@ async function runLiteratureSearchUncached(
     ),
   ]);
 
+  // Eval-only: snapshot the enriched candidate pool BEFORE final ranking, so the
+  // offline harness can re-rank this exact pool deterministically.
+  const rawCandidates = params.includeRawCandidates
+    ? fused.map((r) => ({ ...r }))
+    : undefined;
+
   // Rank by clinical quality (relevance[rerank] + evidence hierarchy + citations
   // + velocity + journal) and annotate with a trace, flags, and "why relevant".
   const ranked = rankAndAnnotate(fused, {
@@ -560,6 +578,7 @@ async function runLiteratureSearchUncached(
       trialAcronyms: plan.trialAcronyms,
       wantsTrials: plan.wantsTrials,
     },
+    ...(rawCandidates ? { rawCandidates } : {}),
   };
 }
 


### PR DESCRIPTION
## What
Splits the eval into a noisy half (live retrieval, run once) and a deterministic half (ranking, replayable), so ranking-stage cycles can be A/B-ed with **zero retrieval/throttling noise**.

- `run-search`: eval-only `includeRawCandidates` returns the post-enrich/rerank candidate pool; live web/MCP path untouched (default off).
- `capture-candidates.ts`: freeze each query's pool once.
- `rerank-offline.ts`: replay `rankAndAnnotate` (pure) over frozen pools, no network.

## Why
Cycle 3 proved two live runs differ by ±8pt on the aggregate from transient throttling (every "regressed" query recovered on re-run with identical code). Comparing live runs is an unsound basis for per-cycle keep/revert.

## Verified
Re-running `rerank-offline` twice → byte-identical rankings. Enables PAIRED A/B (`git stash` old vs new ranker on the same frozen pool). See `REPRODUCIBLE-HARNESS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)