### PR TITLE
feat(search): demote off-outcome (adverse-event) drift in ranking

### DIFF
--- a/docs/literature-search/CYCLE-06-OUTCOME-DRIFT.md
+++ b/docs/literature-search/CYCLE-06-OUTCOME-DRIFT.md
@@ -1,0 +1,35 @@
+# Cycle 6 — Off-outcome (adverse-event) drift demotion
+
+## Lacuna (frozen-pool inspection)
+For an adverse-event safety query the top results were EFFICACY meta-analyses about a
+DIFFERENT outcome. `safety-glp1-pancreatitis` ("GLP-1 RAs and risk of acute
+**pancreatitis**") returned "Cardiovascular, mortality, and kidney **outcomes** with
+GLP-1 RAs" at ranks 1–2 (the actual pancreatitis papers sat at 3/5/6/8/9). The
+cross-encoder rates them as topically similar; they share the drug class.
+
+## Change (ONE coherent, TDD) — extends entity-drift
+New `outcomeDriftPenalty` composed into `entityDriftPenalty`: when the QUERY names a
+specific adverse outcome (pancreatitis, ketoacidosis, myocarditis, aneurysm,
+thrombosis, fracture, hemorrhage, malignancy, …) and a result's title is about an
+EFFICACY outcome (cardiovascular/kidney/renal outcomes, all-cause mortality, HbA1c,
+weight loss, HF hospitalization) WITHOUT mentioning the queried adverse event → gentle
+×0.8 demotion. **Gated on the query naming an adverse outcome** — so an efficacy/PICO
+query that genuinely wants those outcomes is never penalized. 4 new unit tests
+(incl. the PICO counter-example).
+
+## Result (keep) — DETERMINISTIC frozen-pool A/B
+On-outcome rate in the top-5 (result title mentions the queried adverse event):
+| query | before → after |
+|---|---|
+| safety-glp1-pancreatitis | 2/5 → **4/5** |
+| safety-sglt2-dka | 3/5 → **4/5** |
+| safety-fluoroquinolone-aneurysm | 4/5 → 4/5 (already on-outcome) |
+| safety-vaccine-myocarditis | 5/5 → 5/5 (already on-outcome) |
+| **pico-sglt2-cv-mortality** (efficacy) | **unchanged** ✓ — gating protects it |
+
+**2 improved, 0 regressions; the efficacy/PICO query is provably untouched.** 264
+search tests green; tsc clean. Targets the `safety-glp1-pancreatitis` council loss
+(baseline Manan 3.44 vs Elicit 4.39).
+
+**Decision: KEEP.** Bounded, table-driven, gated on adverse-outcome queries, and
+deterministically shown to raise on-outcome ranking with no efficacy-query regression.

--- a/src/lib/search/__tests__/entity-drift.test.ts
+++ b/src/lib/search/__tests__/entity-drift.test.ts
@@ -98,6 +98,42 @@ describe("entityDriftPenalty — off-specific-drug mismatch", () => {
   });
 });
 
+describe("entityDriftPenalty — off-outcome (adverse-event) drift", () => {
+  const PANC_Q = "GLP-1 receptor agonists and risk of acute pancreatitis";
+
+  it("demotes an efficacy-outcome MA for an adverse-event query", () => {
+    expect(
+      entityDriftPenalty(PANC_Q, {
+        title: "Cardiovascular, mortality, and kidney outcomes with GLP-1 receptor agonists",
+      })
+    ).toBeLessThan(1);
+  });
+
+  it("does NOT demote a result that covers the queried adverse outcome", () => {
+    expect(
+      entityDriftPenalty(PANC_Q, {
+        title: "GLP-1 receptor agonists and risk of acute pancreatitis: a meta-analysis",
+      })
+    ).toBe(1);
+  });
+
+  it("does NOT fire for an efficacy/PICO query that genuinely wants those outcomes", () => {
+    // The query is ABOUT cardiovascular mortality — efficacy results must NOT be demoted.
+    const q = "In adults with type 2 diabetes, do SGLT2 inhibitors reduce cardiovascular mortality?";
+    expect(
+      entityDriftPenalty(q, { title: "SGLT2 inhibitors and cardiovascular mortality outcomes" })
+    ).toBe(1);
+  });
+
+  it("fires for a ketoacidosis safety query", () => {
+    expect(
+      entityDriftPenalty("SGLT2 inhibitors and risk of diabetic ketoacidosis", {
+        title: "Cardiovascular and renal outcomes with SGLT2 inhibitors: a meta-analysis",
+      })
+    ).toBeLessThan(1);
+  });
+});
+
 describe("entityDriftPenalty — safety and bounds", () => {
   it("returns 1 for an unrelated query/result pair", () => {
     expect(

--- a/src/lib/search/entity-drift.ts
+++ b/src/lib/search/entity-drift.ts
@@ -112,6 +112,28 @@ const DRUG_CLASSES: DrugClass[] = [
 
 const COMPARISON_RE = /\b(versus|vs\.?|compared (?:to|with)|head[- ]to[- ]head)\b/i;
 
+// Specific adverse-event outcomes. When the QUERY asks about one of these, a result
+// about a DIFFERENT (efficacy) outcome that never mentions the adverse event is
+// off-outcome drift (e.g. a "cardiovascular outcomes" MA for a "pancreatitis" query).
+const ADVERSE_OUTCOME_RE =
+  /\b(pancreatitis|pancreatic cancer|ketoacidosis|\bdka\b|myocarditis|pericarditis|aneurysm|dissection|amputation|fractures?|thrombo(?:sis|embolism)?|embolism|h[ae]morrhage|bleeding|malignanc(?:y|ies)|carcinoma|gangrene|rhabdomyolysis|angioedema|hypoglyc[ae]mia|retinopathy|nephrolithiasis|cholelithiasis|gallstones?)\b/i;
+
+// Efficacy / different-outcome markers in a RESULT title — the "wrong answer" shape
+// for an adverse-event query. Phrased as outcome clauses to avoid over-matching.
+const EFFICACY_OUTCOME_RE =
+  /\b(cardiovascular (?:outcomes?|disease|death|mortality|events?)|all-cause mortality|kidney (?:outcomes?|disease)|renal outcomes?|glyc[ae]mic (?:control|outcomes?)|hba1c|weight (?:loss|reduction)|heart failure hospitali[sz]ation|major adverse cardiovascular)\b/i;
+
+/** Demote a result about a different (efficacy) outcome than the adverse event the
+ *  query asks about. Returns 1 unless the query is adverse-event-specific AND the
+ *  result is off-outcome (efficacy markers, no coverage of the queried event). */
+function outcomeDriftPenalty(query: string, title: string): number {
+  const adverse = query.match(ADVERSE_OUTCOME_RE);
+  if (!adverse) return 1; // not an adverse-event query — never fire (protects PICO/efficacy queries)
+  // Coverage: the result mentions the SAME adverse outcome → not drift.
+  if (new RegExp(`\\b${adverse[0]}`, "i").test(title)) return 1;
+  return EFFICACY_OUTCOME_RE.test(title) ? OFFDRUG_PENALTY : 1;
+}
+
 /** Penalty when a result is about a different subtype than the query specifies. */
 export const CONTRAST_PENALTY = 0.65;
 /** Penalty when a result is about a different specific drug than the query names. */
@@ -157,6 +179,7 @@ export function entityDriftPenalty(
   const title = (result.title ?? "").toLowerCase();
   if (!title.trim()) return 1;
   const q = query.toLowerCase();
-  const factor = contrastPenalty(q, title) * offDrugPenalty(q, title);
+  const factor =
+    contrastPenalty(q, title) * offDrugPenalty(q, title) * outcomeDriftPenalty(q, title);
   return Math.min(1, Math.max(0.01, factor));
 }


### PR DESCRIPTION
## What (Cycle 6 — extends entity-drift)
For an adverse-event safety query the cross-encoder floats efficacy MAs about a different outcome to the top (e.g. "Cardiovascular, mortality, and kidney outcomes with GLP-1 RAs" for a "risk of acute pancreatitis" query). New `outcomeDriftPenalty`: when the query names a specific adverse outcome (pancreatitis, ketoacidosis, myocarditis, aneurysm, …) and a result is about an efficacy outcome without the queried event → ×0.8 demotion. **Gated on the query naming an adverse outcome**, so efficacy/PICO queries are never penalized.

## Result — deterministic frozen-pool A/B
On-outcome rate in top-5:
- `safety-glp1-pancreatitis` 2/5 → **4/5**
- `safety-sglt2-dka` 3/5 → **4/5**
- `pico-sglt2-cv-mortality` (efficacy) **unchanged** ✓ — gating protects it
- **2 improved, 0 regressions.**

4 new unit tests (incl. the PICO counter-example); 264 search tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)