### PR TITLE
feat(eval): content-addressed candidate cache for $0 deterministic 87q reruns

### DIFF
--- a/docs/literature-search/REPRODUCIBLE-HARNESS.md
+++ b/docs/literature-search/REPRODUCIBLE-HARNESS.md
@@ -21,6 +21,27 @@ is replayable:
 
 Verified: re-running `rerank-offline` twice produces byte-identical rankings.
 
+## One-command cached eval (`eval:search:cached`)
+The capture → rerank dance above is now also available as a single transparent
+command backed by a **content-addressed local cache**
+(`eval/literature-search/.cache/candidates/`, gitignored):
+
+```bash
+op-run -- npm run eval:search:cached -- --label after     # first run: captures pools live ONCE, persists, scores
+npm run eval:search:cached -- --label after               # every repeat: $0, no network, deterministic
+npm run eval:search:cached -- --label after --only exact-dapa-hf,acronym-partner-3
+op-run -- npm run eval:search:cached -- --label fresh --refresh   # force a live re-capture
+```
+
+Each query's pool is keyed by `sha1(normalized-query + sources + year-window)` so
+the cache is shared across labels and runs — capture once, replay forever (TTL 30d,
+`--refresh` to override). The first run spends the API/GPU and fills the cache; every
+subsequent run reads JSON, re-applies the CURRENT `rankAndAnnotate`, and re-scores —
+identical pools, so any metric delta is 100% attributable to the ranking change. This
+is the default measurement loop for ranking work (it "pays for itself" after run one).
+The cache logic (`candidate-cache.ts`) is unit-tested (key stability, TTL, hit/miss/
+stale/refresh) so the seam itself is trustworthy.
+
 ## Paired A/B (isolates a ranking change from all noise)
 ```bash
 git stash                                                   # park the ranking change

--- a/eval/literature-search/.gitignore
+++ b/eval/literature-search/.gitignore
@@ -1,4 +1,7 @@
 # Generated eval output (reproducible via `npm run eval:search`).
 runs/
+# Local candidate-pool cache (content-addressed; re-captured on demand). Lets
+# `eval:search:cached` replay the 87q deterministically without re-spending API/GPU.
+.cache/
 # Raw judge transcripts (the parsed *.json verdicts ARE committed).
 council/raw-*.txt

--- a/eval/literature-search/__tests__/candidate-cache.test.ts
+++ b/eval/literature-search/__tests__/candidate-cache.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, existsSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { UnifiedSearchResult } from "@/types/search";
+import {
+  poolCacheKey,
+  isFresh,
+  cachePath,
+  readPool,
+  writePool,
+  loadOrCapturePool,
+  type CachedPool,
+} from "../candidate-cache";
+
+function paper(title: string): UnifiedSearchResult {
+  return { title, authors: [], journal: "", year: 2024, sources: ["pubmed"] } as unknown as UnifiedSearchResult;
+}
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "cand-cache-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("poolCacheKey — stable & content-addressed", () => {
+  it("is deterministic for the same query", () => {
+    expect(poolCacheKey({ query: "SGLT2 in heart failure" })).toBe(
+      poolCacheKey({ query: "SGLT2 in heart failure" })
+    );
+  });
+
+  it("normalizes whitespace and case so trivially-different phrasings share a key", () => {
+    expect(poolCacheKey({ query: "  SGLT2   in Heart Failure " })).toBe(
+      poolCacheKey({ query: "sglt2 in heart failure" })
+    );
+  });
+
+  it("changes when retrieval-affecting params change (year window, sources)", () => {
+    const base = poolCacheKey({ query: "q" });
+    expect(poolCacheKey({ query: "q", yearFrom: 2020 })).not.toBe(base);
+    expect(poolCacheKey({ query: "q", sources: ["pubmed", "openalex"] })).not.toBe(base);
+    // source order must not matter
+    expect(poolCacheKey({ query: "q", sources: ["openalex", "pubmed"] })).toBe(
+      poolCacheKey({ query: "q", sources: ["pubmed", "openalex"] })
+    );
+  });
+});
+
+describe("isFresh — TTL boundary", () => {
+  const now = new Date("2026-06-27T12:00:00Z");
+  it("is fresh within the TTL window", () => {
+    expect(isFresh({ capturedAt: "2026-06-26T12:00:00Z" }, 7, now)).toBe(true);
+  });
+  it("is stale past the TTL window", () => {
+    expect(isFresh({ capturedAt: "2026-06-01T12:00:00Z" }, 7, now)).toBe(false);
+  });
+  it("treats a malformed or future timestamp as not fresh", () => {
+    expect(isFresh({ capturedAt: "not-a-date" }, 7, now)).toBe(false);
+    expect(isFresh({ capturedAt: "2099-01-01T00:00:00Z" }, 7, now)).toBe(false);
+  });
+});
+
+describe("readPool / writePool — round-trip", () => {
+  it("writes by key and reads it back", () => {
+    const entry: CachedPool = {
+      id: "q1",
+      query: "q one",
+      key: poolCacheKey({ query: "q one" }),
+      capturedAt: "2026-06-27T00:00:00Z",
+      recency: false,
+      candidates: [paper("A"), paper("B")],
+    };
+    writePool(dir, entry);
+    expect(existsSync(cachePath(dir, entry.key))).toBe(true);
+    const back = readPool(dir, entry.key);
+    expect(back?.candidates.map((c) => c.title)).toEqual(["A", "B"]);
+  });
+
+  it("returns null for a missing key and for corrupt JSON", () => {
+    expect(readPool(dir, "deadbeef")).toBeNull();
+    const key = "corrupt0000000000";
+    writeFileSync(cachePath(dir, key), "{ not json");
+    expect(readPool(dir, key)).toBeNull();
+  });
+});
+
+describe("loadOrCapturePool — the cache that stops re-spending", () => {
+  const now = () => new Date("2026-06-27T12:00:00Z");
+
+  it("MISS: calls capture once, persists, returns fromCache=false", async () => {
+    const capture = vi.fn(async () => ({ candidates: [paper("A")], recency: false }));
+    const { entry, fromCache } = await loadOrCapturePool(
+      "q1",
+      { query: "dapagliflozin heart failure" },
+      { dir, ttlDays: 7, now, capture }
+    );
+    expect(fromCache).toBe(false);
+    expect(capture).toHaveBeenCalledTimes(1);
+    expect(entry.candidates.map((c) => c.title)).toEqual(["A"]);
+    expect(readPool(dir, poolCacheKey({ query: "dapagliflozin heart failure" }))).not.toBeNull();
+  });
+
+  it("HIT: a fresh cached pool is served WITHOUT calling capture (no re-spend)", async () => {
+    const capture = vi.fn(async () => ({ candidates: [paper("A")], recency: false }));
+    const params = { query: "same query" };
+    await loadOrCapturePool("q1", params, { dir, ttlDays: 7, now, capture });
+    const second = await loadOrCapturePool("q1", params, { dir, ttlDays: 7, now, capture });
+    expect(second.fromCache).toBe(true);
+    expect(capture).toHaveBeenCalledTimes(1); // still 1 — the repeat eval spent nothing
+  });
+
+  it("STALE: re-captures when the cached pool is older than the TTL", async () => {
+    const params = { query: "stale query" };
+    const key = poolCacheKey(params);
+    writePool(dir, {
+      id: "q1",
+      query: params.query,
+      key,
+      capturedAt: "2026-01-01T00:00:00Z",
+      recency: false,
+      candidates: [paper("OLD")],
+    });
+    const capture = vi.fn(async () => ({ candidates: [paper("NEW")], recency: false }));
+    const { entry, fromCache } = await loadOrCapturePool("q1", params, {
+      dir,
+      ttlDays: 7,
+      now,
+      capture,
+    });
+    expect(fromCache).toBe(false);
+    expect(capture).toHaveBeenCalledTimes(1);
+    expect(entry.candidates.map((c) => c.title)).toEqual(["NEW"]);
+  });
+
+  it("REFRESH: bypasses a fresh entry when refresh=true", async () => {
+    const params = { query: "force refresh" };
+    await loadOrCapturePool("q1", params, {
+      dir,
+      ttlDays: 7,
+      now,
+      capture: async () => ({ candidates: [paper("A")], recency: false }),
+    });
+    const capture = vi.fn(async () => ({ candidates: [paper("B")], recency: false }));
+    const { entry, fromCache } = await loadOrCapturePool("q1", params, {
+      dir,
+      ttlDays: 7,
+      now,
+      capture,
+      refresh: true,
+    });
+    expect(fromCache).toBe(false);
+    expect(capture).toHaveBeenCalledTimes(1);
+    expect(entry.candidates.map((c) => c.title)).toEqual(["B"]);
+  });
+});

--- a/eval/literature-search/candidate-cache.ts
+++ b/eval/literature-search/candidate-cache.ts
@@ -1,0 +1,131 @@
+/**
+ * Content-addressed candidate cache for the literature-search eval harness.
+ *
+ * Why this exists: a full 87q eval fans out to PubMed / OpenAlex / the MedCPT
+ * dense lane (GPU) for EVERY query, every run. Re-running an eval to measure a
+ * pure ranking change therefore re-spends API quota + GPU minutes AND reintroduces
+ * live-retrieval noise (throttle, pool drift) that makes per-cycle keep/revert
+ * unsound. This module freezes the post-enrichment candidate POOL to local JSON,
+ * keyed by the retrieval-affecting inputs (query + sources + year window), so the
+ * FIRST run spends once and every repeat run is $0 and deterministic — the ranking
+ * stage (the only thing under test) re-runs against the identical frozen pool.
+ *
+ * Pure, dependency-injected (`capture`, `now`, `dir`) so the cache logic is unit
+ * tested without touching the network. The harness wires it to the real search.
+ */
+
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { UnifiedSearchResult } from "@/types/search";
+
+/** A frozen candidate pool for one benchmark query. */
+export interface CachedPool {
+  id: string;
+  query: string;
+  /** Content key (see {@link poolCacheKey}). */
+  key: string;
+  /** ISO timestamp of capture; drives {@link isFresh}. */
+  capturedAt: string;
+  /** The recency plan flag at capture time (date- vs relevance-sorted retrieval). */
+  recency: boolean;
+  candidates: UnifiedSearchResult[];
+}
+
+/** The inputs that change WHICH papers are retrieved — and so the cache key. */
+export interface PoolKeyParams {
+  query: string;
+  sources?: string[];
+  yearFrom?: number;
+  yearTo?: number;
+}
+
+/**
+ * Stable, content-addressed key for a candidate pool. Normalizes the query
+ * (trim + lowercase + collapse whitespace) so trivially-different phrasings of the
+ * SAME search share a cache entry, and sorts `sources` so lane order never forks
+ * the key. The year window forks the key (it changes retrieval). 16 hex chars of
+ * SHA-1 — collision-free at benchmark scale and filesystem-friendly.
+ */
+export function poolCacheKey(params: PoolKeyParams): string {
+  const normalized = {
+    query: params.query.trim().toLowerCase().replace(/\s+/g, " "),
+    sources: params.sources ? [...params.sources].sort() : null,
+    yearFrom: params.yearFrom ?? null,
+    yearTo: params.yearTo ?? null,
+  };
+  return createHash("sha1").update(JSON.stringify(normalized)).digest("hex").slice(0, 16);
+}
+
+/** True when a cached entry was captured within the last `ttlDays` (and not in the future). */
+export function isFresh(entry: { capturedAt: string }, ttlDays: number, now: Date): boolean {
+  const captured = Date.parse(entry.capturedAt);
+  if (Number.isNaN(captured)) return false;
+  const ageMs = now.getTime() - captured;
+  return ageMs >= 0 && ageMs <= ttlDays * 24 * 60 * 60 * 1000;
+}
+
+export function cachePath(dir: string, key: string): string {
+  return join(dir, `${key}.json`);
+}
+
+/** Read a cached pool by key. Returns null on miss or unparseable file (never throws). */
+export function readPool(dir: string, key: string): CachedPool | null {
+  const path = cachePath(dir, key);
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as CachedPool;
+  } catch {
+    return null;
+  }
+}
+
+export function writePool(dir: string, entry: CachedPool): void {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(cachePath(dir, entry.key), JSON.stringify(entry, null, 2));
+}
+
+/** Fetches a fresh candidate pool from the live search (the expensive path). */
+export type CaptureFn = (
+  params: PoolKeyParams
+) => Promise<{ candidates: UnifiedSearchResult[]; recency: boolean }>;
+
+export interface LoadOrCaptureDeps {
+  dir: string;
+  ttlDays: number;
+  now: () => Date;
+  capture: CaptureFn;
+  /** Force a live re-capture even when a fresh entry exists. */
+  refresh?: boolean;
+}
+
+/**
+ * Return the frozen candidate pool for a query: serve a fresh cache entry without
+ * spending anything (`fromCache: true`), otherwise call `capture` once, persist
+ * the result, and return it (`fromCache: false`). The single seam that turns a
+ * "re-spend every run" harness into a "spend once, replay free" one.
+ */
+export async function loadOrCapturePool(
+  id: string,
+  params: PoolKeyParams,
+  deps: LoadOrCaptureDeps
+): Promise<{ entry: CachedPool; fromCache: boolean }> {
+  const key = poolCacheKey(params);
+  if (!deps.refresh) {
+    const existing = readPool(deps.dir, key);
+    if (existing && isFresh(existing, deps.ttlDays, deps.now())) {
+      return { entry: existing, fromCache: true };
+    }
+  }
+  const fetched = await deps.capture(params);
+  const entry: CachedPool = {
+    id,
+    query: params.query,
+    key,
+    capturedAt: deps.now().toISOString(),
+    recency: fetched.recency,
+    candidates: fetched.candidates,
+  };
+  writePool(deps.dir, entry);
+  return { entry, fromCache: false };
+}

--- a/eval/literature-search/run-cached.ts
+++ b/eval/literature-search/run-cached.ts
@@ -1,0 +1,189 @@
+/**
+ * Cached literature-search eval — the deterministic, $0-on-repeat harness.
+ *
+ * For each benchmark query it loads the frozen candidate POOL from the local cache
+ * (`eval/literature-search/.cache/candidates/`), or — on a miss/stale/`--refresh`
+ * — captures it ONCE from the live search (PubMed/OpenAlex/MedCPT-dense + GPU
+ * rerank) and persists it. It then applies the CURRENT ranking code
+ * (`rankAndAnnotate`, pure) to the frozen pool and computes metrics. So:
+ *   - first run on a fresh cache: spends the API/GPU once, fills the cache;
+ *   - every repeat run: reads JSON, re-ranks, scores — no network, no GPU, and
+ *     identical pools, so any metric delta is 100% attributable to the ranking
+ *     change under test (this is the measurement harness for the ranking work).
+ *
+ * Usage:
+ *   op-run -- npm run eval:search:cached -- --label after            # first time: captures + scores
+ *   npm run eval:search:cached -- --label after                     # repeat: $0, deterministic
+ *   npm run eval:search:cached -- --label after --only acronym-partner-3,broad-hfref-management
+ *   op-run -- npm run eval:search:cached -- --label fresh --refresh # force live re-capture
+ *
+ * Writes eval/literature-search/runs/<label>/summary.{json,md}.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { BENCHMARK_QUERIES, type BenchmarkQuery } from "./queries";
+import { runLiteratureSearch } from "@/lib/search/run-search";
+import { planQuery } from "@/lib/search/query-planner";
+import { rankAndAnnotate } from "@/lib/search/pipeline";
+import { computeQueryMetrics } from "@/lib/search/eval/metrics";
+import { buildSummaryMd, buildSummaryJson, type QueryRun } from "./report";
+import { loadOrCapturePool, type CaptureFn } from "./candidate-cache";
+import type { UnifiedSearchResult } from "@/types/search";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CACHE_DIR = join(HERE, ".cache", "candidates");
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+function loadEnv(): void {
+  for (const f of [".env.local", ".env"]) {
+    try {
+      (process as unknown as { loadEnvFile: (p: string) => void }).loadEnvFile(
+        join(process.cwd(), f)
+      );
+    } catch {
+      /* env file absent — providers fall back to keyless/public access */
+    }
+  }
+}
+
+interface CliArgs {
+  label: string;
+  only?: string[];
+  refresh: boolean;
+  ttlDays: number;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const out: CliArgs = { label: "cached", refresh: false, ttlDays: 30 };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--label") out.label = argv[++i];
+    else if (a === "--only") out.only = argv[++i].split(",").map((s) => s.trim());
+    else if (a === "--refresh") out.refresh = true;
+    else if (a === "--ttl-days") out.ttlDays = parseInt(argv[++i], 10) || 30;
+  }
+  return out;
+}
+
+const pct = (v: number | null) => (v === null ? "—" : `${Math.round(v * 100)}%`);
+
+function toEvalItems(results: UnifiedSearchResult[]) {
+  return results.map((r) => ({
+    title: String(r.title ?? ""),
+    doi: r.doi || undefined,
+    pmid: r.pmid || undefined,
+    year: typeof r.year === "number" ? r.year : undefined,
+    journal: r.journal || undefined,
+    studyType: r.studyType || undefined,
+    abstract: r.abstract || undefined,
+  }));
+}
+
+/** Live capture of the post-enrichment candidate pool (the expensive path). */
+const capture: CaptureFn = async (params) => {
+  const res = await runLiteratureSearch({
+    query: params.query,
+    perPage: 10,
+    yearFrom: params.yearFrom,
+    yearTo: params.yearTo,
+    includeRawCandidates: true,
+  });
+  return { candidates: res.rawCandidates ?? [], recency: res.plan.recency };
+};
+
+/** Rank a FROZEN pool with the current code and score it against ground truth. */
+function scorePool(q: BenchmarkQuery, candidates: UnifiedSearchResult[]): QueryRun {
+  const plan = planQuery(q.query);
+  const ranked = rankAndAnnotate(candidates, {
+    query: q.query,
+    recency: plan.recency,
+    isTrialLookup: plan.isTrialLookup,
+  });
+  const items = toEvalItems(ranked.slice(0, 10));
+  return {
+    id: q.id,
+    query: q.query,
+    category: q.category,
+    latencyMs: 0,
+    sourceCounts: {},
+    zeroSources: candidates.length === 0 ? ["pubmed", "openalex"] : [],
+    results: items,
+    metrics: computeQueryMetrics(items, { mustHaves: q.mustHaves, query: q.query }),
+  };
+}
+
+async function main() {
+  loadEnv();
+  const args = parseArgs(process.argv.slice(2));
+  const selected = args.only
+    ? BENCHMARK_QUERIES.filter((q) => args.only!.includes(q.id))
+    : BENCHMARK_QUERIES;
+  if (selected.length === 0) {
+    console.error("No queries selected. Check --only ids.");
+    process.exit(1);
+  }
+
+  const outDir = join(HERE, "runs", args.label);
+  mkdirSync(join(outDir, "queries"), { recursive: true });
+  console.log(
+    `[eval:cached] label=${args.label} queries=${selected.length} cache=${CACHE_DIR}` +
+      (args.refresh ? " (refresh)" : "")
+  );
+
+  const runs: QueryRun[] = [];
+  let hits = 0;
+  let fetched = 0;
+  for (const q of selected) {
+    let candidates: UnifiedSearchResult[] = [];
+    try {
+      const { entry, fromCache } = await loadOrCapturePool(
+        q.id,
+        { query: q.query },
+        { dir: CACHE_DIR, ttlDays: args.ttlDays, now: () => new Date(), capture, refresh: args.refresh }
+      );
+      candidates = entry.candidates;
+      if (fromCache) hits++;
+      else fetched++;
+    } catch (e) {
+      console.log(`  ✗ ${q.id.padEnd(34)} capture failed: ${e instanceof Error ? e.message : e}`);
+    }
+
+    const run = scorePool(q, candidates);
+    runs.push(run);
+    writeFileSync(join(outDir, "queries", `${q.id}.json`), JSON.stringify(run, null, 2));
+    const r = run.metrics;
+    const src = candidates.length ? "cache/live" : "EMPTY";
+    console.log(
+      `  ✓ ${q.id.padEnd(28)} pool=${String(candidates.length).padStart(3)} ` +
+        `recall@10=${pct(r.recallAt10).padStart(4)} ndcg@10=${pct(r.ndcgAt10).padStart(4)} ` +
+        `best=${String(r.bestMustHaveRank ?? "—").padStart(2)} [${src}]`
+    );
+    // Only pace when we actually hit the network this iteration.
+    if (candidates.length && fetched > hits) await sleep(700);
+  }
+
+  // Preserve benchmark order in the summary.
+  runs.sort((a, b) => {
+    const ia = BENCHMARK_QUERIES.findIndex((q) => q.id === a.id);
+    const ib = BENCHMARK_QUERIES.findIndex((q) => q.id === b.id);
+    return ia - ib;
+  });
+  writeFileSync(
+    join(outDir, "summary.json"),
+    JSON.stringify(buildSummaryJson(args.label, runs, new Date().toISOString()), null, 2)
+  );
+  writeFileSync(join(outDir, "summary.md"), buildSummaryMd(args.label, runs));
+  console.log(
+    `\n[eval:cached] ${hits} cache hits, ${fetched} live captures → ${outDir}/summary.{json,md}`
+  );
+  if (hits > 0) {
+    console.log(`[eval:cached] reused ${hits} frozen pools — that many API/GPU fan-outs NOT re-spent.`);
+  }
+}
+
+main().catch((err) => {
+  console.error("[eval:cached] fatal:", err);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "ux:score:zone": "node qa/ux-score.mjs --zone",
     "ux:screenshot": "npx playwright test qa/ux-screenshot.ts",
     "eval:search": "tsx eval/literature-search/run.ts",
+    "eval:search:cached": "tsx eval/literature-search/run-cached.ts",
     "eval:web:exa": "npx tsx eval/web-search/capture-exa.ts",
     "eval:web:freeze": "npx tsx eval/web-search/capture-searxng.ts",
     "eval:web:run": "npx tsx eval/web-search/run.ts --label baseline",


### PR DESCRIPTION
## What

Item 1 of three ("do first — it pays for itself"). A content-addressed local cache of the frozen candidate pool so repeat 87q evals stop re-spending API quota + GPU minutes.

## Why

A full eval fans out to PubMed/OpenAlex/MedCPT-dense (GPU) for **every query, every run**. Re-running to measure a pure *ranking* change therefore re-spends money AND reintroduces live-retrieval noise (throttle, pool drift) that makes per-cycle keep/revert on the aggregate unsound. This freezes the post-enrichment pool once and replays the ranking stage against identical pools.

## How

- **`candidate-cache.ts`** — pure, dependency-injected cache: `poolCacheKey` (sha1 of normalized query + sources + year window), `isFresh` (TTL), `read/writePool`, `loadOrCapturePool` (hit → `fromCache:true` no spend; miss/stale/`--refresh` → capture once + persist). Unit-tested: key stability+normalization, TTL boundary, hit/miss/stale/refresh.
- **`run-cached.ts`** + `npm run eval:search:cached` — one command: capture-or-read each pool, re-rank with the current `rankAndAnnotate`, score, and report cache hits vs live captures.
- Cache dir `eval/literature-search/.cache/` is gitignored; harness doc updated.

## Proof (end-to-end)

```
RUN 1 (op-run, live):  exact-dapa-hf  pool=41  recall@10=100%  ndcg@10=100%  best=1  [1 live capture]
RUN 2 (no network):    exact-dapa-hf  pool=41  recall@10=100%  ndcg@10=100%  best=1  [1 cache hit] — 0.28s
```

Identical metrics, zero network, sub-second. This becomes the measurement harness for the ranking + HyDE work that follows.

## Tests

- New: `candidate-cache.test.ts` (12 tests).
- Full eval + search suites green: **309 passed (31 files)**. Tier 1 (tsc + eslint) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEgTUohzwMogXKPsWVdwJx