### PR TITLE
feat(search): surface journal-quartile badge in research results

### DIFF
--- a/src/app/(app)/research/page.tsx
+++ b/src/app/(app)/research/page.tsx
@@ -23,6 +23,7 @@ import {
 import { useChat } from "@ai-sdk/react";
 import { TextStreamChatTransport } from "ai";
 import { cn } from "@/lib/utils";
+import { JournalQuartileBadge } from "@/components/search/JournalQuartileBadge";
 import { GlassPanel } from "@/components/ui/glass-panel";
 import { AISynthesisPanel } from "@/components/research/AISynthesisPanel";
 import { savePaper } from "@/lib/actions/papers";
@@ -1054,6 +1055,9 @@ export default function ResearchPage() {
                           {EVIDENCE_LABELS[r.evidenceLevel] || "Level V"}
                         </span>
                       )}
+
+                      {/* Journal quartile badge (Scimago Q1–Q4) */}
+                      <JournalQuartileBadge quartile={r.journalQuartile} />
 
                       {/* Open Access badge */}
                       {r.isOpenAccess && (

--- a/src/components/search/JournalQuartileBadge.tsx
+++ b/src/components/search/JournalQuartileBadge.tsx
@@ -1,0 +1,37 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * Journal-quartile chip (Scimago Q1–Q4). Surfaces the journal-quality signal that
+ * already rides on each result (`journalQuartile`) but was previously only used in
+ * ranking, never shown. Colours mirror `journal-quality.ts` QUARTILE_COLORS so the
+ * badge and any other quartile UI stay consistent. Renders nothing for an unrated
+ * journal — absence of a quartile is not a Q4.
+ */
+const QUARTILE_STYLES: Record<"Q1" | "Q2" | "Q3" | "Q4", string> = {
+  Q1: "bg-emerald-500/10 text-emerald-600 border-emerald-500/30",
+  Q2: "bg-sky-500/10 text-sky-600 border-sky-500/30",
+  Q3: "bg-amber-500/10 text-amber-600 border-amber-500/30",
+  Q4: "bg-orange-500/10 text-orange-600 border-orange-500/30",
+};
+
+export function JournalQuartileBadge({
+  quartile,
+  className,
+}: {
+  quartile?: "Q1" | "Q2" | "Q3" | "Q4" | null;
+  className?: string;
+}) {
+  if (!quartile) return null;
+  return (
+    <span
+      className={cn(
+        "px-2 py-0.5 rounded-full text-[10px] font-medium border",
+        QUARTILE_STYLES[quartile],
+        className
+      )}
+      title={`${quartile} journal (Scimago quartile)`}
+    >
+      {quartile} journal
+    </span>
+  );
+}

--- a/src/components/search/__tests__/JournalQuartileBadge.test.tsx
+++ b/src/components/search/__tests__/JournalQuartileBadge.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { JournalQuartileBadge } from "../JournalQuartileBadge";
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("JournalQuartileBadge", () => {
+  it("renders the quartile label for a rated journal", () => {
+    act(() => root.render(<JournalQuartileBadge quartile="Q1" />));
+    expect(container.textContent).toContain("Q1");
+    // emerald is the Q1 colour (matches journal-quality QUARTILE_COLORS)
+    expect(container.querySelector("span")?.className).toContain("emerald");
+  });
+
+  it("uses a distinct colour per quartile", () => {
+    act(() => root.render(<JournalQuartileBadge quartile="Q3" />));
+    expect(container.textContent).toContain("Q3");
+    expect(container.querySelector("span")?.className).toContain("amber");
+  });
+
+  it("renders nothing for an unrated journal (null / undefined)", () => {
+    act(() => root.render(<JournalQuartileBadge quartile={null} />));
+    expect(container.querySelector("span")).toBeNull();
+    act(() => root.render(<JournalQuartileBadge quartile={undefined} />));
+    expect(container.querySelector("span")).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Item 2 (UI surfacing). A small Scimago **Q1–Q4 quartile chip** next to the evidence-level badge in the research results, so journal quality is visible at a glance.

## Why

The journal quartile already rides on every result (`journalQuartile`) and drives ranking, but was never shown to the user. The data already flows to the client — this just surfaces it.

## How

- **`JournalQuartileBadge.tsx`** — reusable presentational component. Colours mirror `journal-quality.ts` `QUARTILE_COLORS` (emerald/sky/amber/orange) so all quartile UI stays consistent. Renders **nothing** for an unrated journal (absence of a quartile is not a Q4).
- Wired into the research results badge row — additive, gated on `r.journalQuartile`, no logic touched.

## Tests

- New `JournalQuartileBadge.test.tsx` (3, jsdom): renders label + per-quartile colour, renders nothing for null/undefined.
- Component suites green (46); Tier 1 (tsc + eslint) clean. tsc passing confirms `journalQuartile` is on the result type the page consumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEgTUohzwMogXKPsWVdwJx