### PR TITLE
feat(search): HyDE + multi-query expansion on DeepSeek (dormant by default)

### DIFF
--- a/src/lib/search/__tests__/hyde.test.ts
+++ b/src/lib/search/__tests__/hyde.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { mockGenerateText } = vi.hoisted(() => ({ mockGenerateText: vi.fn() }));
+vi.mock("ai", () => ({ generateText: mockGenerateText }));
+vi.mock("@ai-sdk/openai", () => ({
+  createOpenAI: () => ({ chat: (modelId: string) => ({ modelId }) }),
+}));
+
+import { sanitizeVariants, parseHydeResponse, hasHyde, generateSearchVariants } from "../hyde";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+});
+afterEach(() => vi.unstubAllEnvs());
+
+describe("sanitizeVariants — clean the LLM output", () => {
+  it("drops an echo of the original query (case-insensitive), duplicates, and too-short strings", () => {
+    const out = sanitizeVariants(
+      ["SGLT2 inhibitors heart failure", "sglt2 INHIBITORS heart failure", "dapagliflozin HFrEF", "dapagliflozin HFrEF", "x"],
+      "SGLT2 inhibitors heart failure",
+      5
+    );
+    expect(out).toEqual(["dapagliflozin HFrEF"]);
+  });
+
+  it("caps at max and preserves order", () => {
+    const out = sanitizeVariants(["a alpha", "b beta", "c gamma", "d delta"], "orig query", 2);
+    expect(out).toEqual(["a alpha", "b beta"]);
+  });
+});
+
+describe("parseHydeResponse — tolerant JSON extraction", () => {
+  it("extracts JSON wrapped in a ```json code fence and surrounding prose", () => {
+    const text = 'Sure!\n```json\n{"variants":["empagliflozin HFrEF"],"hypotheticalAbstract":"An RCT showed benefit."}\n```';
+    const out = parseHydeResponse(text, "heart failure drugs", 3);
+    expect(out.variants).toEqual(["empagliflozin HFrEF"]);
+    expect(out.hypotheticalAbstract).toBe("An RCT showed benefit.");
+  });
+
+  it("throws when there is no JSON object (so the caller fails open)", () => {
+    expect(() => parseHydeResponse("I cannot help with that.", "q", 3)).toThrow();
+  });
+});
+
+describe("hasHyde", () => {
+  it("reflects DEEPSEEK_API_KEY presence", () => {
+    expect(hasHyde()).toBe(false);
+    vi.stubEnv("DEEPSEEK_API_KEY", "sk-test");
+    expect(hasHyde()).toBe(true);
+  });
+});
+
+describe("generateSearchVariants — fail-open, cached LLM expansion", () => {
+  it("returns empty (no LLM call) when no DEEPSEEK_API_KEY is set", async () => {
+    const out = await generateSearchVariants("statin myopathy risk in elderly");
+    expect(out).toEqual({ variants: [] });
+    expect(mockGenerateText).not.toHaveBeenCalled();
+  });
+
+  it("returns sanitized variants + hypothetical abstract on success, and caches the query", async () => {
+    vi.stubEnv("DEEPSEEK_API_KEY", "sk-test");
+    mockGenerateText.mockResolvedValue({
+      text: JSON.stringify({
+        variants: ["empagliflozin cardiovascular outcomes", "broad cardio dementia query unique-1"],
+        hypotheticalAbstract: "In a randomized trial, the SGLT2 inhibitor reduced cardiovascular death.",
+      }),
+    });
+
+    const first = await generateSearchVariants("broad cardio dementia query unique-1");
+    expect(first.variants).toEqual(["empagliflozin cardiovascular outcomes"]); // echo of original dropped
+    expect(first.hypotheticalAbstract).toContain("SGLT2 inhibitor");
+
+    // Same query again → served from cache, no second LLM call.
+    const second = await generateSearchVariants("broad cardio dementia query unique-1");
+    expect(second).toEqual(first);
+    expect(mockGenerateText).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails open to empty when the LLM call throws", async () => {
+    vi.stubEnv("DEEPSEEK_API_KEY", "sk-test");
+    mockGenerateText.mockRejectedValue(new Error("deepseek 503"));
+    const out = await generateSearchVariants("unique throwing query xyz");
+    expect(out).toEqual({ variants: [] });
+  });
+
+  it("fails open to empty when the LLM returns unparseable text", async () => {
+    vi.stubEnv("DEEPSEEK_API_KEY", "sk-test");
+    mockGenerateText.mockResolvedValue({ text: "I cannot help with that." });
+    const out = await generateSearchVariants("unique unparseable query qrs");
+    expect(out).toEqual({ variants: [] });
+  });
+});

--- a/src/lib/search/hyde.ts
+++ b/src/lib/search/hyde.ts
@@ -1,0 +1,131 @@
+/**
+ * LLM query expansion (HyDE + multi-query) for under-specified searches.
+ *
+ * A short or natural-language query ("drugs that help the failing heart") often
+ * misses landmark papers that use precise terms (generic drug names, MeSH, trial
+ * outcomes). One cheap LLM call (DeepSeek, OpenAI-compatible) produces:
+ *   - a few alternative QUERY formulations (multi-query — synonyms, drug-class ↔
+ *     generic, MeSH phrasing), run as extra retrieval lanes and RRF-fused, and
+ *   - a 1–2 sentence HYPOTHETICAL ABSTRACT (HyDE) — the text a perfectly-relevant
+ *     paper would contain — embedded by the dense lane to retrieve by meaning.
+ *
+ * Fail-open and OFF by default: with no DEEPSEEK_API_KEY, or on any error, it
+ * returns no variants and the caller searches the original query exactly as
+ * before. Results are cached per normalized query so repeats cost nothing.
+ */
+
+import { createOpenAI } from "@ai-sdk/openai";
+import { generateText } from "ai";
+import { z } from "zod";
+
+const DEEPSEEK_BASE_URL = "https://api.deepseek.com";
+const DEEPSEEK_MODEL = "deepseek-chat";
+const MAX_VARIANTS = 3;
+
+export interface HydeResult {
+  /** Alternative query formulations (cleaned, deduped, original excluded). */
+  variants: string[];
+  /** A short hypothetical abstract for HyDE dense retrieval (absent on failure). */
+  hypotheticalAbstract?: string;
+}
+
+const HydeSchema = z.object({
+  variants: z.array(z.string()),
+  hypotheticalAbstract: z.string(),
+});
+
+const cache = new Map<string, HydeResult>();
+
+/** True when LLM expansion is configured (DeepSeek key present). */
+export function hasHyde(): boolean {
+  return Boolean(process.env.DEEPSEEK_API_KEY);
+}
+
+/**
+ * Clean raw LLM variants: trim, drop strings shorter than 3 chars, drop the echo
+ * of the original query and any duplicates (case-insensitive), preserve order,
+ * and cap at `max`. Pure — the deterministic half of the expansion.
+ */
+export function sanitizeVariants(raw: string[], original: string, max: number): string[] {
+  const seen = new Set<string>([original.trim().toLowerCase()]);
+  const out: string[] = [];
+  for (const v of raw) {
+    const t = (v ?? "").trim();
+    if (t.length < 3) continue;
+    const norm = t.toLowerCase();
+    if (seen.has(norm)) continue;
+    seen.add(norm);
+    out.push(t);
+    if (out.length >= max) break;
+  }
+  return out;
+}
+
+/**
+ * Parse + validate the model's JSON reply into a clean HydeResult. Tolerates code
+ * fences and surrounding prose by extracting the outermost `{…}`. Throws on missing
+ * or invalid JSON so the caller can fail open. Pure (no network).
+ */
+export function parseHydeResponse(text: string, original: string, max: number): HydeResult {
+  const cleaned = text.replace(/```(?:json)?/gi, "").trim();
+  const start = cleaned.indexOf("{");
+  const end = cleaned.lastIndexOf("}");
+  if (start === -1 || end <= start) throw new Error("no JSON object in HyDE response");
+  const parsed = HydeSchema.parse(JSON.parse(cleaned.slice(start, end + 1)));
+  return {
+    variants: sanitizeVariants(parsed.variants, original, max),
+    hypotheticalAbstract: parsed.hypotheticalAbstract.trim() || undefined,
+  };
+}
+
+function buildPrompt(query: string): string {
+  return [
+    "You are a biomedical literature-search assistant.",
+    `Original query: "${query}"`,
+    "",
+    `Generate up to ${MAX_VARIANTS} ALTERNATIVE search-query formulations that would`,
+    "surface the most relevant primary literature — expand drug classes to their",
+    "generic names, add MeSH-style phrasing and key synonyms. Each must be a concise",
+    "search query (not a sentence) and differ from the original. Also write a 1–2",
+    "sentence HYPOTHETICAL ABSTRACT: the text a perfectly-relevant paper answering",
+    "this query would contain, using precise clinical terms.",
+    "",
+    "Respond with ONLY a JSON object of this exact shape, no prose:",
+    '{"variants": ["...", "..."], "hypotheticalAbstract": "..."}',
+  ].join("\n");
+}
+
+/**
+ * Generate LLM query variants + a hypothetical abstract for a query. Fail-open:
+ * returns `{ variants: [] }` with no LLM call when unconfigured, and on any error.
+ * Cached per normalized query.
+ */
+export async function generateSearchVariants(query: string): Promise<HydeResult> {
+  const trimmed = query.trim();
+  if (!hasHyde() || trimmed.length === 0) return { variants: [] };
+
+  const key = trimmed.toLowerCase();
+  const cached = cache.get(key);
+  if (cached) return cached;
+
+  try {
+    const deepseek = createOpenAI({
+      baseURL: DEEPSEEK_BASE_URL,
+      apiKey: process.env.DEEPSEEK_API_KEY,
+    });
+    // `.chat()` targets /chat/completions — DeepSeek's OpenAI-compatible endpoint
+    // (the provider's default model call uses the newer /responses API, which
+    // DeepSeek does not implement). generateText + manual JSON parse, because
+    // DeepSeek rejects the json_schema response_format that generateObject emits.
+    const { text } = await generateText({
+      model: deepseek.chat(DEEPSEEK_MODEL),
+      prompt: buildPrompt(trimmed),
+    });
+    const result = parseHydeResponse(text, trimmed, MAX_VARIANTS);
+    cache.set(key, result);
+    return result;
+  } catch (error) {
+    console.error("HyDE expansion failed (fail-open):", error);
+    return { variants: [] };
+  }
+}

--- a/src/lib/search/run-search.ts
+++ b/src/lib/search/run-search.ts
@@ -24,6 +24,7 @@ import { planQuery } from "@/lib/search/query-planner";
 import { rankAndAnnotate } from "@/lib/search/pipeline";
 import { searchResultCache, buildCacheKey } from "@/lib/search/result-cache";
 import { attachRerankScores } from "@/lib/search/rerank";
+import { generateSearchVariants, hasHyde, type HydeResult } from "@/lib/search/hyde";
 import { okStatus, type SourceStatus } from "@/lib/search/source-status";
 import type { UnifiedSearchResult } from "@/types/search";
 
@@ -365,6 +366,20 @@ async function runLiteratureSearchUncached(
     laneLabels.push(label);
   };
 
+  // LLM query expansion (HyDE + multi-query). OFF by default (HYDE_ENABLED!=="1");
+  // dormant unless a DeepSeek key is also present. One cheap LLM call yields a
+  // hypothetical abstract + alternative formulations that become EXTRA dense lanes
+  // (below), fused by RRF — closing the recall gap on under-specified queries.
+  // Bounded by a timeout and fail-open: any failure → no extra lanes → the default
+  // retrieval path is byte-for-byte unchanged. Sequential (must precede fan-out),
+  // but cached per query so repeats add nothing.
+  const hydeEnabled = process.env.HYDE_ENABLED === "1" && hasHyde();
+  const hyde: HydeResult = hydeEnabled
+    ? await withSourceTimeout("HyDE", generateSearchVariants(searchQuery), 5000).catch(
+        () => ({ variants: [] as string[] })
+      )
+    : { variants: [] };
+
   if (sources.includes("pubmed")) {
     pushLane(
       "pubmed",
@@ -427,6 +442,39 @@ async function runLiteratureSearchUncached(
         errorOutcome("medcpt_dense", e instanceof Error ? e.message : "MedCPT dense failed")
       )
     );
+
+    // HyDE / multi-query: each LLM-generated formulation (and the hypothetical
+    // abstract) runs as its OWN dense lane against the owned MedCPT index, then
+    // RRF-fuses with everything else. The dense lane is throttle-proof, so extra
+    // lanes add recall without external rate-limit pressure. Bounded by the same
+    // fan-out deadline and fail-open per lane. Empty when HyDE is off/failed.
+    const hydeDenseQueries = [
+      ...(hyde.hypotheticalAbstract ? [hyde.hypotheticalAbstract] : []),
+      ...hyde.variants,
+    ];
+    hydeDenseQueries.forEach((hq, i) => {
+      pushLane(
+        `medcpt_dense_hyde_${i}`,
+        withSourceTimeout(
+          "MedCPT Dense (HyDE)",
+          searchMedcptDense(hq, {
+            limit: poolPerSource,
+            yearStart: params.yearFrom,
+            yearEnd: params.yearTo,
+          }).then(({ results, total, status }) => ({
+            source: `medcpt_dense_hyde_${i}`,
+            results,
+            total,
+            status,
+          }))
+        ).catch((e) =>
+          errorOutcome(
+            `medcpt_dense_hyde_${i}`,
+            e instanceof Error ? e.message : "MedCPT dense (HyDE) failed"
+          )
+        )
+      );
+    });
   }
 
   // Semantic Scholar is opt-in only (never required). Used purely as an extra


### PR DESCRIPTION
## What

Item 3 of three. LLM query expansion to close the recall gap on **under-specified queries**. One cheap DeepSeek call generates a **hypothetical abstract** (HyDE) + a few **alternative formulations** (multi-query); each runs as its own dense lane against the owned MedCPT index and RRF-fuses with the rest.

## Why it's safe (dormant by default)

- **OFF by default.** Gated behind `HYDE_ENABLED==="1"` **and** a DeepSeek key. Otherwise the LLM is never called and retrieval is byte-for-byte the existing default path.
- **Fail-open at every step:** no key / timeout / API error / unparseable reply → no extra lanes, default retrieval unchanged.
- **Cached** per normalized query → repeats cost nothing.
- Extra lanes hit only the **owned, throttle-proof** dense index — no added external rate-limit pressure.

## Proven live (end-to-end)

For "drugs that help the failing heart reduce death", DeepSeek returned 3 sound reformulations (drug-class → generic expansion, MeSH phrasing) + a clinically-realistic hypothetical abstract. Four extra dense lanes fired (`medcpt_dense_hyde_0..3`) and the candidate pool grew **13 → 38** via RRF fusion. The fail-open path was also exercised (a 404 and a parse error both degraded cleanly to the default path).

## Implementation notes

- DeepSeek via `createOpenAI({ baseURL }).chat()` — the provider's default model call targets the new `/responses` API (404 on DeepSeek), so `.chat()` routes to `/chat/completions`.
- `generateText` + a **pure, tested** JSON parser (`parseHydeResponse`), because DeepSeek rejects the `json_schema` `response_format` that `generateObject` emits.

## Tests

- New `hyde.test.ts` (9): sanitize (echo/dup/short/cap), tolerant JSON parse (code fences, throws on garbage), fail-open on no-key / throw / unparseable, and caching.
- Full search suite green (306); Tier 1 (tsc + eslint) clean.

## Measuring the recall lift

The frozen-pool cache can't be reused (HyDE changes retrieval), so the recall A/B is a fresh live run, opt-in to avoid a throttle-noisy capture now:

```
HYDE_ENABLED=1 op-run -- npm run eval:search -- --label hyde-on
op-run -- npm run eval:search -- --label hyde-off
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEgTUohzwMogXKPsWVdwJx