### PR TITLE
chore(search): use DeepSeek V4 Flash for HyDE expansion

### DIFF
--- a/src/lib/search/hyde.ts
+++ b/src/lib/search/hyde.ts
@@ -19,7 +19,9 @@ import { generateText } from "ai";
 import { z } from "zod";
 
 const DEEPSEEK_BASE_URL = "https://api.deepseek.com";
-const DEEPSEEK_MODEL = "deepseek-chat";
+// DeepSeek V4 Flash: fast + cheap, the right tier for a single per-query expansion
+// call. Overridable via DEEPSEEK_MODEL (e.g. "deepseek-v4-pro") without a code change.
+const DEEPSEEK_MODEL = process.env.DEEPSEEK_MODEL || "deepseek-v4-flash";
 const MAX_VARIANTS = 3;
 
 export interface HydeResult {


### PR DESCRIPTION
## What

Point the HyDE / multi-query expansion at **`deepseek-v4-flash`** (was `deepseek-chat`), overridable via `DEEPSEEK_MODEL` (e.g. `deepseek-v4-pro`) with no code change.

## Why V4 Flash

A single per-query expansion call wants the fast/cheap tier. Confirmed this key exposes exactly `deepseek-v4-flash` and `deepseek-v4-pro` via `GET /models`.

## Verified

Live call with `deepseek-v4-flash` returns sound reformulations + a clinical hypothetical abstract (sacubitril/valsartan vs enalapril, CV mortality). Unit tests green, Tier 1 clean.

## Secret handling

`DEEPSEEK_API_KEY` is already wired via the 1Password `Dev` vault (`op-run`); the code reads it from `process.env`. No secret in code or chat. (Production runtime — Vercel — will need `DEEPSEEK_API_KEY` set in its env when HyDE is enabled there.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEgTUohzwMogXKPsWVdwJx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Made the HyDE model selection configurable through an environment setting, with a new default model used when none is provided.
* **Bug Fixes**
  * Improved flexibility for query expansion by allowing easier model swaps without changing the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->