### PR TITLE
feat(search): enable HyDE by default, gate off trial + paper-lookup queries

### DIFF
--- a/docs/literature-search/HYDE-AB-RESULTS.md
+++ b/docs/literature-search/HYDE-AB-RESULTS.md
@@ -1,0 +1,61 @@
+# HyDE / multi-query — measured A/B (DeepSeek V4 Flash)
+
+**Date:** 2026-06-27. **Model:** `deepseek-v4-flash`. **Harness:** full 87q live, `eval:search`,
+HyDE-off vs HyDE-on under the same conditions (back-to-back runs).
+
+## Result — a decisive win
+
+| metric | HyDE off | HyDE on | Δ |
+|---|---|---|---|
+| recall@10 | 0.7568 | **0.8514** | **+0.0946** |
+| best-in-top-3 | 0.6757 | 0.7297 | +0.0541 |
+| nDCG@10 | 0.6913 | 0.7555 | +0.0641 |
+| MRR | 0.6717 | 0.7088 | +0.0371 |
+| **empty result sets** | **13** | **3** | **−10** |
+
+HyDE recovered **10 of 13 throttle-empties**: when the rented lexical lanes (PubMed/OpenAlex)
+get rate-limited to zero, the LLM-generated hypothetical abstract + query variants run as extra
+lanes against the **owned, throttle-proof** MedCPT dense index and still return candidates. So
+HyDE buys both recall AND throttle-resilience.
+
+The 6 genuinely-helped queries are all in the under-specified categories HyDE targets (pico,
+long-term-outcomes, therapy-comparison, trial-family) — most went 0.00 → 1.00.
+
+## The 2 "regressions" were throttle, not HyDE
+
+Per-query, two queries dropped 1.00 → 0.00. Both are **OpenAlex throttling in the on-run**, not
+HyDE dilution — proven by the source counts:
+
+| query | category | off | on |
+|---|---|---|---|
+| `exact-plato-ticagrelor` | exact_paper | openalex=**8571**, recall 1 | openalex=**0** (rate-limited), recall 0 |
+| `psy-stard-major-depression` | trial_acronym | openalex=2720, recall 1 | pubmed=0 **and** openalex=0 (both throttled), recall 0 |
+
+The on-run runs longer (extra LLM latency per query stretches the batch out), so it hit more
+OpenAlex throttling on those queries. Union-max correction would wash both out — HyDE's true
+effect is even cleaner than the raw +9.5.
+
+## Decision (shipped)
+
+- **HyDE ON by default** when a DeepSeek key is present (opt out with `HYDE_ENABLED="0"`);
+  dormant + fail-open without a key.
+- **Skipped** for **trial-acronym lookups** (`plan.isTrialLookup` — acronym expansion only adds
+  noise to primary-report ranking) and for **specific paper lookups** (`isPaperLookupQuery` —
+  DOI / PMID / pasted-title, where the target is already known). These add latency/cost without
+  recall benefit and, by lengthening the burst, slightly worsen the throttle.
+- Tradeoff accepted: ~1–2s added latency per non-exact/non-trial search (the LLM call precedes
+  fan-out) + ~$0.0002/query DeepSeek + extra Modal dense calls. Negligible at 100 users; the
+  recall lift is worth it. (A future refinement could run the LLM call concurrently with the
+  first lexical wave to hide the latency.)
+
+## Reproduce
+
+```bash
+op-run -- npm run eval:search -- --label hyde-off            # HyDE off (HYDE_ENABLED unset → on, so disable:)
+HYDE_ENABLED=0 op-run -- npm run eval:search -- --label hyde-off
+op-run -- npm run eval:search -- --label hyde-on             # HyDE on (default)
+# compare runs/<label>/summary.json aggregates
+```
+
+Caveat: a single live A/B carries throttle noise (see the 2 "regressions"). The cleanest read is
+the aggregate + the empties delta; per-query, trust only queries with a non-empty pool in both runs.

--- a/src/lib/search/__tests__/hyde.test.ts
+++ b/src/lib/search/__tests__/hyde.test.ts
@@ -6,7 +6,13 @@ vi.mock("@ai-sdk/openai", () => ({
   createOpenAI: () => ({ chat: (modelId: string) => ({ modelId }) }),
 }));
 
-import { sanitizeVariants, parseHydeResponse, hasHyde, generateSearchVariants } from "../hyde";
+import {
+  sanitizeVariants,
+  parseHydeResponse,
+  isPaperLookupQuery,
+  hasHyde,
+  generateSearchVariants,
+} from "../hyde";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -40,6 +46,25 @@ describe("parseHydeResponse — tolerant JSON extraction", () => {
 
   it("throws when there is no JSON object (so the caller fails open)", () => {
     expect(() => parseHydeResponse("I cannot help with that.", "q", 3)).toThrow();
+  });
+});
+
+describe("isPaperLookupQuery — gate HyDE off where it can't help", () => {
+  it("gates a pasted paper TITLE (long, Title-Cased, no question)", () => {
+    expect(isPaperLookupQuery("Dexamethasone in Hospitalized Patients with Covid-19 RECOVERY")).toBe(true);
+    expect(isPaperLookupQuery("Pembrolizumab plus Chemotherapy in Metastatic Non-Small-Cell Lung Cancer")).toBe(true);
+  });
+
+  it("gates a bare DOI or PMID identifier", () => {
+    expect(isPaperLookupQuery("10.1056/NEJMoa2034577")).toBe(true);
+    expect(isPaperLookupQuery("33301246")).toBe(true);
+  });
+
+  it("does NOT gate an under-specified topic / PICO query (HyDE should run)", () => {
+    expect(isPaperLookupQuery("management of heart failure with reduced ejection fraction")).toBe(false);
+    expect(isPaperLookupQuery("SGLT2 inhibitors cardiovascular outcomes")).toBe(false);
+    expect(isPaperLookupQuery("does early goal-directed therapy reduce mortality in septic shock?")).toBe(false);
+    expect(isPaperLookupQuery("drugs that help the failing heart")).toBe(false);
   });
 });
 

--- a/src/lib/search/hyde.ts
+++ b/src/lib/search/hyde.ts
@@ -43,6 +43,33 @@ export function hasHyde(): boolean {
   return Boolean(process.env.DEEPSEEK_API_KEY);
 }
 
+const DOI_RE = /\b10\.\d{4,9}\/\S+/;
+const PMID_RE = /^\d{7,8}$/;
+
+/**
+ * True when the query is a SPECIFIC paper lookup — a DOI, a bare PMID, or a pasted
+ * paper TITLE (long, predominantly Title-Cased, not a question). HyDE can't help
+ * here: the target is already known, so expansion only adds latency/cost (and the
+ * exact-title boost downstream already floats the right paper). Conservative by
+ * design — it must NOT fire on under-specified topic/PICO queries, where HyDE earns
+ * its keep, so a lowercase/keyword/question query is never treated as a lookup.
+ */
+export function isPaperLookupQuery(query: string): boolean {
+  const q = query.trim();
+  if (!q) return false;
+  if (DOI_RE.test(q)) return true;
+  if (PMID_RE.test(q)) return true;
+  if (q.includes("?")) return false;
+  const words = q.split(/\s+/);
+  if (words.length < 6) return false;
+  // Significant words = real words (>3 chars, contain a letter). A pasted title is
+  // mostly Title-Cased; a typed topic query is mostly lowercase.
+  const sig = words.filter((w) => w.length > 3 && /[a-z]/i.test(w));
+  if (sig.length < 4) return false;
+  const capitalized = sig.filter((w) => /^[A-Z]/.test(w)).length;
+  return capitalized / sig.length >= 0.6;
+}
+
 /**
  * Clean raw LLM variants: trim, drop strings shorter than 3 chars, drop the echo
  * of the original query and any duplicates (case-insensitive), preserve order,

--- a/src/lib/search/run-search.ts
+++ b/src/lib/search/run-search.ts
@@ -24,7 +24,12 @@ import { planQuery } from "@/lib/search/query-planner";
 import { rankAndAnnotate } from "@/lib/search/pipeline";
 import { searchResultCache, buildCacheKey } from "@/lib/search/result-cache";
 import { attachRerankScores } from "@/lib/search/rerank";
-import { generateSearchVariants, hasHyde, type HydeResult } from "@/lib/search/hyde";
+import {
+  generateSearchVariants,
+  hasHyde,
+  isPaperLookupQuery,
+  type HydeResult,
+} from "@/lib/search/hyde";
 import { okStatus, type SourceStatus } from "@/lib/search/source-status";
 import type { UnifiedSearchResult } from "@/types/search";
 
@@ -366,14 +371,22 @@ async function runLiteratureSearchUncached(
     laneLabels.push(label);
   };
 
-  // LLM query expansion (HyDE + multi-query). OFF by default (HYDE_ENABLED!=="1");
-  // dormant unless a DeepSeek key is also present. One cheap LLM call yields a
-  // hypothetical abstract + alternative formulations that become EXTRA dense lanes
-  // (below), fused by RRF — closing the recall gap on under-specified queries.
-  // Bounded by a timeout and fail-open: any failure → no extra lanes → the default
-  // retrieval path is byte-for-byte unchanged. Sequential (must precede fan-out),
-  // but cached per query so repeats add nothing.
-  const hydeEnabled = process.env.HYDE_ENABLED === "1" && hasHyde();
+  // LLM query expansion (HyDE + multi-query). ON by default when a DeepSeek key is
+  // present (opt out with HYDE_ENABLED="0"); dormant + fail-open without a key. One
+  // cheap LLM call yields a hypothetical abstract + alternative formulations that
+  // become EXTRA dense lanes (below), fused by RRF — measured +9.5pt recall@10 and
+  // 13→3 fewer empty result sets on the 87q harness, because the owned dense lanes
+  // recover queries the rate-limited lexical lanes drop. SKIPPED for trial-acronym
+  // lookups (acronym expansion only adds noise to primary-report ranking) and for
+  // specific paper lookups (DOI/PMID/pasted-title — the target is already known),
+  // where it can't help and would just cost latency. Bounded by a timeout and
+  // fail-open: any failure → no extra lanes → default retrieval unchanged. Sequential
+  // (must precede fan-out), but cached per query so repeats add nothing.
+  const hydeEnabled =
+    process.env.HYDE_ENABLED !== "0" &&
+    hasHyde() &&
+    !plan.isTrialLookup &&
+    !isPaperLookupQuery(searchQuery);
   const hyde: HydeResult = hydeEnabled
     ? await withSourceTimeout("HyDE", generateSearchVariants(searchQuery), 5000).catch(
         () => ({ variants: [] as string[] })


### PR DESCRIPTION
## What

Following the measured A/B, ship HyDE **on by default** and skip it where it can't help.

## The A/B (full 87q live, `deepseek-v4-flash`, off vs on, same conditions)

| metric | HyDE off | HyDE on | Δ |
|---|---|---|---|
| recall@10 | 0.7568 | **0.8514** | **+0.095** |
| best-in-top-3 | 0.6757 | 0.7297 | +0.054 |
| nDCG@10 | 0.6913 | 0.7555 | +0.064 |
| MRR | 0.6717 | 0.7088 | +0.037 |
| **empty result sets** | **13** | **3** | **−10** |

HyDE recovered **10 of 13 throttle-empties** — the owned dense lanes return candidates when the rented lexical lanes get rate-limited. The 2 apparent per-query regressions were proven to be **OpenAlex throttling in the on-run** (`openalex` count → 0), not HyDE dilution. Full methodology + the source-count proof: `docs/literature-search/HYDE-AB-RESULTS.md`.

## Change

- **Default ON** when a DeepSeek key is present (opt out with `HYDE_ENABLED="0"`); dormant + fail-open without a key, so the default path is unchanged when unconfigured.
- **Skip** trial-acronym lookups (`plan.isTrialLookup`) and specific paper lookups (`isPaperLookupQuery`: DOI / PMID / pasted Title-Cased title) — no recall benefit there, and they only add latency/cost and lengthen the throttle burst.
- `isPaperLookupQuery` is **conservative**: lowercase/keyword/question queries are never treated as lookups, so under-specified topic/PICO queries keep HyDE.

## Tradeoff (accepted)

~1–2s added latency per non-exact/non-trial search (LLM call precedes fan-out) + ~$0.0002/query DeepSeek + extra Modal dense calls. Negligible at 100 users; the recall lift is worth it. A future refinement could run the LLM call concurrently with the first lexical wave to hide the latency.

## Tests

- `hyde.test.ts` now 12 (added `isPaperLookupQuery` gating cases: titles + DOI/PMID gate; topic/PICO/question do not).
- Full search suite green (317); Tier 1 (tsc + eslint) clean. HyDE stays off in tests (no key set), so no test-behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEgTUohzwMogXKPsWVdwJx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search expansion is now enabled by default when available, with smarter handling for certain lookup-style searches.
  * Specific paper, DOI, and PMID lookups now skip expansion to keep results focused.

* **Bug Fixes**
  * Improved search behavior for exact-match queries and trial lookups.
  * Reduced unnecessary empty or noisy results in cases where the original query is already specific.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->