### PR TITLE
feat(search): recency-windowed dense lane for fresh-evidence intent

### DIFF
--- a/src/lib/search/__tests__/recency-tiering.test.ts
+++ b/src/lib/search/__tests__/recency-tiering.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { rankAndAnnotate } from "../pipeline";
+import { recencyYearFloor } from "../run-search";
+import type { UnifiedSearchResult } from "@/types/search";
+
+function paper(p: Partial<UnifiedSearchResult>): UnifiedSearchResult {
+  return {
+    title: "Untitled",
+    authors: [],
+    journal: "",
+    year: 2020,
+    citationCount: 0,
+    publicationTypes: [],
+    isOpenAccess: false,
+    sources: ["pubmed"],
+    ...p,
+  };
+}
+
+describe("rankAndAnnotate — recency intent prefers newer PIVOTAL evidence", () => {
+  it("ranks a newer pivotal trial above an older, more-cited established trial", () => {
+    // The recency-loss case: an older landmark has accumulated far more citations,
+    // but the user explicitly asked for the latest evidence and the newer trial is
+    // itself high quality (same evidence tier, strong journal, strong relevance).
+    const olderEstablished = paper({
+      title: "Semaglutide cardiovascular outcomes (2019 landmark)",
+      studyType: "rct",
+      evidenceLevel: "II",
+      year: 2019,
+      citationCount: 9000,
+      journal: "N Engl J Med",
+      journalQuartile: "Q1",
+      rerankScore: 0.78,
+    });
+    const newerPivotal = paper({
+      title: "Semaglutide cardiovascular outcomes (2025 trial)",
+      studyType: "rct",
+      evidenceLevel: "II",
+      year: 2025,
+      citationCount: 600,
+      journal: "N Engl J Med",
+      journalQuartile: "Q1",
+      rerankScore: 0.75,
+    });
+    const ranked = rankAndAnnotate([olderEstablished, newerPivotal], {
+      query: "latest semaglutide cardiovascular outcomes 2025",
+      recency: true,
+    });
+    expect(ranked[0].year).toBe(2025);
+  });
+
+  it("still keeps a high-quality landmark above newer LOW-value noise (guard)", () => {
+    const landmark = paper({
+      title: "Landmark trial of drug X",
+      studyType: "rct",
+      evidenceLevel: "II",
+      year: 2022,
+      citationCount: 4000,
+      journal: "NEJM",
+      journalQuartile: "Q1",
+      rerankScore: 0.9,
+    });
+    const newerNoise = paper({
+      title: "Minor commentary mentioning drug X",
+      studyType: "other",
+      evidenceLevel: "V",
+      year: 2026,
+      citationCount: 1,
+      rerankScore: 0.2,
+    });
+    const ranked = rankAndAnnotate([newerNoise, landmark], {
+      query: "latest drug X",
+      recency: true,
+    });
+    expect(ranked[0].title).toBe("Landmark trial of drug X");
+  });
+});
+
+describe("recencyYearFloor — recency-windowed dense lane", () => {
+  it("covers the last N calendar years inclusive", () => {
+    // 2026 with a 3-year window → 2024, so the lane spans 2024/2025/2026.
+    expect(recencyYearFloor(2026, 3)).toBe(2024);
+  });
+
+  it("a 1-year window is the current year only", () => {
+    expect(recencyYearFloor(2026, 1)).toBe(2026);
+  });
+});

--- a/src/lib/search/run-search.ts
+++ b/src/lib/search/run-search.ts
@@ -157,6 +157,21 @@ export const FANOUT_DEADLINE_MS = 5000;
  */
 export const DENSE_RECOVERY_TIMEOUT_MS = 6000;
 
+/** Window (calendar years, inclusive) for the recency-intent dense lane. */
+export const RECENCY_DENSE_WINDOW_YEARS = 3;
+
+/**
+ * Year floor for the recency-windowed dense lane — the start of the last
+ * `windowYears` calendar years (e.g. 2026 with a 3-year window → 2024, so the
+ * lane covers 2024/2025/2026). A separate, year-restricted query over the SAME
+ * owned index surfaces the freshest semantically-relevant papers, which the
+ * unfiltered (similarity-only) dense lane can bury under older high-similarity
+ * hits.
+ */
+export function recencyYearFloor(currentYear: number, windowYears: number): number {
+  return currentYear - windowYears + 1;
+}
+
 // Cap for the post-fusion enrich+rerank pool. Only the top candidates by RRF
 // score can reach the returned page, so bounding both steps here keeps OpenAlex
 // enrichment to a single batch regardless of how many lanes contributed —
@@ -465,6 +480,43 @@ async function runLiteratureSearchUncached(
         errorOutcome("medcpt_dense", e instanceof Error ? e.message : "MedCPT dense failed")
       )
     );
+
+    // Recency intent: an additional recency-WINDOWED dense lane over the same
+    // owned index. The base dense lane ranks purely by semantic similarity, so a
+    // newer pivotal paper can sit below older high-similarity hits; restricting to
+    // the last few years surfaces the freshest semantically-relevant papers into
+    // the pool. RRF-fused and additive — the unfiltered lanes still carry older
+    // landmarks, and the quality ranker still demotes recent junk — so it lifts
+    // recall of fresh evidence without burying landmarks. Throttle-proof (owned
+    // index), gated on recency intent, and only when the caller has not already
+    // constrained the year range. Its reach is bounded by the index snapshot.
+    if (plan.recency && params.yearFrom === undefined) {
+      const recentFloor = recencyYearFloor(
+        new Date().getFullYear(),
+        RECENCY_DENSE_WINDOW_YEARS
+      );
+      pushLane(
+        "medcpt_dense_recent",
+        withSourceTimeout(
+          "MedCPT Dense (recency)",
+          searchMedcptDense(searchQuery, {
+            limit: poolPerSource,
+            yearStart: recentFloor,
+            yearEnd: params.yearTo,
+          }).then(({ results, total, status }) => ({
+            source: "medcpt_dense_recent",
+            results,
+            total,
+            status,
+          }))
+        ).catch((e) =>
+          errorOutcome(
+            "medcpt_dense_recent",
+            e instanceof Error ? e.message : "MedCPT dense recency failed"
+          )
+        )
+      );
+    }
 
     // HyDE / multi-query: each LLM-generated formulation (and the hypothetical
     // abstract) runs as its OWN dense lane against the owned MedCPT index, then


### PR DESCRIPTION
## Cycle 3 of 5 — pulling ahead of Elicit

**Recency.** I started to "strengthen the recency multiplier" — then tested it and found the **ranking is already correct**: a newer pivotal good-quality paper already outranks an older more-cited one under recency intent, while a landmark still beats newer low-value noise. (Both are now locked as regression guards.) So the recency losses are **retrieval freshness**, not ranking — the council notes confirm Manan's pool held *"older SELECT papers"* while the newest pivotal evidence never entered it.

## Fix (retrieval side, throttle-proof)
For recency intent, add a **recency-windowed dense lane** over the same owned MedCPT index (`yearStart` = last 3 calendar years). The base dense lane ranks purely by similarity, so fresh papers sit below older high-similarity hits; the windowed lane surfaces them into the pool.

- **RRF-fused and additive** — the unfiltered lanes still carry older landmarks, and the quality ranker still demotes recent junk (guard test), so it lifts fresh-evidence recall **without burying landmarks**.
- Gated on `plan.recency`, and only when the caller hasn't pinned a year range.
- Throttle-proof (owned index). Reach is bounded by the index snapshot's freshness — **index-refresh cadence is the complementary infra fix**, called out for the backlog.

## Tests
4 unit tests: two recency-ranking guards (proving + locking that ranking is already correct) + `recencyYearFloor` window. Full suite green, no regression; tsc + eslint clean.

## Honest note
Unlike cycles 1–2, this cycle's live effect depends on the MedCPT index containing recent papers. The change is correct and additive regardless; its *magnitude* is gated by index freshness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEgTUohzwMogXKPsWVdwJx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search results can now better prioritize newer, relevant studies when recency is enabled.
  * Added support for a rolling recent-year window so searches can focus on more current literature.

* **Bug Fixes**
  * Improved ranking behavior so newer high-value results can surface above older, more-cited items, while keeping top-quality landmark results ahead of low-value newer noise.
  * Refined year-based filtering to consistently apply the expected inclusive date range for recent searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->