### PR TITLE
feat(search): low-confidence signal for negative-control / ambiguous traps

### DIFF
--- a/src/lib/mcp/__tests__/tools.test.ts
+++ b/src/lib/mcp/__tests__/tools.test.ts
@@ -61,6 +61,7 @@ describe("search_papers tool", () => {
       hasMore: false,
       sourceCounts: { pubmed: 1, openalex: 1 },
       sourceStatuses: { pubmed: { status: "ok" }, openalex: { status: "ok" } },
+      confidence: "ok",
       plan: { pubmedQuery: "TAVR low risk", recency: false, trialAcronyms: [], wantsTrials: false },
     });
   });

--- a/src/lib/search/__tests__/confidence.test.ts
+++ b/src/lib/search/__tests__/confidence.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { assessConfidence, LOW_CONFIDENCE_RELEVANCE } from "../confidence";
+
+describe("assessConfidence", () => {
+  it("reports 'ok' when at least one result is strongly relevant", () => {
+    const results = [{ rerankScore: 0.85 }, { rerankScore: 0.4 }, { rerankScore: 0.1 }];
+    expect(assessConfidence(results)).toBe("ok");
+  });
+
+  it("reports 'low' when even the best result is weakly relevant (trap / no strong match)", () => {
+    // A negative-control or ambiguous query where nothing clears the relevance bar.
+    const results = [{ rerankScore: 0.18 }, { rerankScore: 0.12 }, { rerankScore: 0.05 }];
+    expect(assessConfidence(results)).toBe("low");
+  });
+
+  it("does NOT assert low confidence when there is no relevance signal at all", () => {
+    // rerank is skipped for some lookups (e.g. trial-acronym); absence of a signal
+    // is not evidence of a weak match — never cry wolf.
+    const results = [{}, {}, {}];
+    expect(assessConfidence(results)).toBe("ok");
+  });
+
+  it("treats the boundary as not-low (>= floor is ok)", () => {
+    expect(assessConfidence([{ rerankScore: LOW_CONFIDENCE_RELEVANCE }])).toBe("ok");
+  });
+
+  it("returns 'ok' for an empty result set (no claim either way)", () => {
+    expect(assessConfidence([])).toBe("ok");
+  });
+
+  it("respects a custom floor", () => {
+    expect(assessConfidence([{ rerankScore: 0.45 }], 0.5)).toBe("low");
+    expect(assessConfidence([{ rerankScore: 0.55 }], 0.5)).toBe("ok");
+  });
+});

--- a/src/lib/search/confidence.ts
+++ b/src/lib/search/confidence.ts
@@ -1,0 +1,36 @@
+/**
+ * Retrieval confidence signal.
+ *
+ * Dense retrieval always returns SOMETHING, so for a negative-control query
+ * ("KEYNOTE trials for heart failure") or an ambiguous acronym it can present a
+ * confident-looking page of tangential hits. The cross-encoder relevance score
+ * (rerankScore, 0-1) is the honest measure of how well the BEST result actually
+ * matches the query: when even the top result is weakly relevant, we mark the
+ * result set low-confidence so the UI can say "no strong match — these may be
+ * tangential" instead of over-committing to a wrong answer.
+ *
+ * This is a pure, additive signal — it does not reorder or drop anything.
+ */
+
+/** Below this top relevance, no result is a strong match for the query. */
+export const LOW_CONFIDENCE_RELEVANCE = 0.3;
+
+export type Confidence = "ok" | "low";
+
+/**
+ * Assess whether a ranked result set has a strong match. Returns "low" only when
+ * a relevance signal exists AND even the best result falls below `floor`. Absent
+ * any rerankScore (e.g. rerank skipped for a trial-acronym lookup) we never assert
+ * low confidence — silence is not evidence of a weak match.
+ */
+export function assessConfidence(
+  results: readonly { rerankScore?: number }[],
+  floor: number = LOW_CONFIDENCE_RELEVANCE
+): Confidence {
+  const scores = results
+    .map((r) => r.rerankScore)
+    .filter((s): s is number => typeof s === "number");
+  if (scores.length === 0) return "ok";
+  const best = Math.max(...scores);
+  return best < floor ? "low" : "ok";
+}

--- a/src/lib/search/run-search.ts
+++ b/src/lib/search/run-search.ts
@@ -32,6 +32,7 @@ import {
 } from "@/lib/search/hyde";
 import { okStatus, type SourceStatus } from "@/lib/search/source-status";
 import { isTransientEmpty } from "@/lib/search/transient-empty";
+import { assessConfidence, type Confidence } from "@/lib/search/confidence";
 import type { UnifiedSearchResult } from "@/types/search";
 
 export const SEARCH_SOURCES = ["pubmed", "semantic_scholar", "openalex"] as const;
@@ -108,6 +109,12 @@ export interface LiteratureSearchResult {
    * distinguish "source down" from "genuinely nothing found".
    */
   sourceStatuses: Record<string, SourceStatus>;
+  /**
+   * Whether any result is a strong match. "low" when even the top result is only
+   * weakly relevant (negative-control / ambiguous-acronym traps), so the UI can
+   * say "no strong match" instead of over-committing. Additive — never reorders.
+   */
+  confidence: Confidence;
   /** The retrieval plan used (sort strategy, expansions, trial detection). */
   plan: {
     pubmedQuery: string;
@@ -721,6 +728,7 @@ async function runLiteratureSearchUncached(
     hasMore: filtered.length > perPage,
     sourceCounts,
     sourceStatuses,
+    confidence: assessConfidence(pageResults),
     plan: {
       pubmedQuery: pmPrimary,
       recency: plan.recency,


### PR DESCRIPTION
## Cycle 4 of 5 — pulling ahead of Elicit

**Negative-control / ambiguous-acronym — done honestly.** Dense retrieval always returns *something*, so a negative-control query ("KEYNOTE trials for heart failure") or an ambiguous acronym can present a confident-looking page of tangential hits.

I evaluated the reorder-based fixes (cross-domain demotion table, acronym→sense MMR) and **deferred them**: they'd risk regressing the 80+ legitimate queries — "metformin in cancer" is a *real* cross-domain topic — to win 3–4 intentional trap queries, and they need a domain ontology to be safe. Bad trade.

The safe, genuinely-useful piece (and your stated ask — *"a low-confidence / no-strong-match signal so dense retrieval stops over-committing"*) is the **confidence signal**.

## Changes
- `assessConfidence(results)` → `"low"` when a relevance signal exists **and** even the top `rerankScore` is below `LOW_CONFIDENCE_RELEVANCE` (0.3); `"ok"` otherwise. Never cries wolf when no rerank signal is present (trial-acronym lookups skip rerank).
- `LiteratureSearchResult.confidence` surfaces it at the query level so the UI can say *"no strong match — these may be tangential."*
- **Pure and additive** — reorders/drops nothing → **zero regression risk**.

## Tests
6 unit tests (strong match → ok, all-weak → low, no-signal → ok, boundary, empty, custom floor). Full search + MCP suites green; tsc + eslint clean. (One MCP fixture updated to include the new required field — fixture parity, not a weakened assertion.)

## Follow-up
UI surfacing of the `confidence` flag in the results header is a small front-end follow-up; this PR makes the signal available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEgTUohzwMogXKPsWVdwJx