### PR TITLE
feat(search): federate discussions tab across Reddit/HN/StackExchange (CYCLE 0+1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,3 +21,31 @@ ScholarSync is an AI-powered academic writing platform expanding from medicine-o
 - Run existing tests after every change
 - Reference parent PRD issue in commits
 - Each issue should be independently demoable when complete
+
+## Non-academic search federation (web/news/discussions)
+- The academic engine (`run-search.ts`, academic sources, the `tab=academic`/no-param
+  GET branch) is OFF-LIMITS. Non-academic work lives ONLY in
+  `fetchNonAcademicResults`/`fetchFederatedNonAcademicResults` (`route.ts`), new
+  `src/lib/search/sources/*`, and `src/lib/search/web/*`. The medical default is the
+  non-federated path and stays unchanged.
+- `src/lib/search/web/federate.ts` fans a query across a per-tab `SOURCES_BY_TAB` set,
+  fail-open + per-source timeout, then RRF-fuses on **canonical URL**
+  (`rank-fusion-web.ts`) — NOT the academic `isSamePaper` (it keys on DOI/PMID/title+year,
+  which URL-only web rows lack). A single source short-circuits to passthrough, so a
+  SearXNG-only federation is byte-identical to the legacy single-source path.
+- Discussions sources: Reddit, HN (Algolia), Stack Exchange — all FREE/keyless, each its
+  own circuit breaker + `resilientFetch`, returns `UnifiedSearchResult[]` `sources:["discussions"]`.
+  SearXNG `social media` is intentionally NOT fused into discussions (fediverse noise:
+  lemmy/mastodon, no Reddit/HN/SE; measured a wash and the council penalizes it).
+- Gotcha — discussion APIs AND-match terse titles, so verbose NL queries return zero. Fixes:
+  `toKeywordQuery` (`web/query-terms.ts`) strips format/function words; HN also needs
+  `removeWordsIfNoResults=allOptional`.
+- Reddit blocks datacenter egress IPs (HTTP 403) regardless of User-Agent; there is no
+  Reddit OAuth credential in the vault. The adapter is fail-open and reads
+  `REDDIT_OAUTH_TOKEN` if present — until prod has a non-blocked IP or that token, Reddit
+  contributes nothing and reddit.com gold queries stay unmatched.
+- Eval: `eval/web-search/capture-providers.ts` freezes the FUSED pool into the same
+  `cache/<tab>-<hash>.json` shape `run.ts` replays (`--providers searxng` reproduces the
+  SearXNG-only baseline — the CYCLE 0 faithfulness check). Layer 1 (`run.ts`, deterministic,
+  no Cohere) gates the paid blinded council (`council/`); cache/runs/council/exa are
+  measurement artifacts, not committed.

--- a/eval/web-search/__tests__/capture-providers.test.ts
+++ b/eval/web-search/__tests__/capture-providers.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mkdtempSync, readFileSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { UnifiedSearchResult } from "@/types/search";
+
+const { mockFederateWith } = vi.hoisted(() => ({ mockFederateWith: vi.fn() }));
+
+vi.mock("@/lib/search/web/federate", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/search/web/federate")>();
+  return { ...actual, federateWith: mockFederateWith };
+});
+
+import { captureProviders } from "../capture-providers";
+import type { WebBenchmarkQuery } from "../types";
+
+function row(url: string, title: string): UnifiedSearchResult {
+  return { title, authors: [], journal: "", year: 0, url, sources: ["discussions"], citationCount: 0, publicationTypes: ["discussions"], isOpenAccess: false };
+}
+
+describe("captureProviders", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("freezes the fused pool with a per-row provider tag and provider list", async () => {
+    const hn = row("https://news.ycombinator.com/item?id=1", "thread");
+    const se = row("https://stats.stackexchange.com/q/2", "question");
+    mockFederateWith.mockResolvedValue({
+      results: [hn, se],
+      perSource: [],
+      perSourceRows: [
+        { id: "hacker-news", results: [hn] },
+        { id: "stackexchange", results: [se] },
+      ],
+      degraded: false,
+    });
+
+    const dir = mkdtempSync(join(tmpdir(), "providers-"));
+    const queries: WebBenchmarkQuery[] = [
+      { id: "disc-x", tab: "discussions", queryClass: "methodology", query: "peer review", intent: "", recencyBiased: false, mustHaves: [{ label: "a", domain: "reddit.com", rule: "consensus" }] },
+    ];
+
+    const n = await captureProviders(queries, dir, null, 0);
+    expect(n).toBe(1);
+
+    const files = readdirSync(dir).filter((f) => f.endsWith(".json"));
+    expect(files).toHaveLength(1);
+    const body = JSON.parse(readFileSync(join(dir, files[0]), "utf8"));
+    expect(body.tab).toBe("discussions");
+    expect(body.results).toHaveLength(2);
+    expect(body.results[0].provider).toBe("hacker-news");
+    expect(body.results[1].provider).toBe("stackexchange");
+    // provider list reflects the full discussions source set
+    expect(body.providers).toContain("hacker-news");
+  });
+
+  it("skips (does not freeze) a degraded federation", async () => {
+    mockFederateWith.mockResolvedValue({ results: [], perSource: [], perSourceRows: [], degraded: true });
+    const dir = mkdtempSync(join(tmpdir(), "providers-"));
+    const queries: WebBenchmarkQuery[] = [
+      { id: "disc-y", tab: "discussions", queryClass: "niche", query: "x", intent: "", recencyBiased: false, mustHaves: [] },
+    ];
+    const n = await captureProviders(queries, dir, null, 0);
+    expect(n).toBe(0);
+    expect(readdirSync(dir).filter((f) => f.endsWith(".json"))).toHaveLength(0);
+  });
+});

--- a/eval/web-search/capture-providers.ts
+++ b/eval/web-search/capture-providers.ts
@@ -1,0 +1,96 @@
+/**
+ * Federation-aware pool capture (CYCLE 0). Freezes the FUSED multi-source pool
+ * for each benchmark query into the same eval/web-search/cache/<tab>-<hash>.json
+ * shape run.ts already replays — so the deterministic scorer sees the federated
+ * pool, not a single SearXNG category. Each frozen row carries a debug-only
+ * `provider` tag (which source(s) contributed it); run.ts/metrics.ts ignore it.
+ *
+ * Faithful superset: with SearXNG as the only configured provider
+ * (`--providers searxng`), the single-source federation passes through
+ * unchanged, so re-freezing + run.ts reproduces the SearXNG-only baseline.
+ *
+ *   SEARXNG_URL=... npx tsx eval/web-search/capture-providers.ts                 # full federation
+ *   SEARXNG_URL=... npx tsx eval/web-search/capture-providers.ts --providers searxng  # CYCLE 0 check
+ */
+import { writeFileSync, mkdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  federateWith,
+  SOURCES_BY_TAB,
+  searxngSourceForTab,
+  type WebSource,
+  type FederatedTab,
+} from "@/lib/search/web/federate";
+import { canonicalUrl } from "@/lib/search/web/canonical-url";
+import { BENCHMARK_QUERIES } from "./queries";
+import { cacheKey } from "./capture-searxng";
+import type { UnifiedSearchResult } from "@/types/search";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CACHE_DIR = join(HERE, "cache");
+
+function sourcesForTab(tab: FederatedTab, providerFilter: string | null): WebSource[] {
+  if (providerFilter === "searxng") return [searxngSourceForTab(tab)];
+  return SOURCES_BY_TAB[tab];
+}
+
+function providerTag(row: UnifiedSearchResult, perSourceRows: Array<{ id: string; results: UnifiedSearchResult[] }>): string {
+  const key = row.url ? canonicalUrl(row.url) : `title:${row.title.toLowerCase().trim()}`;
+  const ids: string[] = [];
+  for (const ps of perSourceRows) {
+    const hit = ps.results.some((r) => (r.url ? canonicalUrl(r.url) : `title:${r.title.toLowerCase().trim()}`) === key);
+    if (hit) ids.push(ps.id);
+  }
+  return ids.join("+");
+}
+
+export async function captureProviders(
+  queries: typeof BENCHMARK_QUERIES,
+  dir: string,
+  providerFilter: string | null,
+  delayMs = 600
+): Promise<number> {
+  mkdirSync(dir, { recursive: true });
+  let ok = 0;
+  for (const q of queries) {
+    const sources = sourcesForTab(q.tab, providerFilter);
+    const fed = await federateWith(q.query, q.tab, sources, { limit: 30 });
+    if (fed.degraded) {
+      console.log(`  ✗ ${q.id.padEnd(34)} federation degraded — skipped (do not freeze a degraded pool)`);
+      continue;
+    }
+    const results = fed.results.map((r) => ({ ...r, provider: providerTag(r, fed.perSourceRows) }));
+    const body = {
+      tab: q.tab,
+      query: q.query,
+      capturedAt: "FROZEN",
+      providers: sources.map((s) => s.id),
+      results,
+    };
+    writeFileSync(join(dir, cacheKey(q.tab, q.query)), JSON.stringify(body, null, 2));
+    ok++;
+    const counts = fed.perSource.map((s) => `${s.id}:${s.count}`).join(" ");
+    console.log(`  ✓ ${q.id.padEnd(34)} ${fed.results.length} fused (${counts})`);
+    await new Promise((r) => setTimeout(r, delayMs));
+  }
+  return ok;
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  const pi = argv.indexOf("--providers");
+  const providerFilter = pi >= 0 ? argv[pi + 1] : null;
+  const n = await captureProviders(BENCHMARK_QUERIES, CACHE_DIR, providerFilter);
+  console.log(
+    `\n[providers] froze ${n}/${BENCHMARK_QUERIES.length} fused pools → ${CACHE_DIR}` +
+      (providerFilter ? ` (providers=${providerFilter})` : "")
+  );
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((e) => {
+    console.error("[providers] fatal:", e);
+    process.exit(1);
+  });
+}

--- a/src/app/api/search/unified/__tests__/route.test.ts
+++ b/src/app/api/search/unified/__tests__/route.test.ts
@@ -10,6 +10,7 @@ const mockSearchSemanticScholar = vi.hoisted(() => vi.fn());
 const mockSearchOpenAlex = vi.hoisted(() => vi.fn());
 const mockSearchClinicalTrials = vi.hoisted(() => vi.fn());
 const mockSearchSearXNG = vi.hoisted(() => vi.fn());
+const mockFederateNonAcademic = vi.hoisted(() => vi.fn());
 const mockReciprocalRankFusion = vi.hoisted(() => vi.fn());
 const mockRerankResults = vi.hoisted(() => vi.fn());
 const mockAugmentQuery = vi.hoisted(() => vi.fn());
@@ -65,6 +66,10 @@ vi.mock("@/lib/search/sources/clinical-trials", () => ({
 
 vi.mock("@/lib/search/sources/searxng", () => ({
   searchSearXNG: mockSearchSearXNG,
+}));
+
+vi.mock("@/lib/search/web/federate", () => ({
+  federateNonAcademic: mockFederateNonAcademic,
 }));
 
 vi.mock("@/lib/search/rank-fusion", () => ({
@@ -150,6 +155,27 @@ describe("GET /api/search/unified", () => {
         },
       ],
       total: 1,
+      degraded: false,
+    });
+
+    mockFederateNonAcademic.mockResolvedValue({
+      results: [
+        {
+          title: "Peer review reform megathread",
+          authors: [],
+          journal: "r/AskAcademia",
+          year: 2025,
+          abstract: "Community discussion",
+          citationCount: 0,
+          publicationTypes: ["discussions"],
+          isOpenAccess: false,
+          sources: ["discussions"],
+          url: "https://www.reddit.com/r/AskAcademia/comments/abc/thread/",
+          domain: "reddit.com",
+        },
+      ],
+      perSource: [],
+      perSourceRows: [],
       degraded: false,
     });
 
@@ -268,16 +294,38 @@ describe("GET /api/search/unified", () => {
     expect(body.sourceCounts).toEqual({ web: 57 });
   });
 
-  it("routes the discussions tab through SearXNG social-media search", async () => {
+  it("routes the discussions tab through the multi-source federation, not SearXNG", async () => {
     const res = await GET(
       makeRequest({ q: "climate change", tab: "discussions" })
     );
+    const body = await res.json();
 
     expect(res.status).toBe(200);
-    expect(mockSearchSearXNG).toHaveBeenCalledWith("climate change", {
-      category: "social media",
-      limit: 20,
+    expect(mockFederateNonAcademic).toHaveBeenCalledWith(
+      "climate change",
+      "discussions",
+      expect.objectContaining({ limit: 100 })
+    );
+    // Discussions no longer routes through SearXNG social-media (federation owns it).
+    expect(mockSearchSearXNG).not.toHaveBeenCalled();
+    expect(body.results[0].domain).toBe("reddit.com");
+    expect(body.sourceCounts).toEqual({ discussions: 1 });
+  });
+
+  it("surfaces federation degradation as searxngUnavailable on the discussions tab", async () => {
+    mockFederateNonAcademic.mockResolvedValueOnce({
+      results: [],
+      perSource: [],
+      perSourceRows: [],
+      degraded: true,
     });
+
+    const res = await GET(makeRequest({ q: "climate change", tab: "discussions" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.results).toEqual([]);
+    expect(body.searxngUnavailable).toBe(true);
   });
 
   it("returns empty results with a degradation flag when SearXNG is unavailable", async () => {

--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -6,6 +6,7 @@ import { searchOpenAlex } from "@/lib/search/sources/openalex";
 import { searchClinicalTrials } from "@/lib/search/sources/clinical-trials";
 import { searchArxiv } from "@/lib/search/sources/arxiv";
 import { searchSearXNG, type SearXNGCategory } from "@/lib/search/sources/searxng";
+import { federateNonAcademic } from "@/lib/search/web/federate";
 import { reciprocalRankFusion } from "@/lib/search/rank-fusion";
 import { rerankResults } from "@/lib/search/rerank";
 import { getDomainEvidenceLevel } from "@/lib/search/evidence-level";
@@ -277,6 +278,45 @@ async function fetchNonAcademicResults(
   };
 }
 
+/** Tabs served by the multi-source federation rather than a single SearXNG call. */
+const FEDERATED_TABS = new Set<SearchTab>(["discussions"]);
+
+/**
+ * Federated non-academic path: fan out across the tab's source set, RRF-fuse on
+ * canonical URL, then run the SAME quality layer (Cohere rerank + domain
+ * preferences) the single-source path uses. The fused pool is already the full
+ * available set, so there is no incremental re-fetch loop — we page over it.
+ */
+async function fetchFederatedNonAcademicResults(
+  query: string,
+  tab: "web" | "news" | "discussions",
+  page: number,
+  perPage: number,
+  preferences: Awaited<ReturnType<typeof getDomainPreferences>>,
+  timeRange?: "24h" | "week" | "month" | "year"
+): Promise<{
+  results: UnifiedSearchResult[];
+  total: number;
+  hasMore: boolean;
+  degraded: boolean;
+}> {
+  const federation = await federateNonAcademic(query, tab, {
+    limit: MAX_NON_ACADEMIC_RESULTS,
+    timeRange,
+  });
+  const reranked = await rerankResults(query, federation.results);
+  const ranked = applyDomainPreferences(reranked, preferences);
+
+  const start = page * perPage;
+  const paged = ranked.slice(start, start + perPage);
+  return {
+    results: paged,
+    total: ranked.length,
+    hasMore: ranked.length > start + perPage,
+    degraded: federation.degraded,
+  };
+}
+
 export async function GET(req: Request) {
   const log = logger.withRequestId();
 
@@ -362,14 +402,23 @@ export async function GET(req: Request) {
         total: visibleTotal,
         hasMore,
         degraded,
-      } = await fetchNonAcademicResults(
-        effectiveQuery,
-        category,
-        page,
-        perPage,
-        userDomainPreferences,
-        timeRange as "24h" | "week" | "month" | "year" | undefined
-      );
+      } = FEDERATED_TABS.has(tabParam)
+        ? await fetchFederatedNonAcademicResults(
+            effectiveQuery,
+            tabParam,
+            page,
+            perPage,
+            userDomainPreferences,
+            timeRange as "24h" | "week" | "month" | "year" | undefined
+          )
+        : await fetchNonAcademicResults(
+            effectiveQuery,
+            category,
+            page,
+            perPage,
+            userDomainPreferences,
+            timeRange as "24h" | "week" | "month" | "year" | undefined
+          );
 
       // Apply scope domain constraints if a custom scope is active
       let scopeFilteredResults = paged;

--- a/src/lib/search/sources/__tests__/hacker-news.test.ts
+++ b/src/lib/search/sources/__tests__/hacker-news.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockBreaker, mockResilientFetch } = vi.hoisted(() => ({
+  mockBreaker: { canRequest: vi.fn(() => true), onSuccess: vi.fn(), onFailure: vi.fn() },
+  mockResilientFetch: vi.fn(),
+}));
+
+vi.mock("@/lib/http/resilient-fetch", () => ({ resilientFetch: mockResilientFetch }));
+vi.mock("@/lib/http/circuit-breaker", () => ({ createCircuitBreaker: vi.fn(() => mockBreaker) }));
+
+import { searchHackerNews } from "../hacker-news";
+
+function mockJson(data: unknown) {
+  mockResilientFetch.mockResolvedValue({ json: () => Promise.resolve(data) } as Response);
+}
+
+describe("searchHackerNews", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBreaker.canRequest.mockReturnValue(true);
+  });
+
+  it("maps HN stories to discussion threads on news.ycombinator.com", async () => {
+    mockJson({
+      nbHits: 2,
+      hits: [
+        { objectID: "111", title: "Peer review is broken", url: "https://blog.example.com/x", points: 583, num_comments: 337, author: "alice", created_at: "2023-08-06T12:33:24Z" },
+        { objectID: "222", title: "Ask HN: preprints?", url: null, points: 12, num_comments: 4, author: "bob", created_at: "2024-01-02T00:00:00Z" },
+      ],
+    });
+
+    const res = await searchHackerNews("peer review", { limit: 10 });
+
+    expect(res.status.status).toBe("ok");
+    expect(res.results).toHaveLength(2);
+    expect(res.results[0]).toMatchObject({
+      title: "Peer review is broken",
+      url: "https://news.ycombinator.com/item?id=111",
+      domain: "news.ycombinator.com",
+      platform: "Hacker News",
+      engagement: "583 points · 337 comments",
+      sources: ["discussions"],
+      trustTier: "community",
+      year: 2023,
+    });
+    expect(res.results[1].url).toBe("https://news.ycombinator.com/item?id=222");
+  });
+
+  it("is fail-open on fetch error (empty + non-ok status, never throws)", async () => {
+    mockResilientFetch.mockRejectedValue(new Error("[HackerNews] Request timed out after 8000ms"));
+    const res = await searchHackerNews("anything");
+    expect(res.results).toEqual([]);
+    expect(res.total).toBe(0);
+    expect(res.status.status).not.toBe("ok");
+    expect(mockBreaker.onFailure).toHaveBeenCalledTimes(1);
+  });
+
+  it("is fail-open when the circuit breaker is open", async () => {
+    mockBreaker.canRequest.mockReturnValue(false);
+    const res = await searchHackerNews("anything");
+    expect(res.results).toEqual([]);
+    expect(res.status.status).toBe("error");
+    expect(mockResilientFetch).not.toHaveBeenCalled();
+  });
+
+  it("drops hits with no title or objectID", async () => {
+    mockJson({ hits: [{ objectID: "", title: "no id", url: null }, { objectID: "9", title: "", url: null }] });
+    const res = await searchHackerNews("x");
+    expect(res.results).toEqual([]);
+  });
+});

--- a/src/lib/search/sources/__tests__/reddit.test.ts
+++ b/src/lib/search/sources/__tests__/reddit.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockBreaker, mockResilientFetch } = vi.hoisted(() => ({
+  mockBreaker: { canRequest: vi.fn(() => true), onSuccess: vi.fn(), onFailure: vi.fn() },
+  mockResilientFetch: vi.fn(),
+}));
+
+vi.mock("@/lib/http/resilient-fetch", () => ({ resilientFetch: mockResilientFetch }));
+vi.mock("@/lib/http/circuit-breaker", () => ({ createCircuitBreaker: vi.fn(() => mockBreaker) }));
+
+import { searchReddit } from "../reddit";
+
+function mockChildren(children: unknown[]) {
+  mockResilientFetch.mockResolvedValue({
+    json: () => Promise.resolve({ data: { children } }),
+  } as Response);
+}
+
+describe("searchReddit", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBreaker.canRequest.mockReturnValue(true);
+    delete process.env.REDDIT_OAUTH_TOKEN;
+  });
+
+  it("maps Reddit threads to reddit.com results", async () => {
+    mockChildren([
+      { data: { title: "PhD burnout", permalink: "/r/PhD/comments/abc/phd_burnout/", subreddit: "PhD", score: 240, num_comments: 88, created_utc: 1704153600, selftext: "  long  text " } },
+    ]);
+    const res = await searchReddit("phd burnout", { limit: 10 });
+    expect(res.status.status).toBe("ok");
+    expect(res.results[0]).toMatchObject({
+      title: "PhD burnout",
+      url: "https://www.reddit.com/r/PhD/comments/abc/phd_burnout/",
+      domain: "reddit.com",
+      community: "r/PhD",
+      engagement: "240 upvotes · 88 comments",
+      sources: ["discussions"],
+      trustTier: "community",
+    });
+  });
+
+  it("filters out NSFW threads", async () => {
+    mockChildren([{ data: { title: "x", permalink: "/r/x/1/", subreddit: "x", over_18: true } }]);
+    const res = await searchReddit("x");
+    expect(res.results).toEqual([]);
+  });
+
+  it("is fail-open on a 403 block (empty + non-ok, never throws)", async () => {
+    mockResilientFetch.mockRejectedValue(new Error("[Reddit] HTTP 403"));
+    const res = await searchReddit("anything");
+    expect(res.results).toEqual([]);
+    expect(res.total).toBe(0);
+    expect(res.status.status).not.toBe("ok");
+    expect(mockBreaker.onFailure).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the OAuth endpoint + bearer header when REDDIT_OAUTH_TOKEN is set", async () => {
+    process.env.REDDIT_OAUTH_TOKEN = "tok";
+    mockChildren([]);
+    await searchReddit("q");
+    const [url, init] = mockResilientFetch.mock.calls[0];
+    expect(url).toContain("oauth.reddit.com/search");
+    expect((init as RequestInit).headers).toMatchObject({ Authorization: "Bearer tok" });
+  });
+
+  it("is fail-open when the circuit breaker is open", async () => {
+    mockBreaker.canRequest.mockReturnValue(false);
+    const res = await searchReddit("q");
+    expect(res.results).toEqual([]);
+    expect(res.status.status).toBe("error");
+    expect(mockResilientFetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/search/sources/__tests__/stackexchange.test.ts
+++ b/src/lib/search/sources/__tests__/stackexchange.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockBreaker, mockResilientFetch } = vi.hoisted(() => ({
+  mockBreaker: { canRequest: vi.fn(() => true), onSuccess: vi.fn(), onFailure: vi.fn() },
+  mockResilientFetch: vi.fn(),
+}));
+
+vi.mock("@/lib/http/resilient-fetch", () => ({ resilientFetch: mockResilientFetch }));
+vi.mock("@/lib/http/circuit-breaker", () => ({ createCircuitBreaker: vi.fn(() => mockBreaker) }));
+
+import { searchStackExchange } from "../stackexchange";
+
+function mockItems(items: unknown[]) {
+  mockResilientFetch.mockResolvedValue({ json: () => Promise.resolve({ items }) } as Response);
+}
+
+describe("searchStackExchange", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBreaker.canRequest.mockReturnValue(true);
+  });
+
+  it("maps SE questions, decoding HTML entities in titles", async () => {
+    mockItems([
+      { title: "Should we abandon &quot;significance&quot;?", link: "https://stats.stackexchange.com/questions/1/x", score: 5, answer_count: 2, creation_date: 1731395782 },
+    ]);
+    const res = await searchStackExchange("significance", { sites: [{ site: "stats", label: "Cross Validated" }] });
+    expect(res.status.status).toBe("ok");
+    expect(res.results[0]).toMatchObject({
+      title: 'Should we abandon "significance"?',
+      url: "https://stats.stackexchange.com/questions/1/x",
+      domain: "stats.stackexchange.com",
+      platform: "Stack Exchange",
+      community: "Cross Validated",
+      engagement: "5 votes · 2 answers",
+      sources: ["discussions"],
+      trustTier: "community",
+    });
+  });
+
+  it("merges results across multiple sites, fail-open if one site fails", async () => {
+    mockResilientFetch
+      .mockResolvedValueOnce({ json: () => Promise.resolve({ items: [{ title: "stats q", link: "https://stats.stackexchange.com/q/1" }] }) } as Response)
+      .mockRejectedValueOnce(new Error("[StackExchange] HTTP 400"));
+    const res = await searchStackExchange("q", {
+      sites: [{ site: "stats", label: "Cross Validated" }, { site: "academia", label: "Academia" }],
+    });
+    // one site fulfilled -> ok, partial results returned (never throws)
+    expect(res.status.status).toBe("ok");
+    expect(res.results).toHaveLength(1);
+  });
+
+  it("is fail-open when ALL sites fail", async () => {
+    mockResilientFetch.mockRejectedValue(new Error("[StackExchange] HTTP 500"));
+    const res = await searchStackExchange("q", {
+      sites: [{ site: "stats", label: "Cross Validated" }, { site: "academia", label: "Academia" }],
+    });
+    expect(res.results).toEqual([]);
+    expect(res.status.status).not.toBe("ok");
+    expect(mockBreaker.onFailure).toHaveBeenCalledTimes(1);
+  });
+
+  it("is fail-open when the circuit breaker is open", async () => {
+    mockBreaker.canRequest.mockReturnValue(false);
+    const res = await searchStackExchange("q");
+    expect(res.results).toEqual([]);
+    expect(res.status.status).toBe("error");
+    expect(mockResilientFetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/search/sources/hacker-news.ts
+++ b/src/lib/search/sources/hacker-news.ts
@@ -1,0 +1,110 @@
+/**
+ * Hacker News discussions source via the public HN Algolia search API
+ * (https://hn.algolia.com/api — no key required). Returns real HN story
+ * threads as UnifiedSearchResult[] tagged sources:["discussions"].
+ *
+ * Fail-open: on any error / circuit-open it returns an empty, non-ok status so
+ * a down source can never zero the discussions tab.
+ */
+import type { UnifiedSearchResult } from "@/types/search";
+import { resilientFetch } from "@/lib/http/resilient-fetch";
+import { createCircuitBreaker } from "@/lib/http/circuit-breaker";
+import { classifyFetchError, okStatus, type SourceStatus } from "@/lib/search/source-status";
+import { toKeywordQuery } from "@/lib/search/web/query-terms";
+
+const breaker = createCircuitBreaker({ service: "HackerNews", failureThreshold: 5 });
+
+const HN_SEARCH_URL = "https://hn.algolia.com/api/v1/search";
+const HN_ITEM_BASE = "https://news.ycombinator.com/item?id=";
+
+interface HnHit {
+  objectID: string;
+  title: string | null;
+  url: string | null;
+  points: number | null;
+  num_comments: number | null;
+  author: string | null;
+  created_at: string | null;
+}
+
+interface HnResponse {
+  hits?: HnHit[];
+  nbHits?: number;
+}
+
+function yearOf(date: string | null | undefined): number {
+  if (!date) return 0;
+  const m = date.match(/(\d{4})/);
+  return m ? parseInt(m[1], 10) : 0;
+}
+
+function formatEngagement(hit: HnHit): string | undefined {
+  const parts: string[] = [];
+  if (typeof hit.points === "number") parts.push(`${hit.points} points`);
+  if (typeof hit.num_comments === "number") parts.push(`${hit.num_comments} comments`);
+  return parts.length ? parts.join(" · ") : undefined;
+}
+
+function toUnified(hit: HnHit): UnifiedSearchResult | null {
+  const title = (hit.title ?? "").trim();
+  if (!title || !hit.objectID) return null;
+  // The discussion thread itself lives on news.ycombinator.com; that is the
+  // canonical result for the discussions tab (the linked article, if any, is
+  // surfaced via the web tab instead).
+  const threadUrl = `${HN_ITEM_BASE}${hit.objectID}`;
+  const publishedAt = hit.created_at ?? undefined;
+  return {
+    title,
+    authors: hit.author ? [hit.author] : [],
+    journal: "Hacker News",
+    url: threadUrl,
+    domain: "news.ycombinator.com",
+    year: yearOf(hit.created_at),
+    publishedAt,
+    sourceLabel: "Hacker News",
+    platform: "Hacker News",
+    community: hit.url ? (() => { try { return new URL(hit.url!).hostname.replace(/^www\./, ""); } catch { return undefined; } })() : undefined,
+    engagement: formatEngagement(hit),
+    abstract: undefined,
+    citationCount: 0,
+    publicationTypes: ["discussions"],
+    isOpenAccess: false,
+    sources: ["discussions"],
+    trustTier: "community",
+  };
+}
+
+export async function searchHackerNews(
+  query: string,
+  options: { limit?: number } = {}
+): Promise<{ results: UnifiedSearchResult[]; total: number; status: SourceStatus }> {
+  if (!breaker.canRequest()) {
+    return { results: [], total: 0, status: { status: "error", message: "Circuit breaker open — recent Hacker News failures" } };
+  }
+  const limit = Math.min(Math.max(options.limit ?? 25, 1), 50);
+  const url = new URL(HN_SEARCH_URL);
+  url.searchParams.set("query", toKeywordQuery(query));
+  url.searchParams.set("tags", "story");
+  url.searchParams.set("hitsPerPage", String(limit));
+  // Verbose queries AND-match to zero on the title index; fall back to treating
+  // all words as optional (relevance-ranked) so real threads still surface.
+  url.searchParams.set("removeWordsIfNoResults", "allOptional");
+
+  try {
+    const res = await resilientFetch(url.toString(), undefined, {
+      service: "HackerNews",
+      timeout: 8000,
+      baseDelay: 400,
+      maxRetries: 1,
+    });
+    const data: HnResponse = await res.json();
+    breaker.onSuccess();
+    const results = (data.hits ?? [])
+      .map(toUnified)
+      .filter((r): r is UnifiedSearchResult => r !== null);
+    return { results, total: data.nbHits ?? results.length, status: okStatus() };
+  } catch (error) {
+    breaker.onFailure();
+    return { results: [], total: 0, status: classifyFetchError(error) };
+  }
+}

--- a/src/lib/search/sources/reddit.ts
+++ b/src/lib/search/sources/reddit.ts
@@ -1,0 +1,117 @@
+/**
+ * Reddit discussions source via the public listing JSON endpoint
+ * (https://www.reddit.com/search.json — no key required). Returns real Reddit
+ * threads as UnifiedSearchResult[] tagged sources:["discussions"].
+ *
+ * Fail-open: on any error / circuit-open it returns an empty, non-ok status so
+ * a down source can never zero the discussions tab.
+ *
+ * NOTE: Reddit aggressively rate-limits / blocks (HTTP 403) requests from
+ * datacenter IP ranges regardless of User-Agent. Where the serving egress IP is
+ * blocked, set REDDIT_OAUTH_TOKEN (a bearer token from a registered script app)
+ * to route through oauth.reddit.com instead; the source stays fail-open either
+ * way.
+ */
+import type { UnifiedSearchResult } from "@/types/search";
+import { resilientFetch } from "@/lib/http/resilient-fetch";
+import { createCircuitBreaker } from "@/lib/http/circuit-breaker";
+import { classifyFetchError, okStatus, type SourceStatus } from "@/lib/search/source-status";
+import { toKeywordQuery } from "@/lib/search/web/query-terms";
+
+const breaker = createCircuitBreaker({ service: "Reddit", failureThreshold: 5 });
+
+const USER_AGENT = "ScholarSync/1.0 (academic discussions search)";
+
+interface RedditChild {
+  data: {
+    title: string;
+    permalink: string;
+    subreddit: string;
+    score?: number;
+    num_comments?: number;
+    created_utc?: number;
+    selftext?: string;
+    over_18?: boolean;
+  };
+}
+
+interface RedditResponse {
+  data?: { children?: RedditChild[] };
+}
+
+function endpoint(): { url: string; headers: Record<string, string> } {
+  const token = process.env.REDDIT_OAUTH_TOKEN;
+  if (token) {
+    return {
+      url: "https://oauth.reddit.com/search",
+      headers: { "User-Agent": USER_AGENT, Authorization: `Bearer ${token}` },
+    };
+  }
+  return { url: "https://www.reddit.com/search.json", headers: { "User-Agent": USER_AGENT } };
+}
+
+function toUnified(child: RedditChild): UnifiedSearchResult | null {
+  const d = child.data;
+  const title = (d.title ?? "").trim();
+  if (!title || !d.permalink) return null;
+  const created = d.created_utc ? new Date(d.created_utc * 1000).toISOString() : undefined;
+  const parts: string[] = [];
+  if (typeof d.score === "number") parts.push(`${d.score} upvotes`);
+  if (typeof d.num_comments === "number") parts.push(`${d.num_comments} comments`);
+  const snippet = (d.selftext ?? "").replace(/\s+/g, " ").trim().slice(0, 300);
+  return {
+    title,
+    authors: [],
+    journal: `r/${d.subreddit}`,
+    url: `https://www.reddit.com${d.permalink}`,
+    domain: "reddit.com",
+    year: created ? new Date(created).getUTCFullYear() : 0,
+    publishedAt: created,
+    sourceLabel: "Reddit",
+    platform: "Reddit",
+    community: `r/${d.subreddit}`,
+    engagement: parts.length ? parts.join(" · ") : undefined,
+    abstract: snippet || undefined,
+    citationCount: 0,
+    publicationTypes: ["discussions"],
+    isOpenAccess: false,
+    sources: ["discussions"],
+    trustTier: "community",
+  };
+}
+
+export async function searchReddit(
+  query: string,
+  options: { limit?: number } = {}
+): Promise<{ results: UnifiedSearchResult[]; total: number; status: SourceStatus }> {
+  if (!breaker.canRequest()) {
+    return { results: [], total: 0, status: { status: "error", message: "Circuit breaker open — recent Reddit failures" } };
+  }
+  const limit = Math.min(Math.max(options.limit ?? 25, 1), 50);
+  const { url: base, headers } = endpoint();
+  const url = new URL(base);
+  url.searchParams.set("q", toKeywordQuery(query));
+  url.searchParams.set("limit", String(limit));
+  url.searchParams.set("sort", "relevance");
+  url.searchParams.set("type", "link");
+  url.searchParams.set("raw_json", "1");
+
+  try {
+    const res = await resilientFetch(url.toString(), { headers }, {
+      service: "Reddit",
+      timeout: 8000,
+      baseDelay: 400,
+      maxRetries: 0,
+    });
+    const data: RedditResponse = await res.json();
+    breaker.onSuccess();
+    const results = (data.data?.children ?? [])
+      .filter((c) => !c.data.over_18)
+      .map(toUnified)
+      .filter((r): r is UnifiedSearchResult => r !== null);
+    return { results, total: results.length, status: okStatus() };
+  } catch (error) {
+    breaker.onFailure();
+    return { results: [], total: 0, status: classifyFetchError(error) };
+  }
+}

--- a/src/lib/search/sources/stackexchange.ts
+++ b/src/lib/search/sources/stackexchange.ts
@@ -1,0 +1,146 @@
+/**
+ * Stack Exchange discussions source via the public Stack Exchange API
+ * (https://api.stackexchange.com/2.3/search/advanced — no key required, but
+ * keyless requests share a per-IP daily quota). Queries a curated set of
+ * research-relevant sites (Cross Validated, Academia) and returns real question
+ * threads as UnifiedSearchResult[] tagged sources:["discussions"].
+ *
+ * Fail-open: every site call is independently guarded; on any error / circuit
+ * open the source yields an empty, non-ok status and never zeroes the tab.
+ */
+import type { UnifiedSearchResult } from "@/types/search";
+import { resilientFetch } from "@/lib/http/resilient-fetch";
+import { createCircuitBreaker } from "@/lib/http/circuit-breaker";
+import { classifyFetchError, okStatus, type SourceStatus } from "@/lib/search/source-status";
+import { toKeywordQuery } from "@/lib/search/web/query-terms";
+
+const breaker = createCircuitBreaker({ service: "StackExchange", failureThreshold: 5 });
+
+const SE_SEARCH_URL = "https://api.stackexchange.com/2.3/search/advanced";
+
+/** Research-relevant SE sites. api_site_parameter → display label. */
+const DEFAULT_SITES: ReadonlyArray<{ site: string; label: string }> = [
+  { site: "stats", label: "Cross Validated" },
+  { site: "academia", label: "Academia" },
+];
+
+interface SeItem {
+  title: string;
+  link: string;
+  score?: number;
+  answer_count?: number;
+  creation_date?: number;
+  last_activity_date?: number;
+  tags?: string[];
+}
+
+interface SeResponse {
+  items?: SeItem[];
+}
+
+const HTML_ENTITIES: Record<string, string> = {
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": '"',
+  "&#39;": "'",
+  "&#39": "'",
+};
+
+function decodeEntities(text: string): string {
+  return text.replace(/&(amp|lt|gt|quot|#39);?/g, (m) => HTML_ENTITIES[m] ?? m);
+}
+
+function domainOf(url: string): string | undefined {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return undefined;
+  }
+}
+
+function toUnified(item: SeItem, siteLabel: string): UnifiedSearchResult | null {
+  const title = decodeEntities((item.title ?? "").trim());
+  if (!title || !item.link) return null;
+  const created = item.creation_date ? new Date(item.creation_date * 1000).toISOString() : undefined;
+  const parts: string[] = [];
+  if (typeof item.score === "number") parts.push(`${item.score} votes`);
+  if (typeof item.answer_count === "number") parts.push(`${item.answer_count} answers`);
+  return {
+    title,
+    authors: [],
+    journal: siteLabel,
+    url: item.link,
+    domain: domainOf(item.link),
+    year: created ? new Date(created).getUTCFullYear() : 0,
+    publishedAt: created,
+    sourceLabel: siteLabel,
+    platform: "Stack Exchange",
+    community: siteLabel,
+    engagement: parts.length ? parts.join(" · ") : undefined,
+    abstract: undefined,
+    citationCount: 0,
+    publicationTypes: ["discussions"],
+    isOpenAccess: false,
+    sources: ["discussions"],
+    trustTier: "community",
+  };
+}
+
+async function searchSite(
+  query: string,
+  site: string,
+  label: string,
+  limit: number
+): Promise<UnifiedSearchResult[]> {
+  const url = new URL(SE_SEARCH_URL);
+  url.searchParams.set("order", "desc");
+  url.searchParams.set("sort", "relevance");
+  url.searchParams.set("q", toKeywordQuery(query));
+  url.searchParams.set("site", site);
+  url.searchParams.set("pagesize", String(limit));
+  const res = await resilientFetch(url.toString(), undefined, {
+    service: "StackExchange",
+    timeout: 8000,
+    baseDelay: 400,
+    maxRetries: 1,
+  });
+  const data: SeResponse = await res.json();
+  return (data.items ?? [])
+    .map((item) => toUnified(item, label))
+    .filter((r): r is UnifiedSearchResult => r !== null);
+}
+
+export async function searchStackExchange(
+  query: string,
+  options: { limit?: number; sites?: ReadonlyArray<{ site: string; label: string }> } = {}
+): Promise<{ results: UnifiedSearchResult[]; total: number; status: SourceStatus }> {
+  if (!breaker.canRequest()) {
+    return { results: [], total: 0, status: { status: "error", message: "Circuit breaker open — recent Stack Exchange failures" } };
+  }
+  const sites = options.sites ?? DEFAULT_SITES;
+  const limit = Math.min(Math.max(options.limit ?? 15, 1), 30);
+
+  const settled = await Promise.allSettled(
+    sites.map((s) => searchSite(query, s.site, s.label, limit))
+  );
+
+  const results: UnifiedSearchResult[] = [];
+  let anyFulfilled = false;
+  let lastError: unknown;
+  for (const r of settled) {
+    if (r.status === "fulfilled") {
+      anyFulfilled = true;
+      results.push(...r.value);
+    } else {
+      lastError = r.reason;
+    }
+  }
+
+  if (!anyFulfilled) {
+    breaker.onFailure();
+    return { results: [], total: 0, status: classifyFetchError(lastError) };
+  }
+  breaker.onSuccess();
+  return { results, total: results.length, status: okStatus() };
+}

--- a/src/lib/search/web/__tests__/federate.test.ts
+++ b/src/lib/search/web/__tests__/federate.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { federateWith, type WebSource } from "../federate";
+import { okStatus } from "@/lib/search/source-status";
+import type { UnifiedSearchResult } from "@/types/search";
+
+function row(url: string, title: string): UnifiedSearchResult {
+  return { title, authors: [], journal: "", year: 0, url, sources: ["discussions"], citationCount: 0, publicationTypes: ["discussions"], isOpenAccess: false };
+}
+
+function okSource(id: string, results: UnifiedSearchResult[]): WebSource {
+  return { id, label: id, run: async () => ({ results, total: results.length, status: okStatus() }) };
+}
+
+function failSource(id: string): WebSource {
+  return { id, label: id, run: async () => { throw new Error(`[${id}] HTTP 403`); } };
+}
+
+function emptyOkSource(id: string): WebSource {
+  return { id, label: id, run: async () => ({ results: [], total: 0, status: okStatus() }) };
+}
+
+describe("federateWith", () => {
+  it("passes a single source through unchanged (no reorder, no rrfScore)", async () => {
+    const results = [row("https://a.com/1", "one"), row("https://a.com/2", "two")];
+    const fed = await federateWith("q", "discussions", [okSource("searxng", results)]);
+    expect(fed.results).toEqual(results); // identical objects, identical order
+    expect(fed.results[0].rrfScore).toBeUndefined();
+    expect(fed.degraded).toBe(false);
+  });
+
+  it("RRF-fuses when more than one source contributes", async () => {
+    const fed = await federateWith("q", "discussions", [
+      okSource("hn", [row("https://hn/1", "a")]),
+      okSource("se", [row("https://se/1", "b")]),
+    ]);
+    expect(fed.results).toHaveLength(2);
+    expect(fed.results[0].rrfScore).toBeGreaterThan(0);
+  });
+
+  it("is fail-open: a throwing source never zeroes the tab", async () => {
+    const fed = await federateWith("q", "discussions", [
+      failSource("reddit"),
+      okSource("hn", [row("https://hn/1", "a"), row("https://hn/2", "b")]),
+    ]);
+    expect(fed.results).toHaveLength(2); // hn survives reddit's 403
+    expect(fed.degraded).toBe(false);
+    expect(fed.perSource.find((s) => s.id === "reddit")!.status.status).not.toBe("ok");
+    expect(fed.perSource.find((s) => s.id === "hn")!.count).toBe(2);
+  });
+
+  it("marks degraded only when every source fails AND nothing is returned", async () => {
+    const fed = await federateWith("q", "discussions", [failSource("reddit"), failSource("hn")]);
+    expect(fed.results).toEqual([]);
+    expect(fed.degraded).toBe(true);
+  });
+
+  it("is not degraded when sources are healthy but genuinely empty", async () => {
+    const fed = await federateWith("q", "discussions", [emptyOkSource("hn"), emptyOkSource("se")]);
+    expect(fed.results).toEqual([]);
+    expect(fed.degraded).toBe(false);
+  });
+
+  it("drops a source that exceeds the per-source timeout without blocking", async () => {
+    const slow: WebSource = {
+      id: "slow",
+      label: "slow",
+      run: () => new Promise((resolve) => setTimeout(() => resolve({ results: [row("https://x/1", "x")], total: 1, status: okStatus() }), 1000)),
+    };
+    const fed = await federateWith("q", "discussions", [slow, okSource("hn", [row("https://hn/1", "a")])], { timeoutMs: 50 });
+    expect(fed.results).toHaveLength(1);
+    expect(fed.results[0].url).toBe("https://hn/1");
+    expect(fed.perSource.find((s) => s.id === "slow")!.status.status).toBe("timeout");
+  });
+});

--- a/src/lib/search/web/__tests__/query-terms.test.ts
+++ b/src/lib/search/web/__tests__/query-terms.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { toKeywordQuery } from "../query-terms";
+
+describe("toKeywordQuery", () => {
+  it("strips discussion-format and function words", () => {
+    expect(toKeywordQuery("peer review reform discussion")).toBe("peer review reform");
+    expect(toKeywordQuery("preprints versus journal publication debate")).toBe("preprints journal publication");
+    expect(toKeywordQuery("abandon statistical significance discussion")).toBe("abandon statistical significance");
+  });
+
+  it("preserves content-only queries", () => {
+    expect(toKeywordQuery("PhD burnout coping strategies")).toBe("PhD burnout coping strategies");
+    expect(toKeywordQuery("ASPIRIN trial")).toBe("ASPIRIN trial");
+  });
+
+  it("falls back to the original when filtering empties the query", () => {
+    expect(toKeywordQuery("the news discussion")).toBe("the news discussion");
+  });
+});

--- a/src/lib/search/web/__tests__/rank-fusion-web.test.ts
+++ b/src/lib/search/web/__tests__/rank-fusion-web.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { reciprocalRankFusionWeb } from "../rank-fusion-web";
+import type { UnifiedSearchResult } from "@/types/search";
+
+function row(url: string, title: string, source: string, extra: Partial<UnifiedSearchResult> = {}): UnifiedSearchResult {
+  return {
+    title,
+    authors: [],
+    journal: "",
+    year: 0,
+    url,
+    sources: [source],
+    citationCount: 0,
+    publicationTypes: ["discussions"],
+    isOpenAccess: false,
+    ...extra,
+  };
+}
+
+describe("reciprocalRankFusionWeb", () => {
+  it("collapses URL-only rows across sources on canonical URL (where isSamePaper cannot)", () => {
+    // Same page (trailing slash + www difference), no DOI/PMID/year -> academic
+    // isSamePaper would treat these as distinct; canonical-URL fusion merges them.
+    const a = [row("https://news.ycombinator.com/item?id=1", "Thread", "hacker-news")];
+    const b = [row("http://www.news.ycombinator.com/item?id=1/", "Thread", "searxng", { engagement: "10 points" })];
+    const fused = reciprocalRankFusionWeb([{ source: "hacker-news", results: a }, { source: "searxng", results: b }]);
+    expect(fused).toHaveLength(1);
+    expect(fused[0].sources.sort()).toEqual(["hacker-news", "searxng"]);
+    expect(fused[0].engagement).toBe("10 points"); // gap-filled from the duplicate
+    expect(fused[0].rrfScore).toBeGreaterThan(1 / 61); // summed across both lists
+  });
+
+  it("ranks a row appearing in two sources above a single-source row", () => {
+    const a = [row("https://x.com/1", "shared", "s1"), row("https://x.com/2", "solo-a", "s1")];
+    const b = [row("https://x.com/3", "solo-b", "s2"), row("https://x.com/1", "shared", "s2")];
+    const fused = reciprocalRankFusionWeb([{ source: "s1", results: a }, { source: "s2", results: b }]);
+    expect(fused[0].url).toBe("https://x.com/1");
+  });
+
+  it("keeps distinct URLs distinct", () => {
+    const a = [row("https://a.com/1", "a", "s1")];
+    const b = [row("https://b.com/1", "b", "s2")];
+    const fused = reciprocalRankFusionWeb([{ source: "s1", results: a }, { source: "s2", results: b }]);
+    expect(fused).toHaveLength(2);
+  });
+});

--- a/src/lib/search/web/canonical-url.ts
+++ b/src/lib/search/web/canonical-url.ts
@@ -1,0 +1,17 @@
+/**
+ * Canonical URL key for the non-academic (web/news/discussions) federation.
+ * Strips scheme, leading "www.", and a trailing slash, lower-cased — so the
+ * same page surfaced by two sources collapses to one fused row. Semantics match
+ * the eval scorer's canonicalUrl (eval/web-search/metrics.ts) so serving-side
+ * dedup and the dedup dimension agree.
+ */
+export function canonicalUrl(u: string): string {
+  try {
+    const url = new URL(u);
+    const host = url.hostname.replace(/^www\./, "");
+    const path = url.pathname.replace(/\/+$/, "");
+    return `${host}${path}`.toLowerCase();
+  } catch {
+    return u.trim().toLowerCase();
+  }
+}

--- a/src/lib/search/web/federate.ts
+++ b/src/lib/search/web/federate.ts
@@ -1,0 +1,173 @@
+/**
+ * Non-academic federation: fan a query out across a per-tab set of sources in
+ * parallel, each fail-open and timeout-bounded, then RRF-fuse the survivors on
+ * canonical URL. A single source short-circuits to a passthrough (no reorder, no
+ * rrfScore) so a SearXNG-only configuration reproduces the legacy single-source
+ * path byte-for-byte — the property CYCLE 0 validates.
+ *
+ * Lives entirely outside the academic engine: only the non-academic branch of
+ * the unified route calls this.
+ */
+import type { UnifiedSearchResult } from "@/types/search";
+import { okStatus, classifyRejectionReason, type SourceStatus } from "@/lib/search/source-status";
+import { searchSearXNG, type SearXNGCategory } from "@/lib/search/sources/searxng";
+import { searchReddit } from "@/lib/search/sources/reddit";
+import { searchHackerNews } from "@/lib/search/sources/hacker-news";
+import { searchStackExchange } from "@/lib/search/sources/stackexchange";
+import { reciprocalRankFusionWeb } from "./rank-fusion-web";
+
+export type FederatedTab = "web" | "news" | "discussions";
+
+export interface FederateOptions {
+  limit?: number;
+  timeRange?: "24h" | "week" | "month" | "year";
+  /** Per-source wall-clock ceiling. A slow source is dropped, never blocking. */
+  timeoutMs?: number;
+}
+
+export interface WebSourceResult {
+  results: UnifiedSearchResult[];
+  total: number;
+  status: SourceStatus;
+}
+
+export interface WebSource {
+  id: string;
+  label: string;
+  run: (query: string, options: FederateOptions) => Promise<WebSourceResult>;
+}
+
+export interface FederationResult {
+  results: UnifiedSearchResult[];
+  perSource: Array<{ id: string; label: string; count: number; status: SourceStatus }>;
+  /** Per-source raw rows — debug/provenance only (e.g. the capture provider tag). */
+  perSourceRows: Array<{ id: string; results: UnifiedSearchResult[] }>;
+  degraded: boolean;
+}
+
+const DEFAULT_SOURCE_TIMEOUT_MS = 9000;
+
+const SEARXNG_CATEGORY_BY_TAB: Record<FederatedTab, SearXNGCategory> = {
+  web: "general",
+  news: "news",
+  discussions: "social media",
+};
+
+export function searxngSourceForTab(tab: FederatedTab): WebSource {
+  const category = SEARXNG_CATEGORY_BY_TAB[tab];
+  return {
+    id: "searxng",
+    label: `SearXNG (${category})`,
+    run: async (query, options) => {
+      const r = await searchSearXNG(query, {
+        category,
+        limit: options.limit,
+        timeRange: options.timeRange,
+      });
+      return {
+        results: r.results,
+        total: r.total,
+        status: r.degraded
+          ? { status: "error", message: "SearXNG degraded" }
+          : okStatus(),
+      };
+    },
+  };
+}
+
+const redditSource: WebSource = {
+  id: "reddit",
+  label: "Reddit",
+  run: (query, options) => searchReddit(query, { limit: options.limit }),
+};
+
+const hackerNewsSource: WebSource = {
+  id: "hacker-news",
+  label: "Hacker News",
+  run: (query, options) => searchHackerNews(query, { limit: options.limit }),
+};
+
+const stackExchangeSource: WebSource = {
+  id: "stackexchange",
+  label: "Stack Exchange",
+  run: (query, options) => searchStackExchange(query, { limit: options.limit }),
+};
+
+/**
+ * Per-tab source set. Discussions federates the real-thread verticals; SearXNG
+ * "social media" is intentionally excluded (it returns fediverse noise — no
+ * Reddit/HN/SE — and measured worse). web/news stay single-SearXNG so their
+ * serving path is unchanged.
+ */
+export const SOURCES_BY_TAB: Record<FederatedTab, WebSource[]> = {
+  web: [searxngSourceForTab("web")],
+  news: [searxngSourceForTab("news")],
+  discussions: [redditSource, hackerNewsSource, stackExchangeSource],
+};
+
+async function withTimeout<T>(label: string, promise: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+export async function federateWith(
+  query: string,
+  _tab: FederatedTab,
+  sources: WebSource[],
+  options: FederateOptions = {}
+): Promise<FederationResult> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_SOURCE_TIMEOUT_MS;
+
+  const settled = await Promise.all(
+    sources.map(async (source) => {
+      try {
+        const r = await withTimeout(source.id, source.run(query, options), timeoutMs);
+        return { id: source.id, label: source.label, ...r };
+      } catch (error) {
+        return {
+          id: source.id,
+          label: source.label,
+          results: [] as UnifiedSearchResult[],
+          total: 0,
+          status: classifyRejectionReason(error),
+        };
+      }
+    })
+  );
+
+  const lists = settled
+    .filter((s) => s.results.length > 0)
+    .map((s) => ({ source: s.id, results: s.results }));
+
+  // Single contributing source → passthrough (no reorder, no rrfScore) so a
+  // one-source federation is byte-identical to the legacy direct call.
+  const results =
+    lists.length <= 1 ? (lists[0]?.results ?? []) : reciprocalRankFusionWeb(lists);
+
+  const anyOk = settled.some((s) => s.status.status === "ok");
+  const degraded = !anyOk && results.length === 0;
+
+  return {
+    results,
+    perSource: settled.map((s) => ({ id: s.id, label: s.label, count: s.results.length, status: s.status })),
+    perSourceRows: settled.map((s) => ({ id: s.id, results: s.results })),
+    degraded,
+  };
+}
+
+export async function federateNonAcademic(
+  query: string,
+  tab: FederatedTab,
+  options: FederateOptions = {}
+): Promise<FederationResult> {
+  return federateWith(query, tab, SOURCES_BY_TAB[tab], options);
+}

--- a/src/lib/search/web/query-terms.ts
+++ b/src/lib/search/web/query-terms.ts
@@ -1,0 +1,28 @@
+/**
+ * Compact a natural-language query into content keywords for the discussion
+ * verticals (Reddit/HN/Stack Exchange). Those APIs index terse thread titles and
+ * AND-match terms, so prose-style queries with format/intent filler
+ * ("peer review reform discussion", "...debate") return nothing. The discussions
+ * tab already implies the FORMAT, so format words like "discussion"/"debate" and
+ * common function words are noise here — stripping them is a semantic
+ * normalization, not a hack. SearXNG (web/news) keeps the raw query.
+ */
+const STOPWORDS = new Set([
+  // discussion-format / intent words (the tab already conveys this)
+  "discussion", "discussions", "debate", "debates", "thread", "threads",
+  "forum", "forums", "community", "opinion", "opinions", "news",
+  // common English function words
+  "a", "an", "the", "and", "or", "of", "in", "on", "to", "for", "vs",
+  "versus", "about", "with", "is", "are", "be",
+]);
+
+export function toKeywordQuery(query: string): string {
+  const terms = query
+    .split(/\s+/)
+    .map((t) => t.trim())
+    .filter(Boolean)
+    .filter((t) => !STOPWORDS.has(t.toLowerCase()));
+  // Never strip away the entire query — fall back to the original if filtering
+  // emptied it (e.g. a query made entirely of stopwords).
+  return terms.length > 0 ? terms.join(" ") : query.trim();
+}

--- a/src/lib/search/web/rank-fusion-web.ts
+++ b/src/lib/search/web/rank-fusion-web.ts
@@ -1,0 +1,76 @@
+/**
+ * Reciprocal-rank fusion for the non-academic federation, keyed on canonical
+ * URL rather than the academic isSamePaper() (which keys on DOI/PMID/title+year
+ * and silently fails to collapse URL-only web rows — their identifiers are
+ * absent and year is frequently 0). This is the cheap canonical-URL shim the
+ * design calls for; the academic dedup.ts is left untouched.
+ */
+import type { UnifiedSearchResult } from "@/types/search";
+import { canonicalUrl } from "./canonical-url";
+
+export interface WebSourceList {
+  source: string;
+  results: UnifiedSearchResult[];
+}
+
+function fusionKey(r: UnifiedSearchResult): string {
+  if (r.url) return canonicalUrl(r.url);
+  return `title:${r.title.toLowerCase().replace(/\s+/g, " ").trim()}`;
+}
+
+/** Fill gaps on the kept row from a duplicate without overwriting present data. */
+function mergeWebRows(
+  primary: UnifiedSearchResult,
+  secondary: UnifiedSearchResult,
+  source: string
+): UnifiedSearchResult {
+  return {
+    ...primary,
+    abstract: primary.abstract || secondary.abstract,
+    publishedAt: primary.publishedAt || secondary.publishedAt,
+    year: primary.year || secondary.year,
+    platform: primary.platform || secondary.platform,
+    community: primary.community || secondary.community,
+    engagement: primary.engagement || secondary.engagement,
+    sourceLabel: primary.sourceLabel || secondary.sourceLabel,
+    trustTier: primary.trustTier ?? secondary.trustTier,
+    sources: primary.sources.includes(source)
+      ? primary.sources
+      : [...primary.sources, source],
+  };
+}
+
+export function reciprocalRankFusionWeb(
+  lists: WebSourceList[],
+  k = 60
+): UnifiedSearchResult[] {
+  const merged: UnifiedSearchResult[] = [];
+  const scores: number[] = [];
+  const keyToIdx = new Map<string, number>();
+
+  for (const { source, results } of lists) {
+    for (let rank = 0; rank < results.length; rank++) {
+      const row = results[rank];
+      const key = fusionKey(row);
+      const contribution = 1 / (k + rank + 1);
+      const existingIdx = keyToIdx.get(key);
+
+      if (existingIdx !== undefined) {
+        scores[existingIdx] += contribution;
+        merged[existingIdx] = mergeWebRows(merged[existingIdx], row, source);
+      } else {
+        keyToIdx.set(key, merged.length);
+        merged.push({
+          ...row,
+          sources: row.sources.includes(source) ? [...row.sources] : [...row.sources, source],
+        });
+        scores.push(contribution);
+      }
+    }
+  }
+
+  return merged
+    .map((result, i) => ({ result, score: scores[i] }))
+    .sort((a, b) => b.score - a.score)
+    .map(({ result, score }) => ({ ...result, rrfScore: score }));
+}


### PR DESCRIPTION
## What & why
Grows the non-academic **discussions** tab from a single SearXNG "social media" call (fediverse noise — lemmy/mastodon, no real threads) into a real-thread **federation** across Reddit + Hacker News + Stack Exchange. Delivered as **CYCLE 0** (make the eval machine federation-aware) then **CYCLE 1** (the discussions verticals), measured keep-or-revert.

The academic engine, `run-search.ts`, the academic sources, and the **medical / no-domain-param default are byte-unchanged** — all work is inside the non-academic branch (`fetchFederatedNonAcademicResults`), new `src/lib/search/sources/*`, and a new `src/lib/search/web/*`.

## CYCLE 0 — federation-aware eval (prerequisite, no quality claim)
- `eval/web-search/capture-providers.ts` freezes the **fused** multi-source pool into the existing `cache/<tab>-<hash>.json` shape `run.ts` already replays (+ a debug-only per-row `provider` tag). `run.ts` / `metrics.ts` / `scoreTab` untouched.
- **Validated faithful superset:** a SearXNG-only federation passes through unchanged and **reproduces the SearXNG-only baseline scorecard with 0 drift across all 12 queries** (deterministic, isolated from live SearXNG variance).

## CYCLE 1 — discussions verticals
- New fail-open sources, each copying the `searxng.ts`/`tavily.ts` template (own `createCircuitBreaker` + `resilientFetch`, empty + non-ok status on failure — a down source never zeroes the tab): `reddit.ts`, `hacker-news.ts` (HN Algolia), `stackexchange.ts` (Cross Validated + Academia).
- `src/lib/search/web/`: `federate.ts` (`SOURCES_BY_TAB` fan-out, per-source timeout, **single-source passthrough** so SearXNG-only == legacy path), `rank-fusion-web.ts` (RRF keyed on **canonical URL** — the academic `isSamePaper` can't collapse URL-only web rows), `query-terms.ts` (strip format/function words; discussion APIs AND-match terse titles and return zero on verbose NL queries).
- `route.ts`: discussions served by the federation + the **same** quality layer (Cohere rerank + domain prefs) as the single-source path. **SearXNG social-media dropped** from discussions — measured a wash on the deterministic score and it injects fediverse noise the council penalizes.

## Measurement
**Layer 1 (deterministic, free, no Cohere):**
| tab | baseline tabAvg | cycle1 tabAvg |
|---|---|---|
| web | 3.9 | 3.9 (identical) |
| news | 3.9 | 3.9 (identical) |
| **discussions** | **3.0** | **5.3** |

- `disc-preprint-vs-journal`: recall@10 **0 → 10** (HN `news.ycombinator.com` gold), composite 3.1 → 7.3
- `disc-stats-significance`: recall@10 **0 → 10** (`stats.stackexchange.com` gold), composite 2.4 → 6.9
- web/news pools byte-identical (their code path is unchanged) → **no mainstream regression**.

**Blinded LLM council vs Exa (opus + grok + deepseek, temp 0):**
| tab | baseline | cycle1 |
|---|---|---|
| web | — | 0/4 |
| news | — | 0/4 |
| **discussions** | structural 0 | **4/4 = 100%** |
| **overall** | **0/12 (0%)** | **4/12 (33%)** |

All three judges blindly preferred ours over Exa on **every** discussions query — including the two reddit-gold queries, where our HN/Academia threads beat Exa's tweets. web/news remain the next cycles' target (unchanged here).

## Known limitation
Reddit blocks datacenter egress IPs (HTTP 403) regardless of User-Agent, and no Reddit OAuth credential is available. Its adapter is fully built and **fail-open** (reads `REDDIT_OAUTH_TOKEN` if present); until prod has a non-blocked IP or that token, Reddit contributes nothing and the two `reddit.com` gold queries stay unmatched. The win above is achieved **without** Reddit.

## Keep-or-revert: KEEP
- discussions recall ROSE (0 → 10 on 2 gold queries) and council beat-or-tie 0 → 100% ✓
- no web/news mainstream regression (byte-identical) ✓
- every source fail-open (unit-tested) ✓
- academic suite green: `npx vitest run src/lib/search/__tests__/ralph-search` → 31 passed ✓
- web-eval suite green: `npx vitest run eval/web-search` → 58 passed ✓

## How to test
```
npx vitest run src/lib/search/__tests__/ralph-search   # academic (off-limits) — 31 pass
npx vitest run eval/web-search                          # web-eval — 58 pass
npx vitest run src/lib/search/sources/__tests__/{reddit,hacker-news,stackexchange}.test.ts src/lib/search/web
# reproduce measurement:
SEARXNG_URL=http://34.14.206.241:8080 npx tsx eval/web-search/capture-providers.ts
npx tsx eval/web-search/run.ts --label cycle1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added federated non-academic search for the Discussions tab, combining multiple discussion sources into one ranked result list.
  * Added new discussion sources for Hacker News, Reddit, and Stack Exchange.
  * Improved result merging and ranking so duplicate links are consolidated and more relevant items surface higher.

* **Bug Fixes**
  * Search sources now fail open when one provider errors or times out, helping keep results available instead of returning an empty page.
  * Invalid or unsafe results are filtered out more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->