### PR TITLE
feat(search): Brave web/news backbone + Reddit-via-Brave discussions (CYCLE 2)

### DIFF
--- a/src/lib/search/sources/__tests__/brave.test.ts
+++ b/src/lib/search/sources/__tests__/brave.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { mapBraveResult, braveFreshness, buildBraveQuery } from "../brave";
+
+describe("mapBraveResult", () => {
+  it("maps a web result to a UnifiedSearchResult, stripping HTML and folding extra_snippets", () => {
+    const m = mapBraveResult(
+      {
+        title: "Gut Microbiome <strong>Depression</strong>",
+        url: "https://example.com/a",
+        description: "A <strong>bidirectional</strong> link",
+        profile: { name: "Example Profile" },
+        meta_url: { hostname: "www.example.com" },
+        extra_snippets: ["snippet one", "snippet two"],
+      },
+      "web"
+    )!;
+    expect(m.title).toBe("Gut Microbiome Depression");
+    expect(m.url).toBe("https://example.com/a");
+    expect(m.abstract).toContain("bidirectional");
+    expect(m.abstract).toContain("snippet one");
+    expect(m.sourceLabel).toBe("Example Profile");
+    expect(m.domain).toBe("example.com");
+    expect(m.sources).toEqual(["web"]);
+  });
+
+  it("maps a news result with page_age into year + publishedAt", () => {
+    const m = mapBraveResult(
+      {
+        title: "Ozempic shortage",
+        url: "https://news.example.com/x",
+        description: "supply",
+        page_age: "2026-06-27T12:41:03",
+        meta_url: { hostname: "news.example.com" },
+      },
+      "news"
+    )!;
+    expect(m.year).toBe(2026);
+    expect(m.publishedAt).toBe("2026-06-27T12:41:03");
+    expect(m.sources).toEqual(["news"]);
+  });
+
+  it("tags discussions results and derives domain from the url when meta_url is absent", () => {
+    const m = mapBraveResult(
+      { title: "PhD burnout thread", url: "https://www.reddit.com/r/AskAcademia/abc" },
+      "discussions"
+    )!;
+    expect(m.sources).toEqual(["discussions"]);
+    expect(m.domain).toBe("reddit.com");
+  });
+
+  it("returns null when title or url is missing", () => {
+    expect(mapBraveResult({ url: "https://x.com" }, "web")).toBeNull();
+    expect(mapBraveResult({ title: "no url" }, "web")).toBeNull();
+  });
+});
+
+describe("braveFreshness", () => {
+  it("maps a timeRange to Brave freshness codes", () => {
+    expect(braveFreshness("24h")).toBe("pd");
+    expect(braveFreshness("week")).toBe("pw");
+    expect(braveFreshness("month")).toBe("pm");
+    expect(braveFreshness("year")).toBe("py");
+    expect(braveFreshness(undefined)).toBeUndefined();
+  });
+});
+
+describe("buildBraveQuery", () => {
+  it("prepends a site: filter when provided", () => {
+    expect(buildBraveQuery("phd burnout", "reddit.com")).toBe("site:reddit.com phd burnout");
+  });
+  it("returns the query unchanged with no filter", () => {
+    expect(buildBraveQuery("phd burnout")).toBe("phd burnout");
+  });
+});

--- a/src/lib/search/sources/brave.ts
+++ b/src/lib/search/sources/brave.ts
@@ -1,0 +1,192 @@
+import { createCircuitBreaker } from "@/lib/http/circuit-breaker";
+import { createOutboundLimiter } from "@/lib/http/outbound-limiter";
+import { resilientFetch } from "@/lib/http/resilient-fetch";
+import { normalizeDomain } from "@/lib/search/domain-utils";
+import {
+  classifyFetchError,
+  okStatus,
+  type SourceStatus,
+} from "@/lib/search/source-status";
+import type { UnifiedSearchResult } from "@/types/search";
+
+const breaker = createCircuitBreaker({ service: "Brave", failureThreshold: 5 });
+
+// Brave's free tier is ~1 query/second. Pace to avoid self-inflicted 429s that
+// would trip the breaker and dark the lane.
+const limiter = createOutboundLimiter({
+  service: "Brave",
+  requestsPerSecond: 1,
+  burst: 1,
+});
+
+const ENDPOINT: Record<"web" | "news", string> = {
+  web: "https://api.search.brave.com/res/v1/web/search",
+  news: "https://api.search.brave.com/res/v1/news/search",
+};
+
+/** The non-academic tab a result is tagged with — web/news use their endpoint, discussions rides the web endpoint with a site: filter. */
+type BraveTag = "web" | "news" | "discussions";
+
+export interface BraveSearchOptions {
+  /** Which Brave endpoint to query. */
+  kind: "web" | "news";
+  limit?: number;
+  timeRange?: "24h" | "week" | "month" | "year";
+  /** Restrict to a single domain via a `site:` operator (e.g. "reddit.com"). */
+  siteFilter?: string;
+  /** Source tag for the mapped results; defaults to `kind`. Discussions sets this to "discussions". */
+  tag?: BraveTag;
+}
+
+interface BraveRawResult {
+  title?: string;
+  url?: string;
+  description?: string;
+  profile?: { name?: string } | null;
+  meta_url?: { hostname?: string } | null;
+  page_age?: string | null;
+  extra_snippets?: string[] | null;
+}
+
+interface BraveWebResponse {
+  web?: { results?: BraveRawResult[] };
+  results?: BraveRawResult[];
+}
+
+function collapseWhitespace(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+function stripHtml(text: string): string {
+  return text.replace(/<[^>]+>/g, " ");
+}
+
+function clean(text: string | null | undefined): string {
+  return collapseWhitespace(stripHtml(text ?? ""));
+}
+
+function domainOf(url: string, metaHost?: string | null): string {
+  const host = metaHost ?? "";
+  if (host) return host.replace(/^www\./, "");
+  try {
+    return normalizeDomain(url) ?? new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return "";
+  }
+}
+
+/** Map a Brave freshness window from the unified timeRange vocabulary. */
+export function braveFreshness(
+  timeRange?: "24h" | "week" | "month" | "year"
+): string | undefined {
+  switch (timeRange) {
+    case "24h":
+      return "pd";
+    case "week":
+      return "pw";
+    case "month":
+      return "pm";
+    case "year":
+      return "py";
+    default:
+      return undefined;
+  }
+}
+
+/** Prepend a `site:` operator to scope the query to one domain. */
+export function buildBraveQuery(query: string, siteFilter?: string): string {
+  return siteFilter ? `site:${siteFilter} ${query}` : query;
+}
+
+export function mapBraveResult(
+  raw: BraveRawResult,
+  tag: BraveTag
+): UnifiedSearchResult | null {
+  const title = clean(raw.title);
+  const url = raw.url ?? "";
+  if (!title || !url) return null;
+
+  const extras = (raw.extra_snippets ?? []).map(clean).filter(Boolean);
+  const abstract = [clean(raw.description), ...extras].filter(Boolean).join(" ");
+  const domain = domainOf(url, raw.meta_url?.hostname);
+  const sourceLabel = raw.profile?.name || domain;
+  const publishedAt = raw.page_age || undefined;
+  const year = publishedAt
+    ? parseInt(publishedAt.match(/(\d{4})/)?.[1] ?? "0", 10)
+    : 0;
+
+  return {
+    title,
+    authors: [],
+    journal: sourceLabel,
+    url,
+    domain,
+    year,
+    publishedAt,
+    sourceLabel,
+    abstract: abstract || undefined,
+    citationCount: 0,
+    publicationTypes: [tag],
+    isOpenAccess: false,
+    sources: [tag],
+  };
+}
+
+export async function searchBrave(
+  query: string,
+  options: BraveSearchOptions
+): Promise<{ results: UnifiedSearchResult[]; total: number; status: SourceStatus }> {
+  const key = process.env.BRAVE_API_KEY;
+  if (!key) {
+    return {
+      results: [],
+      total: 0,
+      status: { status: "missing_config", message: "BRAVE_API_KEY not set" },
+    };
+  }
+  if (!breaker.canRequest()) {
+    return {
+      results: [],
+      total: 0,
+      status: { status: "error", message: "Circuit breaker open — recent Brave failures" },
+    };
+  }
+
+  const url = new URL(ENDPOINT[options.kind]);
+  url.searchParams.set("q", buildBraveQuery(query, options.siteFilter));
+  if (options.limit) {
+    url.searchParams.set("count", String(Math.min(options.limit, 20)));
+  }
+  const freshness = braveFreshness(options.timeRange);
+  if (freshness) url.searchParams.set("freshness", freshness);
+
+  const tag: BraveTag = options.tag ?? options.kind;
+
+  try {
+    await limiter.acquire();
+    const res = await resilientFetch(
+      url.toString(),
+      { headers: { "X-Subscription-Token": key, Accept: "application/json" } },
+      { service: "Brave", timeout: 8000, baseDelay: 600, maxRetries: 1 }
+    );
+    const data: BraveWebResponse = await res.json();
+    const rawResults =
+      options.kind === "news" ? data.results ?? [] : data.web?.results ?? [];
+
+    const mapped = rawResults
+      .map((r) => mapBraveResult(r, tag))
+      .filter((r): r is UnifiedSearchResult => r !== null);
+    const results = options.limit ? mapped.slice(0, options.limit) : mapped;
+
+    breaker.onSuccess();
+    return { results, total: results.length, status: okStatus() };
+  } catch (error) {
+    breaker.onFailure();
+    console.error("[Brave] Search failed:", error);
+    return {
+      results: [],
+      total: 0,
+      status: classifyFetchError(error, { hasApiKey: true }),
+    };
+  }
+}

--- a/src/lib/search/web/__tests__/federate.test.ts
+++ b/src/lib/search/web/__tests__/federate.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, it } from "vitest";
-import { federateWith, type WebSource } from "../federate";
+import { describe, expect, it, vi } from "vitest";
+import { federateWith, braveSourceForTab, type WebSource } from "../federate";
 import { okStatus } from "@/lib/search/source-status";
 import type { UnifiedSearchResult } from "@/types/search";
+
+vi.mock("@/lib/search/sources/brave", () => ({
+  searchBrave: vi.fn(async () => ({ results: [], total: 0, status: { status: "ok" } })),
+}));
+import { searchBrave } from "@/lib/search/sources/brave";
 
 function row(url: string, title: string): UnifiedSearchResult {
   return { title, authors: [], journal: "", year: 0, url, sources: ["discussions"], citationCount: 0, publicationTypes: ["discussions"], isOpenAccess: false };
@@ -70,5 +75,39 @@ describe("federateWith", () => {
     expect(fed.results).toHaveLength(1);
     expect(fed.results[0].url).toBe("https://hn/1");
     expect(fed.perSource.find((s) => s.id === "slow")!.status.status).toBe("timeout");
+  });
+});
+
+describe("braveSourceForTab", () => {
+  const mockBrave = vi.mocked(searchBrave);
+
+  it("web tab hits the web endpoint", async () => {
+    const src = braveSourceForTab("web");
+    expect(src.id).toBe("brave");
+    await src.run("crispr base editing", { limit: 10 });
+    expect(mockBrave).toHaveBeenCalledWith(
+      "crispr base editing",
+      expect.objectContaining({ kind: "web", limit: 10 })
+    );
+  });
+
+  it("news tab hits the news endpoint and forwards the freshness window", async () => {
+    const src = braveSourceForTab("news");
+    expect(src.id).toBe("brave-news");
+    await src.run("ozempic shortage", { limit: 10, timeRange: "week" });
+    expect(mockBrave).toHaveBeenCalledWith(
+      "ozempic shortage",
+      expect.objectContaining({ kind: "news", timeRange: "week" })
+    );
+  });
+
+  it("discussions tab scopes to reddit.com and tags results as discussions", async () => {
+    const src = braveSourceForTab("discussions");
+    expect(src.id).toBe("brave-reddit");
+    await src.run("phd burnout", { limit: 10 });
+    expect(mockBrave).toHaveBeenCalledWith(
+      "phd burnout",
+      expect.objectContaining({ kind: "web", siteFilter: "reddit.com", tag: "discussions" })
+    );
   });
 });

--- a/src/lib/search/web/federate.ts
+++ b/src/lib/search/web/federate.ts
@@ -11,7 +11,7 @@
 import type { UnifiedSearchResult } from "@/types/search";
 import { okStatus, classifyRejectionReason, type SourceStatus } from "@/lib/search/source-status";
 import { searchSearXNG, type SearXNGCategory } from "@/lib/search/sources/searxng";
-import { searchReddit } from "@/lib/search/sources/reddit";
+import { searchBrave } from "@/lib/search/sources/brave";
 import { searchHackerNews } from "@/lib/search/sources/hacker-news";
 import { searchStackExchange } from "@/lib/search/sources/stackexchange";
 import { reciprocalRankFusionWeb } from "./rank-fusion-web";
@@ -75,11 +75,40 @@ export function searxngSourceForTab(tab: FederatedTab): WebSource {
   };
 }
 
-const redditSource: WebSource = {
-  id: "reddit",
-  label: "Reddit",
-  run: (query, options) => searchReddit(query, { limit: options.limit }),
-};
+/**
+ * Brave as an independent index. web/news hit their dedicated endpoints; the
+ * discussions adapter rides the web endpoint with a `site:reddit.com` filter to
+ * harvest Reddit threads, since Reddit's own API is closed (403) as of 2026.
+ */
+export function braveSourceForTab(tab: FederatedTab): WebSource {
+  if (tab === "news") {
+    return {
+      id: "brave-news",
+      label: "Brave News",
+      run: (query, options) =>
+        searchBrave(query, { kind: "news", limit: options.limit, timeRange: options.timeRange }),
+    };
+  }
+  if (tab === "discussions") {
+    return {
+      id: "brave-reddit",
+      label: "Brave (Reddit)",
+      run: (query, options) =>
+        searchBrave(query, {
+          kind: "web",
+          limit: options.limit,
+          siteFilter: "reddit.com",
+          tag: "discussions",
+        }),
+    };
+  }
+  return {
+    id: "brave",
+    label: "Brave Web",
+    run: (query, options) =>
+      searchBrave(query, { kind: "web", limit: options.limit, timeRange: options.timeRange }),
+  };
+}
 
 const hackerNewsSource: WebSource = {
   id: "hacker-news",
@@ -94,15 +123,17 @@ const stackExchangeSource: WebSource = {
 };
 
 /**
- * Per-tab source set. Discussions federates the real-thread verticals; SearXNG
- * "social media" is intentionally excluded (it returns fediverse noise — no
- * Reddit/HN/SE — and measured worse). web/news stay single-SearXNG so their
- * serving path is unchanged.
+ * Per-tab source set. web/news federate SearXNG with Brave's independent index
+ * (Brave surfaces authoritative explainers + diverse outlets that SearXNG's
+ * keyword scrape misses). Discussions federates the real-thread verticals —
+ * Hacker News + Stack Exchange APIs plus Reddit threads via Brave's `site:`
+ * index (Reddit's own API is dead). SearXNG "social media" is excluded (it
+ * returns fediverse noise and measured worse).
  */
 export const SOURCES_BY_TAB: Record<FederatedTab, WebSource[]> = {
-  web: [searxngSourceForTab("web")],
-  news: [searxngSourceForTab("news")],
-  discussions: [redditSource, hackerNewsSource, stackExchangeSource],
+  web: [searxngSourceForTab("web"), braveSourceForTab("web")],
+  news: [searxngSourceForTab("news"), braveSourceForTab("news")],
+  discussions: [hackerNewsSource, stackExchangeSource, braveSourceForTab("discussions")],
 };
 
 async function withTimeout<T>(label: string, promise: Promise<T>, ms: number): Promise<T> {


### PR DESCRIPTION
## What
Adds the **Brave Search API** as an independent index for non-academic search, federated alongside SearXNG via the existing RRF + canonical-URL machinery.

- `src/lib/search/sources/brave.ts` — Brave Web + News client (rate-limited to free-tier 1 req/s, circuit-broken, fail-open, `missing_config` when unkeyed).
- `federate.ts` — `braveSourceForTab` adapter; `SOURCES_BY_TAB` now:
  - **web** → SearXNG + Brave
  - **news** → SearXNG + Brave News
  - **discussions** → Hacker News + Stack Exchange + Brave `site:reddit.com` (replaces the dead direct-Reddit source — Reddit's API returns 403 in 2026)

## Why
web/news were pinned to single-source SearXNG (journal-paper noise, single-outlet news floods). Brave is an independent index that surfaces authoritative explainers + diverse outlets.

## Measured lift (un-reranked deterministic scorecard, 12-query gold set)
| Tab | before | after | Δ |
|---|---|---|---|
| web | 2.5 | **5.6** | +3.1 |
| news | 3.9 | **5.8** | +1.9 |
| discussions | 5.3 | **7.3** | +2.0 |
| passing | 0/12 | **3/12** | — |

## Tests
+10 unit tests (Brave mapping/helpers + per-tab federation adapter). Full suite green: **6853 passed**, tsc + eslint clean, zero regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEgTUohzwMogXKPsWVdwJx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Brave-powered search results to web and news searches.
  * Expanded discussion search coverage with additional Brave-based results.
* **Bug Fixes**
  * Improved result formatting so titles, snippets, and source details display more cleanly.
  * Better handling of incomplete search results, reducing empty or broken entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->