### PR TITLE
feat(search): self-hosted general web reranker + domain-aware rerank routing

### DIFF
--- a/eval/web-search/quality.ts
+++ b/eval/web-search/quality.ts
@@ -35,7 +35,7 @@ export function toPacketRows(results: UnifiedSearchResult[]): CommonRow[] {
   });
 }
 
-/** Trust-annotate + Cohere rerank (fail-open). Mirrors the current production non-academic path. */
+/** Trust-annotate + self-hosted web rerank (fail-open). Mirrors the production non-academic path. */
 export async function applyQualityLayer(
   query: string,
   results: UnifiedSearchResult[],
@@ -45,7 +45,7 @@ export async function applyQualityLayer(
     return { ...r, domain, trustTier: r.trustTier ?? getTrustTier(domain ?? r.url) };
   });
   try {
-    return await rerankResults(query, annotated);
+    return await rerankResults(query, annotated, undefined, { domain: "web" });
   } catch {
     return annotated; // fail-open: trust-annotated results, original order
   }

--- a/infra/modal/web_reranker_contract_test.py
+++ b/infra/modal/web_reranker_contract_test.py
@@ -1,0 +1,110 @@
+"""
+Contract test for the self-hosted web reranker endpoint (`WebReranker.rerank`).
+
+Verifies — against the LIVE deployed endpoint — that the request/response shape is
+byte-for-byte what `rerankMedcpt` in `src/lib/search/rerank.ts` expects, so the new
+service is a true drop-in behind `WEB_RERANK_URL`:
+
+    REQUEST  : POST { "query": str, "documents": [str] }
+    RESPONSE : { "scores": [float] }   # one RAW logit per document, IN INPUT ORDER
+
+The TS client (`rerankMedcpt`) then does, per the rerank.ts contract:
+    scores
+      .map((logit, index) => ({ index, relevance_score: sigmoid(logit) }))
+      .sort(desc by relevance_score)
+      .slice(0, topN)
+
+So the ONLY guarantees this endpoint must honor are:
+  1. response is an object with a "scores" key whose value is a list,
+  2. len(scores) == len(documents),
+  3. scores are finite floats in INPUT order (index i scores documents[i]),
+  4. a more-relevant document gets a strictly higher score than an off-topic one
+     (so sigmoid + sort reproduces the right ranking),
+  5. empty/blank input returns { "scores": [] } (caller keeps its order).
+
+This intentionally mirrors the assertions in `src/lib/search/__tests__/rerank.test.ts`
+(which mocks the network) but exercises the REAL model, closing the loop the unit
+test cannot. It is NOT a Modal app — run it locally after deploy:
+
+    op-run -- python infra/modal/web_reranker_contract_test.py \
+        "https://shailesh-greatest--manan-web-reranker-webreranker-rerank.modal.run"
+
+Exits non-zero (and prints which assertion failed) if the contract is violated.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import sys
+import urllib.request
+
+
+def _post(url: str, payload: dict) -> dict:
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _sigmoid(x: float) -> float:
+    return 1.0 / (1.0 + math.exp(-x))
+
+
+def main(url: str) -> int:
+    query = "best programming language for web development"
+    documents = [
+        "A guide to JavaScript and TypeScript for building modern web apps.",  # relevant
+        "How to bake a sourdough loaf with a long overnight fermentation.",    # off-topic
+        "Choosing a framework: React, Vue, and Svelte compared for the web.",  # relevant
+    ]
+
+    # 1) Happy path: shape + length + ordering contract.
+    body = _post(url, {"query": query, "documents": documents})
+    assert isinstance(body, dict), f"response is not an object: {body!r}"
+    assert "scores" in body, f"response missing 'scores' key: {body!r}"
+    scores = body["scores"]
+    assert isinstance(scores, list), f"'scores' is not a list: {scores!r}"
+    assert len(scores) == len(documents), (
+        f"scores length {len(scores)} != documents length {len(documents)} "
+        "(must be one score per document, in input order)"
+    )
+    assert all(isinstance(s, (int, float)) and math.isfinite(s) for s in scores), (
+        f"scores must be finite numbers (raw logits the client will sigmoid): {scores!r}"
+    )
+    # Relevance ordering: the two web docs (idx 0, 2) must out-score the baking doc
+    # (idx 1) so that sigmoid + desc-sort surfaces them first, exactly as rerank.ts does.
+    assert scores[0] > scores[1] and scores[2] > scores[1], (
+        f"relevant docs did not out-score the off-topic doc: {scores!r}"
+    )
+    # Reproduce the client's transform to prove the end-to-end ranking is correct.
+    ranked = sorted(
+        ({"index": i, "relevance_score": _sigmoid(s)} for i, s in enumerate(scores)),
+        key=lambda r: r["relevance_score"],
+        reverse=True,
+    )
+    assert ranked[0]["index"] in (0, 2), f"top-ranked doc is the off-topic one: {ranked!r}"
+    assert all(0.0 <= r["relevance_score"] <= 1.0 for r in ranked), (
+        "sigmoid(logit) must land in [0,1] — the relevance_score contract"
+    )
+
+    # 2) Empty/blank input → empty scores (caller keeps its pre-rerank order).
+    assert _post(url, {"query": "", "documents": documents}) == {"scores": []}
+    assert _post(url, {"query": query, "documents": []}) == {"scores": []}
+
+    print("OK — web reranker honors the rerankMedcpt request/response contract.")
+    print(f"  raw scores (input order): {scores}")
+    print(f"  client ranking (index):   {[r['index'] for r in ranked]}")
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(__doc__)
+        print("usage: python web_reranker_contract_test.py <endpoint-url>", file=sys.stderr)
+        raise SystemExit(2)
+    raise SystemExit(main(sys.argv[1]))

--- a/infra/modal/web_reranker_service.py
+++ b/infra/modal/web_reranker_service.py
@@ -1,0 +1,155 @@
+"""
+Modal app for Manan OS's self-hosted GENERAL-DOMAIN (web) cross-encoder reranker.
+
+This is the non-biomedical sibling of `medcpt_service.py`'s CrossEncoder: the same
+self-hosted, scale-to-zero, throttle-proof rerank lane, but tuned for general web
+content (news, encyclopedic, docs, forums) instead of PubMed abstracts. It exists so
+the web/non-academic search path can rerank with a model trained on web text rather
+than borrowing the biomedical MedCPT cross-encoder (which is mis-domained for web
+queries) or paying Cohere's per-call rate limit.
+
+One responsibility, one app, scale-to-zero (no idle GPU cost):
+
+  WebReranker — a web endpoint serving `BAAI/bge-reranker-v2-m3`. The live web search
+  lane POSTs `{ "query": str, "documents": [str] }` and gets back
+  `{ "scores": [float] }` — one RAW relevance logit per document, IN INPUT ORDER
+  (higher = more relevant). This is the IDENTICAL request/response contract the MedCPT
+  CrossEncoder exposes, so it is a drop-in for `rerankMedcpt` in
+  `src/lib/search/rerank.ts`: that client squashes each logit through a sigmoid
+  (`logitToProbability`) into the [0,1] relevance the ranking composite expects. The
+  deployed endpoint URL is what `WEB_RERANK_URL` will point at.
+
+Model choice — BAAI/bge-reranker-v2-m3:
+  * License: Apache-2.0 (permissive, commercial-OK) — unlike jina-reranker-v2
+    (cc-by-nc-4.0, non-commercial) which is disqualifying here.
+  * Pattern parity: a classic cross-encoder loaded with
+    AutoModelForSequenceClassification that emits ONE raw relevance logit per pair —
+    byte-for-byte the same load + read-out as MedCPT-Cross-Encoder, so the sigmoid
+    contract in rerank.ts is preserved with zero client changes (vs. mxbai-rerank-v2,
+    a 1.5B generative/listwise model needing a bespoke library + bigger GPU).
+  * Size/latency/GPU fit: ~0.6B params (bge-m3 backbone). Batching ~50
+    (query, document) pairs is one forward pass that fits comfortably on an A10G
+    (and would fit a T4/L4) — so idle cost is $0 (scale-to-zero) and warm rerank is
+    sub-second.
+  * Quality: strong general + multilingual reranker on BEIR-style web retrieval,
+    the de-facto open general-domain reranker as of 2026.
+
+Secret (never hardcoded) comes from a Modal Secret named `manan-web-reranker-secrets`
+holding HF_TOKEN (bge models are ungated-free, but a token avoids anonymous HF rate
+limits on cold pulls). Create it once with op-run so the token never touches chat:
+
+    op-run -- modal secret create manan-web-reranker-secrets HF_TOKEN="$HF_TOKEN"
+
+Deploy / operate (all via op-run so creds are injected from 1Password):
+
+    op-run -- modal deploy infra/modal/web_reranker_service.py    # serve the reranker
+
+API/library versions verified against Context7 (Modal cls/enter/fastapi_endpoint, GPU
+strings) + the BAAI/bge-reranker-v2-m3 model card on 2026-06-29 (Apache-2.0,
+AutoModelForSequenceClassification single-logit read-out, max_length 512).
+"""
+
+from __future__ import annotations
+
+import os
+
+import modal
+
+# ---------------------------------------------------------------------------
+# Configuration (constants; env/secret-driven values are read at runtime).
+# ---------------------------------------------------------------------------
+APP_NAME = "manan-web-reranker"
+RERANKER_MODEL = "BAAI/bge-reranker-v2-m3"
+# bge-reranker-v2-m3's tokenizer truncates the (query, document) pair to 512 tokens,
+# exactly as the MedCPT cross-encoder does — long web docs are truncated, not rejected.
+RERANK_MAX_LEN = 512
+
+# ---------------------------------------------------------------------------
+# Image + app. torch/transformers are only imported on the remote containers (via
+# image.imports), so deploying this file locally needs nothing but the `modal` client.
+# Versions pinned to match medcpt_service.py for one reproducible torch/transformers ABI.
+# ---------------------------------------------------------------------------
+image = (
+    modal.Image.debian_slim(python_version="3.11")
+    .pip_install(
+        "torch==2.4.1",
+        "transformers==4.44.2",
+        "numpy==2.1.1",
+        "fastapi[standard]==0.115.0",
+    )
+)
+
+app = modal.App(APP_NAME, image=image)
+
+# Cache HF weights across container starts so scale-to-zero stays cheap+fast.
+hf_cache = modal.Volume.from_name("web-reranker-hf-cache", create_if_missing=True)
+
+SECRET = modal.Secret.from_name(
+    "manan-web-reranker-secrets", required_keys=["HF_TOKEN"]
+)
+
+with image.imports():
+    import torch
+    from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+
+# ===========================================================================
+# General-domain cross-encoder reranker — self-hosted, throttle-proof replacement
+# for the external (rate-limited) reranker on the WEB path. Scale-to-zero GPU:
+# $0 idle, warms on use.
+# ===========================================================================
+# Reranking runs POST-fusion over the top ~50 fused candidates — NOT inside the live
+# fan-out deadline — so a brief warm-up is acceptable. An A10G batches all ~50
+# (query, document) pairs in one forward pass (~0.3-0.8s warm). Scale-to-zero keeps
+# idle cost at $0; `scaledown_window` holds the replica warm across a run's query gaps
+# so it does not cold-start mid-request. The lane FAILS OPEN: on cold start, timeout,
+# or error the caller keeps the pre-rerank order (see rerank.ts).
+@app.cls(
+    image=image,
+    gpu="A10G",
+    volumes={"/cache": hf_cache},
+    secrets=[SECRET],
+    scaledown_window=300,
+    timeout=600,
+)
+class WebReranker:
+    @modal.enter()
+    def load(self):
+        os.environ.setdefault("HF_HOME", "/cache")
+        self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        self.tokenizer = AutoTokenizer.from_pretrained(RERANKER_MODEL)
+        self.model = (
+            AutoModelForSequenceClassification.from_pretrained(RERANKER_MODEL)
+            .to(self.device)
+            .eval()
+        )
+
+    @modal.fastapi_endpoint(method="POST")
+    def rerank(self, item: dict):
+        """POST { query: str, documents: [str] } -> { scores: [float] }.
+
+        bge-reranker-v2-m3 relevance logit per (query, document) pair, in input order
+        (higher = more relevant). RAW logit — NOT sigmoid-squashed here — exactly like
+        the MedCPT cross-encoder, so the client (`rerankMedcpt`/`rerankWeb` in
+        rerank.ts) applies the SAME `logitToProbability` sigmoid to get the [0,1]
+        relevance the ranking composite carries. An empty/short input returns no scores
+        (caller keeps its order).
+        """
+        query = (item or {}).get("query", "")
+        documents = (item or {}).get("documents", [])
+        if not isinstance(query, str) or not query.strip() or not documents:
+            return {"scores": []}
+        pairs = [[query, str(d)] for d in documents]
+        with torch.no_grad():
+            encoded = self.tokenizer(
+                pairs,
+                truncation=True,
+                padding=True,
+                return_tensors="pt",
+                max_length=RERANK_MAX_LEN,
+            ).to(self.device)
+            # bge-reranker emits a single relevance logit per pair; `.view(-1)` flattens
+            # the [N, 1] logits to [N] (matching the model card's read-out) so an N=1
+            # request still returns a list, never a scalar.
+            logits = self.model(**encoded).logits.view(-1)
+        return {"scores": logits.cpu().to(torch.float32).numpy().tolist()}

--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -233,8 +233,8 @@ async function fetchNonAcademicResults(
     limit,
     timeRange,
   });
-  // Rerank web results with Cohere (same quality treatment as academic results)
-  let rerankedResults = await rerankResults(query, response.results);
+  // Rerank web results with the self-hosted general reranker (domain-routed, not the biomedical model)
+  let rerankedResults = await rerankResults(query, response.results, undefined, { domain: "web" });
   let rankedResults = applyDomainPreferences(rerankedResults, preferences);
 
   while (!response.degraded) {
@@ -260,7 +260,7 @@ async function fetchNonAcademicResults(
       category,
       limit,
     });
-    rerankedResults = await rerankResults(query, response.results);
+    rerankedResults = await rerankResults(query, response.results, undefined, { domain: "web" });
     rankedResults = applyDomainPreferences(rerankedResults, preferences);
   }
 
@@ -304,7 +304,7 @@ async function fetchFederatedNonAcademicResults(
     limit: MAX_NON_ACADEMIC_RESULTS,
     timeRange,
   });
-  const reranked = await rerankResults(query, federation.results);
+  const reranked = await rerankResults(query, federation.results, undefined, { domain: "web" });
   const ranked = applyDomainPreferences(reranked, preferences);
 
   const start = page * perPage;

--- a/src/lib/search/__tests__/rerank.test.ts
+++ b/src/lib/search/__tests__/rerank.test.ts
@@ -132,6 +132,57 @@ describe("rerankResults — backend selection", () => {
   });
 });
 
+describe("rerankResults — domain routing", () => {
+  const WEB_URL = "https://example-web-rerank.modal.run";
+
+  it("web domain uses WEB_RERANK_URL, not the biomedical MedCPT reranker", async () => {
+    vi.stubEnv("WEB_RERANK_URL", WEB_URL);
+    vi.stubEnv("MEDCPT_RERANK_URL", MEDCPT_URL);
+    mockResilientFetch.mockResolvedValueOnce(jsonResponse({ scores: [-2, 4, 1] }));
+
+    const out = await rerankResults("q", RESULTS, undefined, { domain: "web" });
+
+    expect(mockResilientFetch.mock.calls[0][0]).toBe(WEB_URL);
+    expect(out.map((r) => r.title)).toEqual([
+      "B relevance high",
+      "C relevance mid",
+      "A relevance low",
+    ]);
+  });
+
+  it("web domain does NOT borrow the literature MedCPT reranker (fails open when only MEDCPT is set)", async () => {
+    vi.stubEnv("MEDCPT_RERANK_URL", MEDCPT_URL); // literature lane only
+    const out = await rerankResults("q", RESULTS, undefined, { domain: "web" });
+    expect(mockResilientFetch).not.toHaveBeenCalled();
+    expect(out).toBe(RESULTS); // unchanged
+  });
+
+  it("literature (default) uses MedCPT and ignores WEB_RERANK_URL", async () => {
+    vi.stubEnv("WEB_RERANK_URL", WEB_URL);
+    vi.stubEnv("MEDCPT_RERANK_URL", MEDCPT_URL);
+    mockResilientFetch.mockResolvedValueOnce(jsonResponse({ scores: [1, 2, 3] }));
+
+    await rerankResults("q", RESULTS);
+
+    expect(mockResilientFetch.mock.calls[0][0]).toBe(MEDCPT_URL);
+  });
+
+  it("web domain falls back to Cohere when WEB_RERANK_URL is unset", async () => {
+    vi.stubEnv("COHERE_API_KEY", COHERE_KEY);
+    mockResilientFetch.mockResolvedValueOnce(
+      jsonResponse({
+        results: [
+          { index: 1, relevance_score: 0.9 },
+          { index: 0, relevance_score: 0.2 },
+        ],
+      })
+    );
+    const out = await rerankResults("q", RESULTS, undefined, { domain: "web" });
+    expect(mockResilientFetch.mock.calls[0][0]).toBe("https://api.cohere.com/v2/rerank");
+    expect(out[0].title).toBe("B relevance high");
+  });
+});
+
 describe("hasReranker / attachRerankScores", () => {
   it("hasReranker reflects any configured backend", () => {
     expect(hasReranker()).toBe(false);

--- a/src/lib/search/rerank.ts
+++ b/src/lib/search/rerank.ts
@@ -30,18 +30,21 @@ export function hasReranker(): boolean {
 }
 
 /**
- * Self-hosted MedCPT Cross-Encoder (Modal, scale-to-zero). The endpoint returns a
- * raw relevance LOGIT per document IN INPUT ORDER (range ≈ −16…+10); we squash each
- * to a [0,1] probability ({@link logitToProbability}) — the contract every backend's
- * `relevance_score` honors — then pair to indices, sort desc, and trim to `topN`.
- * Throttle-proof — no external rate limit. Fail-open: a cold start that exceeds the
- * timeout (or any error) propagates as a throw so the caller keeps the pre-rerank order.
+ * Self-hosted cross-encoder (Modal, scale-to-zero) — biomedical MedCPT for the
+ * literature path, general bge-reranker for the web path. Both expose the same
+ * contract: a raw relevance LOGIT per document IN INPUT ORDER (range ≈ −16…+10),
+ * which we squash to a [0,1] probability ({@link logitToProbability}) — the contract
+ * every backend's `relevance_score` honors — then pair to indices, sort desc, and
+ * trim to `topN`. Throttle-proof — no external rate limit. `service` is the
+ * circuit-breaker/log label so each domain's lane is isolated. Fail-open: a cold
+ * start that exceeds the timeout (or any error) throws so the caller keeps order.
  */
-async function rerankMedcpt(
+async function rerankSelfHosted(
   url: string,
   query: string,
   documents: string[],
-  topN: number
+  topN: number,
+  service: string
 ): Promise<RerankScore[]> {
   const res = await resilientFetch(
     url,
@@ -50,7 +53,7 @@ async function rerankMedcpt(
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ query, documents }),
     },
-    { service: "MedCPT-Rerank", timeout: 15000, maxRetries: 1 }
+    { service, timeout: 15000, maxRetries: 1 }
   );
   const data: { scores?: number[] } = await res.json();
   const scores = Array.isArray(data?.scores) ? data.scores : [];
@@ -90,23 +93,29 @@ async function rerankCohere(
 }
 
 /**
- * Rerank by query↔document relevance through a fail-open backend CHAIN, in priority
- * order: self-hosted MedCPT Cross-Encoder (`MEDCPT_RERANK_URL`, biomedical) → Cohere
- * (`COHERE_API_KEY`, warm fallback for the scale-to-zero MedCPT cold window). Each
- * backend is tried only if configured; if it errors or yields no usable scores, the
- * next is attempted. With none configured — or all failing — the input is returned
- * unchanged, and the quality ranker falls back to keyword-overlap relevance: the
- * "no model, never fails" floor, which is the correct infra fallback for a relevance
- * signal that is one capped term in a metadata-dominant composite, not the ruler.
+ * Rerank by query↔document relevance through a fail-open backend CHAIN. The leading
+ * self-hosted backend is DOMAIN-ROUTED: the web path (`domain: "web"`) uses the
+ * general cross-encoder (`WEB_RERANK_URL`); the literature path (default) uses the
+ * biomedical MedCPT cross-encoder (`MEDCPT_RERANK_URL`) — a query is never reranked
+ * by the wrong-domain model. Each domain uses its own circuit-breaker label so an
+ * outage in one lane can't trip the other. Cohere (`COHERE_API_KEY`) is the warm
+ * fallback for either during the scale-to-zero cold window. A backend is tried only
+ * if configured; if it errors or yields no scores, the next is attempted. With none
+ * configured — or all failing — the input is returned unchanged and the quality
+ * ranker falls back to keyword-overlap relevance: the "no model, never fails" floor.
  */
 export async function rerankResults(
   query: string,
   results: UnifiedSearchResult[],
-  topN?: number
+  topN?: number,
+  opts?: { domain?: "web" | "literature" }
 ): Promise<UnifiedSearchResult[]> {
-  const medcptUrl = process.env.MEDCPT_RERANK_URL;
+  const isWeb = opts?.domain === "web";
+  const selfHostedUrl = isWeb
+    ? process.env.WEB_RERANK_URL
+    : process.env.MEDCPT_RERANK_URL;
   const cohereKey = process.env.COHERE_API_KEY;
-  if (results.length === 0 || (!medcptUrl && !cohereKey)) {
+  if (results.length === 0 || (!selfHostedUrl && !cohereKey)) {
     return results;
   }
 
@@ -116,10 +125,17 @@ export async function rerankResults(
   );
 
   const backends: { name: string; run: () => Promise<RerankScore[]> }[] = [];
-  if (medcptUrl)
+  if (selfHostedUrl)
     backends.push({
-      name: "MedCPT",
-      run: () => rerankMedcpt(medcptUrl, query, documents, limit),
+      name: isWeb ? "WebReranker" : "MedCPT",
+      run: () =>
+        rerankSelfHosted(
+          selfHostedUrl,
+          query,
+          documents,
+          limit,
+          isWeb ? "Web-Rerank" : "MedCPT-Rerank"
+        ),
     });
   if (cohereKey)
     backends.push({


### PR DESCRIPTION
## What
- Deploys **`bge-reranker-v2-m3`** on Modal (scale-to-zero, $0 idle) as the general-domain sibling of the MedCPT cross-encoder. Same `{query,documents}→{scores}` contract → drop-in.
- Makes `rerankResults()` **domain-routed**: web → `WEB_RERANK_URL`, literature → `MEDCPT_RERANK_URL`, isolated circuit breakers, Cohere fallback either side.
- Wires `{ domain: "web" }` into the unified route's 3 non-academic sites + the eval quality layer.

## Why
Fixes a latent bug: with `MEDCPT_RERANK_URL` set, the **non-academic path was reranking general web content with the biomedical model**. Now web is correctly routed (and never borrows MedCPT).

## Why it's disabled on the deterministic gate
The set-based top-10 composite scores *membership*, not order. A pure-relevance reorder evicts gold must-haves (web 5.6→4.6, disc 7.3→5.4). The reranker's value is **ordering quality**, which the blinded council judges (it's what won literature). `WEB_RERANK_URL` is left unset; re-enable it for council eval / as a blended signal.

## Tests
+4 routing tests; literature rerank path byte-identical; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEgTUohzwMogXKPsWVdwJx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Web search results now use a self-hosted reranking path for improved ordering.
  * Reranking now adapts by search domain, with web results handled separately from literature results.

* **Bug Fixes**
  * Preserved fail-open behavior so search results still return normally if reranking is unavailable.
  * Added coverage for empty input handling and reranking fallback behavior.

* **Tests**
  * Added contract and routing tests to verify reranking responses, ranking order, and backend selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->