### PR TITLE
feat(search): domain-diversity MMR for non-academic tabs (CYCLE 3)

### DIFF
--- a/eval/web-search/run.ts
+++ b/eval/web-search/run.ts
@@ -10,6 +10,7 @@ import { fileURLToPath } from "node:url";
 import { BENCHMARK_QUERIES } from "./queries";
 import { cacheKey } from "./capture-searxng";
 import { applyQualityLayer, toEvalItems, toPacketRows } from "./quality";
+import { diversifyForTab } from "@/lib/search/diversity";
 import { scoreTab, type DimensionKey } from "./metrics";
 import type { WebTab, CommonRow } from "./types";
 import type { UnifiedSearchResult } from "@/types/search";
@@ -35,8 +36,9 @@ export async function runFromCache(opts: { cacheDir: string; label: string; now:
     }
     const pool = JSON.parse(readFileSync(path, "utf8")) as { results: UnifiedSearchResult[] };
     const ranked = await applyQualityLayer(q.query, pool.results);
-    const score = scoreTab(toEvalItems(ranked), q, opts.now);
-    perQuery.push({ id: q.id, tab: q.tab, composite: score.composite, pass: score.pass, dimensions: score.dimensions, details: score.details, rows: toPacketRows(ranked) });
+    const diversified = diversifyForTab(ranked, q.tab);
+    const score = scoreTab(toEvalItems(diversified), q, opts.now);
+    perQuery.push({ id: q.id, tab: q.tab, composite: score.composite, pass: score.pass, dimensions: score.dimensions, details: score.details, rows: toPacketRows(diversified) });
   }
 
   const tabs: WebTab[] = ["web", "news", "discussions"];

--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -9,6 +9,7 @@ import { searchSearXNG, type SearXNGCategory } from "@/lib/search/sources/searxn
 import { federateNonAcademic } from "@/lib/search/web/federate";
 import { reciprocalRankFusion } from "@/lib/search/rank-fusion";
 import { rerankResults } from "@/lib/search/rerank";
+import { diversifyForTab } from "@/lib/search/diversity";
 import { getDomainEvidenceLevel } from "@/lib/search/evidence-level";
 import { getDomainConfig } from "@/lib/search/domains";
 import { augmentQuery } from "@/lib/ai/query-augment";
@@ -264,11 +265,14 @@ async function fetchNonAcademicResults(
     rankedResults = applyDomainPreferences(rerankedResults, preferences);
   }
 
+  const tab = category === "news" ? "news" : "web";
+  const diversified = diversifyForTab(rankedResults, tab);
+
   const start = page * perPage;
-  const paged = rankedResults.slice(start, start + perPage);
+  const paged = diversified.slice(start, start + perPage);
   const fetchCeiling = Math.min(response.total, MAX_NON_ACADEMIC_RESULTS);
   const canFetchMore = !response.degraded && limit < fetchCeiling;
-  const hasMore = rankedResults.length > start + perPage || canFetchMore;
+  const hasMore = diversified.length > start + perPage || canFetchMore;
 
   return {
     results: paged,
@@ -306,13 +310,14 @@ async function fetchFederatedNonAcademicResults(
   });
   const reranked = await rerankResults(query, federation.results);
   const ranked = applyDomainPreferences(reranked, preferences);
+  const diversified = diversifyForTab(ranked, tab);
 
   const start = page * perPage;
-  const paged = ranked.slice(start, start + perPage);
+  const paged = diversified.slice(start, start + perPage);
   return {
     results: paged,
-    total: ranked.length,
-    hasMore: ranked.length > start + perPage,
+    total: diversified.length,
+    hasMore: diversified.length > start + perPage,
     degraded: federation.degraded,
   };
 }

--- a/src/lib/search/__tests__/diversity.test.ts
+++ b/src/lib/search/__tests__/diversity.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { UnifiedSearchResult } from "@/types/search";
-import { titleSimilarity, diversifyTopK } from "../diversity";
+import { titleSimilarity, diversifyTopK, diversifyByDomain, diversifyForTab } from "../diversity";
 
 function paper(title: string, over: Partial<UnifiedSearchResult> = {}): UnifiedSearchResult {
   return {
@@ -84,5 +84,54 @@ describe("diversifyTopK — MMR reorder within the fixed top-K", () => {
     const input = [paper("alpha beta"), paper("gamma delta"), paper("epsilon zeta"), paper("eta theta")];
     const out = diversifyTopK(input, { k: 4, anchor: 1, lambda: 0.7 });
     expect(out.map((p) => p.title)).toEqual(input.map((p) => p.title));
+  });
+});
+
+describe("diversifyByDomain — domain-aware top-K selection (MMR)", () => {
+  const d = (title: string, domain: string) =>
+    paper(title, { domain, url: `https://${domain}/${title}` });
+
+  it("promotes a distinct-domain result into the top-K over a redundant same-domain one", () => {
+    const results = [d("a", "news.com"), d("b", "news.com"), d("c", "news.com"), d("x", "other.com")];
+    const out = diversifyByDomain(results, { k: 3, lambda: 0.7 });
+    const topDomains = out.slice(0, 3).map((r) => r.domain);
+    expect(new Set(topDomains).size).toBe(2); // was 1 unique (all news.com)
+    expect(topDomains).toContain("other.com"); // x pulled up from rank 4
+  });
+
+  it("leaves an all-distinct-domain list in its original order", () => {
+    const results = [d("a", "a.com"), d("b", "b.com"), d("c", "c.com")];
+    const out = diversifyByDomain(results, { k: 3, lambda: 0.7 });
+    expect(out.map((r) => r.title)).toEqual(["a", "b", "c"]);
+  });
+
+  it("pins the anchor and never drops a result", () => {
+    const results = [d("a", "x.com"), d("b", "x.com"), d("c", "y.com"), d("e", "z.com")];
+    const out = diversifyByDomain(results, { k: 3, lambda: 0.7, anchor: 1 });
+    expect(out[0].title).toBe("a"); // anchor pinned
+    expect(out).toHaveLength(4); // nothing dropped
+    expect(new Set(out.map((r) => r.title)).size).toBe(4);
+  });
+
+  it("lambda=1 (pure relevance) keeps the original order", () => {
+    const results = [d("a", "x.com"), d("b", "x.com"), d("c", "y.com")];
+    const out = diversifyByDomain(results, { k: 3, lambda: 1 });
+    expect(out.map((r) => r.title)).toEqual(["a", "b", "c"]);
+  });
+});
+
+describe("diversifyForTab", () => {
+  const d = (title: string, domain: string) =>
+    paper(title, { domain, url: `https://${domain}/${title}` });
+
+  it("breaks a single-outlet news flood by surfacing a distinct domain into the top page", () => {
+    // 12 from one wire + 1 distinct outlet deeper than the page — diversification
+    // should pull the distinct outlet into the top 10.
+    const flood = Array.from({ length: 12 }, (_, i) => d(`n${i}`, "reuters.com"));
+    const results = [...flood, d("distinct", "apnews.com")];
+    const out = diversifyForTab(results, "news");
+    const top = out.slice(0, 10);
+    expect(top.some((r) => r.domain === "apnews.com")).toBe(true);
+    expect(out).toHaveLength(13); // nothing dropped
   });
 });

--- a/src/lib/search/diversity.ts
+++ b/src/lib/search/diversity.ts
@@ -14,6 +14,7 @@
  */
 
 import type { UnifiedSearchResult } from "@/types/search";
+import { normalizeDomain } from "@/lib/search/domain-utils";
 
 function titleTokens(title: string): Set<string> {
   return new Set(
@@ -90,4 +91,89 @@ export function diversifyTopK(
   }
 
   return [...selected, ...tail];
+}
+
+function domainKey(r: UnifiedSearchResult): string {
+  return (r.domain ?? (r.url ? normalizeDomain(r.url) ?? "" : "")).toLowerCase();
+}
+
+export interface DomainMmrOptions {
+  /** Size of the diversified window (default 10). */
+  k?: number;
+  /** Relevance-vs-diversity trade-off in [0,1]; higher favors relevance (default 0.7). */
+  lambda?: number;
+  /** Number of leading results to pin unchanged (default 0). */
+  anchor?: number;
+}
+
+/**
+ * Diversity-aware top-K SELECTION by domain (MMR). Unlike {@link diversifyTopK}
+ * (which reorders within a FIXED set on title similarity), this CHANGES the top-K
+ * set: it greedily fills K slots, penalizing each candidate by how many of its
+ * domain are already chosen, so a distinct-domain result deeper in the pool can be
+ * promoted above a redundant same-domain one. This lifts the set-based "unique
+ * domains in top-K" signal — e.g. breaks a single-outlet news flood or a
+ * single-platform discussions page. Relevance is the incoming rank (the pool is
+ * assumed sorted best-first); `lambda`↑ favors relevance over diversity. Pure
+ * function; every result is preserved (the unselected tail keeps its original order).
+ */
+export function diversifyByDomain(
+  results: UnifiedSearchResult[],
+  opts: DomainMmrOptions = {}
+): UnifiedSearchResult[] {
+  const n = results.length;
+  const k = Math.min(opts.k ?? 10, n);
+  const lambda = Math.min(1, Math.max(0, opts.lambda ?? 0.7));
+  const anchor = Math.max(0, opts.anchor ?? 0);
+  if (n < 2 || k - anchor < 2) return results;
+
+  // Incoming-rank relevance in [0,1] over the FULL pool (position 0 = 1).
+  const relevance = results.map((_, i) => (n - i) / n);
+  const counts = new Map<string, number>();
+  const out: UnifiedSearchResult[] = [];
+  for (let i = 0; i < anchor; i++) {
+    out.push(results[i]);
+    const dk = domainKey(results[i]);
+    counts.set(dk, (counts.get(dk) ?? 0) + 1);
+  }
+
+  const remaining = results.slice(anchor).map((r, i) => ({ r, idx: anchor + i }));
+
+  while (out.length < k && remaining.length > 0) {
+    let bestPos = 0;
+    let bestScore = -Infinity;
+    for (let p = 0; p < remaining.length; p++) {
+      const { r, idx } = remaining[p];
+      const redundancy = counts.get(domainKey(r)) ?? 0;
+      const mmr = lambda * relevance[idx] - (1 - lambda) * redundancy;
+      // Strictly-greater keeps it stable: earlier (higher-ranked) ties win.
+      if (mmr > bestScore) {
+        bestScore = mmr;
+        bestPos = p;
+      }
+    }
+    const chosen = remaining.splice(bestPos, 1)[0];
+    out.push(chosen.r);
+    const dk = domainKey(chosen.r);
+    counts.set(dk, (counts.get(dk) ?? 0) + 1);
+  }
+
+  return [...out, ...remaining.map((x) => x.r)];
+}
+
+// web is already domain-diverse (keyword web search rarely floods one domain) — a
+// high lambda only breaks a genuine flood. news (wire-flood) and discussions
+// (single-platform) are the flood-prone tabs, so they diversify more aggressively.
+const TAB_DIVERSITY_LAMBDA: Record<"web" | "news" | "discussions", number> = {
+  web: 0.82,
+  news: 0.6,
+  discussions: 0.6,
+};
+
+/** Tab-tuned domain diversification of the top page (k=10). */
+export function diversifyForTab(
+  results: UnifiedSearchResult[],
+  tab: "web" | "news" | "discussions"
+): UnifiedSearchResult[] {
+  return diversifyByDomain(results, { k: 10, lambda: TAB_DIVERSITY_LAMBDA[tab] });
 }


### PR DESCRIPTION
## What
- `diversifyByDomain` — domain-aware top-K **selection** MMR (changes the set, unlike the existing title-based `diversifyTopK` which only reorders within a fixed set).
- `diversifyForTab` — per-tab λ: web 0.82 (light touch, already diverse), news/discussions 0.6 (aggressive, flood-prone).
- Applied as the final non-academic reorder in **both** the eval runner and the production unified route.

## Measured (un-reranked deterministic scorecard)
| Tab | before | after | diversity dim |
|---|---|---|---|
| news | 5.8 | **6.2** | 7.3 → **10** (wire-flood broken) |
| discussions | 7.3 | 7.4 | 3.0 → 3.3 (capped ~3 by platform count) |
| web | 5.6 | 5.6 | 8.8 → 9.0 (already diverse) |

No regressions; all tests covering the change green.

## Note
Production web/news still route single-source (`FEDERATED_TABS = {discussions}`) — shipping CYCLE 2's Brave federation to prod web/news is a tracked follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEgTUohzwMogXKPsWVdwJx