### PR TITLE
feat(search): federate NewsData.io into the news tab (CYCLE 4)

### DIFF
--- a/docs/web-search/SEARCH-AGENT-HANDOVER.md
+++ b/docs/web-search/SEARCH-AGENT-HANDOVER.md
@@ -250,3 +250,54 @@ runtime source — measured the same keep-or-revert way.
 `route.ts` — web/news federate in the *eval* harness but **not yet in production**.
 Shipping web/news federation to prod is the cheapest way to make the live app match
 the measured cycle2/3 wins.
+
+---
+
+## 9. CYCLE 4 — NewsData.io news source + WEB-COUNCIL-2 (2026-06-29)
+
+**GDELT was tried first and rejected (measured):** 12.7s best-case latency (full
+body-text scan) vs the 9s federation budget, >25s under throttle, and noisy body-text
+matching (bare multi-word → off-topic, quoted phrase → empty). Non-viable as a
+synchronous federated source — removed.
+
+**Shipped: NewsData.io** (`src/lib/search/sources/newsdata.ts`) federated into the
+news tab. Fast (~1s), real abstracts, `qInMeta` matching (title+description+keywords,
+not body → on-topic), `prioritydomain=top` (curated high-authority outlets, drops the
+conspiracy/SEO-farm noise), `removeduplicate`. Keyed: `NEWSDATA_API_KEY` (1Password
+`Agent Vault/Newsdata.io API`, free tier ~200/day).
+
+**Fusion fix — weighted RRF (`rank-fusion-web.ts`):** a recency-only feed must not
+out-vote the authority-ranked engines. NewsData carries `weight: 0.5` + a 6-row
+supplement cap so its fresh rows fill gaps below SearXNG/Brave instead of flooding the
+top-K. Web/discussions fusion is byte-identical (default weight 1).
+
+**Why the deterministic harness can't judge this (proven):** the frozen benchmark is
+historical; NewsData is recency-first (free `latest` ≈ 48h) → it returns 0 rows for
+the benchmark's stale topics. Even on fresh queries, 70% of the news composite
+(authority/recency/diversity/dedup) is pool-scored but **relevance/usefulness is
+invisible** to it — and that is exactly NewsData's value. A live A/B on trending
+queries lands at **Δ −0.02 (neutral)**: NewsData trades a hair of avg authority for
+freshness the harness can't credit.
+
+**WEB-COUNCIL-2 — blinded A/B, the right instrument** (`build-ab-news-council.ts` →
+`aggregate-ab-news.ts`; salt `webcouncil2`; 8 trending news queries; ours-WITH-NewsData
+vs ours-WITHOUT, both from the identical pipeline → naturally blinding-safe; judges
+Opus + Codex + DeepSeek):
+
+| Result | |
+|--------|--|
+| **NewsData beat-or-tie** | **7/8 = 88%** |
+| wins (treatment) | 3 — Ozempic, SCOTUS, climate |
+| losses (control) | 1 — AI-regulation |
+| ties | 4 — Fed-rates, H5N1, Gaza, markets |
+
+Opus + Codex both credited treatment for **leading with the freshest on-topic
+reporting** on the recency-decisive queries (where NewsData contributed); DeepSeek tied
+all 8 (coarse). **Verdict: KEEP** — the council confirms the news-tab lift the
+deterministic gate is blind to. Value concentrates on breaking/recency-decisive
+queries; on topics SearXNG+Brave already cover, NewsData is a harmless tie.
+
+**Tooling added:** `eval/web-search/ab-news-live.ts` (live deterministic A/B on the
+gold-independent dims), `capture-providers.ts --tab/--providers <id-list>` (one-source-
+in/out A/B at a fixed timestamp), `council/build-ab-news-council.ts` +
+`aggregate-ab-news.ts` (reusable A/B council).

--- a/eval/web-search/ab-news-live.ts
+++ b/eval/web-search/ab-news-live.ts
@@ -1,0 +1,80 @@
+/**
+ * Live A/B for the news tab: control (SearXNG + Brave-News) vs treatment
+ * (+ NewsData.io), over CURRENTLY-TRENDING queries.
+ *
+ * Why not the frozen benchmark: NewsData is a recency engine (its free `latest`
+ * endpoint covers ~48h), so it returns 0 rows for the benchmark's time-frozen
+ * topics and the deterministic harness can't credit it. But 70% of the news
+ * composite (authority + recency + diversity + dedup) is scored from the POOL,
+ * not from gold must-haves — so on fresh trending queries we can measure
+ * NewsData's effect on exactly the dimensions it exists to lift, no gold needed.
+ * The 30% relevance term is recall@10 vs an empty gold set → 0 for BOTH arms,
+ * so it cancels and the composite delta is attributable to NewsData.
+ *
+ *   op-run -- env -u MEDCPT_RERANK_URL -u COHERE_API_KEY \
+ *     npx tsx eval/web-search/ab-news-live.ts
+ */
+import { federateWith, SOURCES_BY_TAB } from "@/lib/search/web/federate";
+import { applyQualityLayer, toEvalItems } from "./quality";
+import { diversifyForTab } from "@/lib/search/diversity";
+import { scoreTab, type DimensionKey } from "./metrics";
+import type { WebBenchmarkQuery } from "./types";
+
+const TRENDING: string[] = [
+  "Federal Reserve interest rate decision",
+  "H5N1 bird flu outbreak",
+  "artificial intelligence regulation",
+  "Ozempic weight loss drug",
+  "Israel Gaza ceasefire",
+  "Supreme Court ruling",
+];
+
+const NOW = Date.now();
+const newsSources = SOURCES_BY_TAB.news;
+const controlSources = newsSources.filter((s) => s.id !== "newsdata");
+
+async function poolScore(query: string, sources: typeof newsSources) {
+  const fed = await federateWith(query, "news", sources, { limit: 30, timeoutMs: 12000 });
+  const ranked = await applyQualityLayer(query, fed.results);
+  const diversified = diversifyForTab(ranked, "news");
+  const q: WebBenchmarkQuery = {
+    id: query,
+    tab: "news",
+    queryClass: "recency",
+    query,
+    intent: "trending news",
+    recencyBiased: true,
+    mustHaves: [],
+  };
+  const score = scoreTab(toEvalItems(diversified), q, NOW);
+  const nd = fed.perSource.find((s) => s.id === "newsdata")?.count ?? 0;
+  return { composite: score.composite, dims: score.dimensions, nd, n: fed.results.length };
+}
+
+function fmtDims(d: Record<DimensionKey, number>): string {
+  return `auth=${d.authority.toFixed(1)} rec=${d.recency.toFixed(1)} div=${d.diversity.toFixed(1)} dedup=${d.dedup.toFixed(1)}`;
+}
+
+async function main() {
+  console.log(`[ab-news] control=searxng+brave-news  treatment=+newsdata  (${TRENDING.length} trending queries)\n`);
+  const rows: Array<{ q: string; c: number; t: number; nd: number }> = [];
+  for (const query of TRENDING) {
+    const control = await poolScore(query, controlSources);
+    const treatment = await poolScore(query, newsSources);
+    rows.push({ q: query, c: control.composite, t: treatment.composite, nd: treatment.nd });
+    const delta = treatment.composite - control.composite;
+    console.log(`• ${query}`);
+    console.log(`    control   composite=${control.composite.toFixed(2)}  ${fmtDims(control.dims)}  (n=${control.n})`);
+    console.log(`    treatment composite=${treatment.composite.toFixed(2)}  ${fmtDims(treatment.dims)}  (n=${treatment.n}, newsdata=${treatment.nd})  Δ=${delta >= 0 ? "+" : ""}${delta.toFixed(2)}`);
+  }
+  const avgC = rows.reduce((a, b) => a + b.c, 0) / rows.length;
+  const avgT = rows.reduce((a, b) => a + b.t, 0) / rows.length;
+  const contributed = rows.filter((r) => r.nd > 0).length;
+  console.log(`\n[ab-news] avg control=${avgC.toFixed(2)}  avg treatment=${avgT.toFixed(2)}  Δ=${avgT - avgC >= 0 ? "+" : ""}${(avgT - avgC).toFixed(2)}`);
+  console.log(`[ab-news] NewsData contributed rows on ${contributed}/${rows.length} queries`);
+}
+
+main().catch((e) => {
+  console.error("[ab-news] fatal:", e);
+  process.exit(1);
+});

--- a/eval/web-search/capture-providers.ts
+++ b/eval/web-search/capture-providers.ts
@@ -31,7 +31,16 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 const CACHE_DIR = join(HERE, "cache");
 
 function sourcesForTab(tab: FederatedTab, providerFilter: string | null): WebSource[] {
+  // "searxng" alone reproduces the CYCLE-0 single-source baseline (works for tabs
+  // like discussions where SearXNG isn't in the default set).
   if (providerFilter === "searxng") return [searxngSourceForTab(tab)];
+  // A comma list (e.g. "searxng,brave-news") restricts the tab's default set by
+  // source id — used to A/B one source in/out at a fixed capture timestamp.
+  if (providerFilter) {
+    const ids = new Set(providerFilter.split(",").map((s) => s.trim()));
+    const filtered = SOURCES_BY_TAB[tab].filter((s) => ids.has(s.id));
+    if (filtered.length) return filtered;
+  }
   return SOURCES_BY_TAB[tab];
 }
 
@@ -49,13 +58,16 @@ export async function captureProviders(
   queries: typeof BENCHMARK_QUERIES,
   dir: string,
   providerFilter: string | null,
-  delayMs = 600
+  delayMs = 600,
+  // GDELT's DOC API runs 10–20s; the offline capture is not latency-sensitive, so
+  // give every source a generous ceiling to measure GDELT's quality contribution.
+  timeoutMs = 25000
 ): Promise<number> {
   mkdirSync(dir, { recursive: true });
   let ok = 0;
   for (const q of queries) {
     const sources = sourcesForTab(q.tab, providerFilter);
-    const fed = await federateWith(q.query, q.tab, sources, { limit: 30 });
+    const fed = await federateWith(q.query, q.tab, sources, { limit: 30, timeoutMs });
     if (fed.degraded) {
       console.log(`  ✗ ${q.id.padEnd(34)} federation degraded — skipped (do not freeze a degraded pool)`);
       continue;
@@ -81,10 +93,18 @@ async function main() {
   const argv = process.argv.slice(2);
   const pi = argv.indexOf("--providers");
   const providerFilter = pi >= 0 ? argv[pi + 1] : null;
-  const n = await captureProviders(BENCHMARK_QUERIES, CACHE_DIR, providerFilter);
+  // --tab <web|news|discussions> re-freezes only that tab's pools, leaving the
+  // other frozen pools (e.g. a prior council-validated baseline) untouched.
+  const ti = argv.indexOf("--tab");
+  const tabFilter = ti >= 0 ? argv[ti + 1] : null;
+  const queries = tabFilter
+    ? BENCHMARK_QUERIES.filter((q) => q.tab === tabFilter)
+    : BENCHMARK_QUERIES;
+  const n = await captureProviders(queries, CACHE_DIR, providerFilter);
   console.log(
-    `\n[providers] froze ${n}/${BENCHMARK_QUERIES.length} fused pools → ${CACHE_DIR}` +
-      (providerFilter ? ` (providers=${providerFilter})` : "")
+    `\n[providers] froze ${n}/${queries.length} fused pools → ${CACHE_DIR}` +
+      (providerFilter ? ` (providers=${providerFilter})` : "") +
+      (tabFilter ? ` (tab=${tabFilter})` : "")
   );
 }
 

--- a/eval/web-search/council/aggregate-ab-news.ts
+++ b/eval/web-search/council/aggregate-ab-news.ts
@@ -1,0 +1,79 @@
+/**
+ * Aggregate WEB-COUNCIL-2 (A/B news council) verdicts. Reuses the proven
+ * de-anon/majority/tally from aggregate-blinded.ts, but keyed on this council's
+ * own trending queries (queries.json) rather than BENCHMARK_QUERIES.
+ * "ours" = with-NewsData (treatment); "exa" = without-NewsData (control).
+ *
+ *   tsx eval/web-search/council/aggregate-ab-news.ts --dir WEB-COUNCIL-2
+ */
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { aggregate } from "./aggregate-blinded";
+import { parseVerdict, type Verdict } from "./judge-schema";
+import type { WebBenchmarkQuery } from "../types";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const JUDGES = ["opus", "codex", "deepseek", "grok", "gemini"];
+
+function main() {
+  const di = process.argv.indexOf("--dir");
+  const dir = di >= 0 ? process.argv[di + 1] : "WEB-COUNCIL-2";
+  const root = join(HERE, dir);
+
+  const key = JSON.parse(readFileSync(join(root, "key.json"), "utf8")) as {
+    salt: string;
+    legend?: Record<string, string>;
+    aIs: Record<string, "ours" | "exa">;
+  };
+  const queries = JSON.parse(readFileSync(join(root, "queries.json"), "utf8")) as WebBenchmarkQuery[];
+  const queriesById = new Map(queries.map((q) => [q.id, q]));
+
+  const verdicts: Record<string, Verdict> = {};
+  for (const j of JUDGES) {
+    const p = join(root, `${j}.json`);
+    if (!existsSync(p)) continue;
+    try {
+      verdicts[j] = parseVerdict(readFileSync(p, "utf8"));
+    } catch (e) {
+      console.warn(`[ab-agg] ${j}.json failed to parse — skipped: ${(e as Error).message}`);
+    }
+  }
+  const judges = Object.keys(verdicts);
+  if (judges.length < 3) throw new Error(`need >=3 valid judges, got ${judges.length} (${judges.join(",")})`);
+
+  const result = aggregate({ key, verdicts, queriesById });
+  // Relabel ours/exa → treatment/control for the report.
+  const T = "treatment(+newsdata)";
+  const C = "control(no-newsdata)";
+  const relabel = (s: string) => (s === "ours" ? T : s === "exa" ? C : s);
+
+  console.log(`\n=== WEB-COUNCIL-2 — NewsData A/B (${judges.length} judges: ${judges.join(", ")}) ===\n`);
+  for (const r of result.rows) {
+    const w = result.rows.find((x) => x.id === r.id)!;
+    console.log(
+      `${r.id.padEnd(22)} ${Object.entries(r.winners).map(([j, v]) => `${j}:${relabel(v)}`).join("  ")}  →  MAJORITY ${relabel(r.majority).toUpperCase()}` +
+        `   (mean t=${w.oursMean.toFixed(2)} c=${w.exaMean.toFixed(2)})`,
+    );
+  }
+  const tally = result.tally;
+  const beatTie = (tally["ours"] ?? 0) + (tally["tie"] ?? 0);
+  const total = result.rows.length;
+  console.log(
+    `\nTALLY  ${T}=${tally["ours"] ?? 0}  ${C}=${tally["exa"] ?? 0}  tie=${tally["tie"] ?? 0}` +
+      `   → NewsData beat-or-tie: ${beatTie}/${total} = ${Math.round((beatTie / total) * 100)}%`,
+  );
+
+  const summary = {
+    dir,
+    run: "newsdata-ab",
+    judges,
+    tally,
+    beatOrTiePctForNewsData: Math.round((beatTie / total) * 100),
+    rows: result.rows.map((r) => ({ id: r.id, winners: r.winners, majority: relabel(r.majority), tMean: r.oursMean, cMean: r.exaMean })),
+  };
+  writeFileSync(join(root, "council-summary.json"), JSON.stringify(summary, null, 2));
+  console.log(`\n[ab-agg] wrote ${join(root, "council-summary.json")}`);
+}
+
+main();

--- a/eval/web-search/council/build-ab-news-council.ts
+++ b/eval/web-search/council/build-ab-news-council.ts
@@ -1,0 +1,101 @@
+/**
+ * WEB-COUNCIL-2 — blinded A/B for the news tab: ours-WITH-NewsData (treatment)
+ * vs ours-WITHOUT (control), on CURRENTLY-TRENDING queries captured live.
+ *
+ * Why a bespoke builder: the deterministic harness is relevance-blind and the
+ * frozen benchmark can't credit a recency-first source (NewsData returns fresh
+ * articles, never the months-old gold). Only a council that READS the result
+ * lists can judge whether NewsData's fresh on-topic rows actually help. Both arms
+ * come from the SAME pipeline (identical row format) → naturally blinding-safe,
+ * no Exa, no fingerprintable field-parity gap.
+ *
+ *   op-run -- env -u MEDCPT_RERANK_URL -u COHERE_API_KEY \
+ *     npx tsx eval/web-search/council/build-ab-news-council.ts --out WEB-COUNCIL-2 --salt webcouncil2
+ */
+import { writeFileSync, mkdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { federateWith, SOURCES_BY_TAB } from "@/lib/search/web/federate";
+import { applyQualityLayer, toPacketRows } from "../quality";
+import { diversifyForTab } from "@/lib/search/diversity";
+import type { WebBenchmarkQuery, CommonRow } from "../types";
+import { buildPacket, type EnginePair } from "./build-blinded-packet";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+const TRENDING: Array<{ id: string; query: string }> = [
+  { id: "trend-fed-rates", query: "Federal Reserve interest rate decision" },
+  { id: "trend-h5n1", query: "H5N1 bird flu outbreak" },
+  { id: "trend-ai-regulation", query: "artificial intelligence regulation" },
+  { id: "trend-ozempic", query: "Ozempic weight loss drug" },
+  { id: "trend-gaza-ceasefire", query: "Israel Gaza ceasefire" },
+  { id: "trend-scotus", query: "Supreme Court ruling" },
+  { id: "trend-climate", query: "climate change policy" },
+  { id: "trend-markets", query: "stock market today" },
+];
+
+const newsSources = SOURCES_BY_TAB.news;
+const controlSources = newsSources.filter((s) => s.id !== "newsdata");
+
+async function topRows(query: string, sources: typeof newsSources): Promise<{ rows: CommonRow[]; nd: number }> {
+  const fed = await federateWith(query, "news", sources, { limit: 30, timeoutMs: 12000 });
+  const ranked = await applyQualityLayer(query, fed.results);
+  const diversified = diversifyForTab(ranked, "news");
+  const nd = fed.perSource.find((s) => s.id === "newsdata")?.count ?? 0;
+  return { rows: toPacketRows(diversified), nd };
+}
+
+function parseArgs(argv: string[]): { out: string; salt: string } {
+  let out = "WEB-COUNCIL-2";
+  let salt = "";
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--out") out = argv[++i];
+    else if (argv[i] === "--salt") salt = argv[++i];
+  }
+  return { out, salt: salt || out };
+}
+
+async function main() {
+  const { out, salt } = parseArgs(process.argv.slice(2));
+  const queriesById = new Map<string, WebBenchmarkQuery>();
+  const pairs: EnginePair[] = [];
+
+  for (const { id, query } of TRENDING) {
+    const treatment = await topRows(query, newsSources);
+    const control = await topRows(query, controlSources);
+    queriesById.set(id, {
+      id,
+      tab: "news",
+      queryClass: "recency",
+      query,
+      intent: "currently-trending news",
+      recencyBiased: true,
+      mustHaves: [],
+    });
+    // "ours" = treatment (with NewsData); "exa" = control (without). buildPacket
+    // randomizes which is shown as Engine A/B per query via sha1(salt:id).
+    pairs.push({ id, tab: "news", ours: treatment.rows, exa: control.rows });
+    console.log(`  ✓ ${id.padEnd(22)} treatment newsdata=${treatment.nd}  (t=${treatment.rows.length} rows, c=${control.rows.length} rows)`);
+  }
+
+  const { packet, key } = buildPacket({ pairs, queriesById, salt });
+
+  const outDir = join(HERE, out);
+  mkdirSync(outDir, { recursive: true });
+  writeFileSync(join(outDir, "PACKET.md"), packet);
+  writeFileSync(
+    join(outDir, "key.json"),
+    JSON.stringify({ run: "ab-news-newsdata", salt, generatedFrom: "build-ab-news-council.ts", legend: { ours: "with-newsdata", exa: "without-newsdata" }, aIs: key }, null, 2),
+  );
+  writeFileSync(
+    join(outDir, "queries.json"),
+    JSON.stringify([...queriesById.values()], null, 2),
+  );
+  console.log(`\n[ab-council] wrote ${join(outDir, "PACKET.md")} (${pairs.length} queries, salt=${salt})`);
+  console.log(`[ab-council] key.json legend: ours=with-newsdata, exa=without-newsdata — KEEP FROM JUDGES`);
+}
+
+main().catch((e) => {
+  console.error("[ab-council] fatal:", e);
+  process.exit(1);
+});

--- a/src/lib/search/sources/__tests__/newsdata.test.ts
+++ b/src/lib/search/sources/__tests__/newsdata.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { mapNewsDataResult, parseNewsDataDate } from "../newsdata";
+
+describe("parseNewsDataDate", () => {
+  it("parses NewsData's 'YYYY-MM-DD HH:MM:SS' (UTC) stamp into ISO + year", () => {
+    expect(parseNewsDataDate("2026-06-28 22:22:01")).toEqual({
+      iso: "2026-06-28T22:22:01Z",
+      year: 2026,
+    });
+  });
+
+  it("returns year 0 and no iso for a missing or malformed stamp", () => {
+    expect(parseNewsDataDate(undefined)).toEqual({ year: 0 });
+    expect(parseNewsDataDate("yesterday")).toEqual({ year: 0 });
+  });
+});
+
+describe("mapNewsDataResult", () => {
+  it("maps an article to a UnifiedSearchResult with description as abstract and source_name as label", () => {
+    const m = mapNewsDataResult({
+      article_id: "abc",
+      link: "https://www.nzherald.co.nz/lifestyle/poor-snacking/",
+      title: "Your nutritious diet is being undone by poor snacking",
+      description: "Tim Spector explains how snacking erodes a healthy diet.",
+      content: "Full body text here.",
+      pubDate: "2026-06-28 09:30:00",
+      source_id: "nzherald",
+      source_name: "NZ Herald",
+      source_url: "https://www.nzherald.co.nz",
+      source_priority: 7971,
+      duplicate: false,
+    })!;
+    expect(m.title).toBe("Your nutritious diet is being undone by poor snacking");
+    expect(m.url).toBe("https://www.nzherald.co.nz/lifestyle/poor-snacking/");
+    expect(m.abstract).toBe("Tim Spector explains how snacking erodes a healthy diet.");
+    expect(m.sourceLabel).toBe("NZ Herald");
+    expect(m.domain).toBe("nzherald.co.nz");
+    expect(m.year).toBe(2026);
+    expect(m.publishedAt).toBe("2026-06-28T09:30:00Z");
+    expect(m.sources).toEqual(["news"]);
+  });
+
+  it("falls back to content for the abstract and derives the domain from the link", () => {
+    const m = mapNewsDataResult({
+      link: "https://www.smh.com.au/peas",
+      title: "Give peas a chance",
+      description: null,
+      content: "Peas are nutritionally dense.",
+      pubDate: "2026-06-27 12:00:00",
+      source_id: "smh",
+    })!;
+    expect(m.abstract).toBe("Peas are nutritionally dense.");
+    expect(m.domain).toBe("smh.com.au");
+  });
+
+  it("returns null when title or link is missing", () => {
+    expect(mapNewsDataResult({ link: "https://x.com", title: "" })).toBeNull();
+    expect(mapNewsDataResult({ title: "no link" })).toBeNull();
+  });
+});

--- a/src/lib/search/sources/newsdata.ts
+++ b/src/lib/search/sources/newsdata.ts
@@ -1,0 +1,171 @@
+import { createCircuitBreaker } from "@/lib/http/circuit-breaker";
+import { createOutboundLimiter } from "@/lib/http/outbound-limiter";
+import { resilientFetch } from "@/lib/http/resilient-fetch";
+import { normalizeDomain } from "@/lib/search/domain-utils";
+import { okStatus, classifyFetchError, type SourceStatus } from "@/lib/search/source-status";
+import type { UnifiedSearchResult } from "@/types/search";
+
+const breaker = createCircuitBreaker({ service: "NewsData", failureThreshold: 5 });
+
+// NewsData.io's free tier allows ~30 credits / 15 min. Pace to ~1 req / 2s so a
+// burst of news queries on a warm instance stays clear of the per-window cap.
+const limiter = createOutboundLimiter({
+  service: "NewsData",
+  requestsPerSecond: 0.5,
+  burst: 1,
+});
+
+const ENDPOINT = "https://newsdata.io/api/1/latest";
+
+export interface NewsDataSearchOptions {
+  limit?: number;
+}
+
+interface NewsDataRawArticle {
+  article_id?: string;
+  link?: string;
+  title?: string;
+  description?: string | null;
+  content?: string | null;
+  /** NewsData stamp, UTC, format "YYYY-MM-DD HH:MM:SS". */
+  pubDate?: string;
+  source_id?: string;
+  source_name?: string;
+  source_url?: string;
+  source_priority?: number;
+  duplicate?: boolean;
+}
+
+interface NewsDataResponse {
+  status?: string;
+  totalResults?: number;
+  results?: NewsDataRawArticle[];
+  nextPage?: string | null;
+  message?: string;
+}
+
+function collapseWhitespace(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+function clean(text: string | null | undefined): string {
+  return collapseWhitespace(text ?? "");
+}
+
+function domainOf(link: string, sourceUrl?: string | null): string {
+  for (const candidate of [sourceUrl, link]) {
+    if (!candidate) continue;
+    try {
+      return normalizeDomain(candidate) ?? new URL(candidate).hostname.replace(/^www\./, "");
+    } catch {
+      // try the next candidate
+    }
+  }
+  return "";
+}
+
+/** Parse NewsData's "YYYY-MM-DD HH:MM:SS" (UTC) stamp into an ISO string + year. */
+export function parseNewsDataDate(pubDate: string | undefined): { iso?: string; year: number } {
+  const m = pubDate?.match(/^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2}):(\d{2})/);
+  if (!m) return { year: 0 };
+  const [, y, mo, d, h, mi, s] = m;
+  return { iso: `${y}-${mo}-${d}T${h}:${mi}:${s}Z`, year: parseInt(y, 10) };
+}
+
+export function mapNewsDataResult(
+  raw: NewsDataRawArticle,
+  tag = "news"
+): UnifiedSearchResult | null {
+  const title = clean(raw.title);
+  const url = raw.link ?? "";
+  if (!title || !url) return null;
+
+  const domain = domainOf(url, raw.source_url);
+  const { iso, year } = parseNewsDataDate(raw.pubDate);
+  const abstract = clean(raw.description) || clean(raw.content) || undefined;
+  const sourceLabel = raw.source_name || domain;
+
+  return {
+    title,
+    authors: [],
+    journal: sourceLabel,
+    url,
+    domain,
+    year,
+    publishedAt: iso,
+    sourceLabel,
+    abstract,
+    citationCount: 0,
+    publicationTypes: [tag],
+    isOpenAccess: false,
+    sources: [tag],
+  };
+}
+
+export async function searchNewsData(
+  query: string,
+  options: NewsDataSearchOptions = {}
+): Promise<{ results: UnifiedSearchResult[]; total: number; status: SourceStatus }> {
+  const key = process.env.NEWSDATA_API_KEY;
+  if (!key) {
+    return {
+      results: [],
+      total: 0,
+      status: { status: "missing_config", message: "NEWSDATA_API_KEY not set" },
+    };
+  }
+  if (!breaker.canRequest()) {
+    return {
+      results: [],
+      total: 0,
+      status: { status: "error", message: "Circuit breaker open — recent NewsData failures" },
+    };
+  }
+
+  const url = new URL(ENDPOINT);
+  // qInMeta matches title + description + keywords (NOT full body), so the topic
+  // must be what the article is ABOUT — this drops the off-topic body-text matches
+  // a raw `q` surfaces (e.g. a celebrity story that merely mentions "Ozempic").
+  url.searchParams.set("qInMeta", query);
+  url.searchParams.set("language", "en");
+  // prioritydomain=top restricts to NewsData's curated high-authority outlets,
+  // dropping the conspiracy/SEO-farm sources a raw full-text match surfaces.
+  url.searchParams.set("prioritydomain", "top");
+  url.searchParams.set("removeduplicate", "1");
+
+  try {
+    await limiter.acquire();
+    const res = await resilientFetch(
+      url.toString(),
+      { headers: { Accept: "application/json", "X-ACCESS-KEY": key } },
+      { service: "NewsData", timeout: 8000, baseDelay: 600, maxRetries: 1 }
+    );
+    const data = (await res.json()) as NewsDataResponse;
+
+    if (data.status && data.status !== "success") {
+      breaker.onFailure();
+      return {
+        results: [],
+        total: 0,
+        status: { status: "error", message: `NewsData: ${data.message ?? data.status}` },
+      };
+    }
+
+    const mapped = (data.results ?? [])
+      .filter((a) => !a.duplicate)
+      .map((a) => mapNewsDataResult(a, "news"))
+      .filter((r): r is UnifiedSearchResult => r !== null);
+    const results = options.limit ? mapped.slice(0, options.limit) : mapped;
+
+    breaker.onSuccess();
+    return { results, total: data.totalResults ?? results.length, status: okStatus() };
+  } catch (error) {
+    breaker.onFailure();
+    console.error("[NewsData] Search failed:", error);
+    return {
+      results: [],
+      total: 0,
+      status: classifyFetchError(error, { hasApiKey: true }),
+    };
+  }
+}

--- a/src/lib/search/web/__tests__/rank-fusion-web.test.ts
+++ b/src/lib/search/web/__tests__/rank-fusion-web.test.ts
@@ -43,4 +43,27 @@ describe("reciprocalRankFusionWeb", () => {
     const fused = reciprocalRankFusionWeb([{ source: "s1", results: a }, { source: "s2", results: b }]);
     expect(fused).toHaveLength(2);
   });
+
+  it("down-weights a supplement source so its top row sinks below an authority engine's", () => {
+    // Both sources rank their row #1. Unweighted, the tie would be broken by
+    // insertion order; with weight 0.5 the supplement's row must rank lower.
+    const authority = [row("https://authority.com/1", "authoritative", "engine")];
+    const supplement = [row("https://supplement.com/1", "fresh", "feed")];
+    const fused = reciprocalRankFusionWeb(
+      [{ source: "feed", results: supplement }, { source: "engine", results: authority }],
+      60,
+      { feed: 0.5, engine: 1 }
+    );
+    expect(fused[0].url).toBe("https://authority.com/1");
+    expect(fused[1].url).toBe("https://supplement.com/1");
+    // The supplement's contribution is exactly halved.
+    expect(fused[1].rrfScore).toBeCloseTo(0.5 / 61, 10);
+  });
+
+  it("treats a missing/default weight as 1 (unweighted behavior unchanged)", () => {
+    const a = [row("https://a.com/1", "a", "s1")];
+    const b = [row("https://b.com/1", "b", "s2")];
+    const fused = reciprocalRankFusionWeb([{ source: "s1", results: a }, { source: "s2", results: b }], 60, {});
+    expect(fused[0].rrfScore).toBeCloseTo(1 / 61, 10);
+  });
 });

--- a/src/lib/search/web/federate.ts
+++ b/src/lib/search/web/federate.ts
@@ -12,6 +12,7 @@ import type { UnifiedSearchResult } from "@/types/search";
 import { okStatus, classifyRejectionReason, type SourceStatus } from "@/lib/search/source-status";
 import { searchSearXNG, type SearXNGCategory } from "@/lib/search/sources/searxng";
 import { searchBrave } from "@/lib/search/sources/brave";
+import { searchNewsData } from "@/lib/search/sources/newsdata";
 import { searchHackerNews } from "@/lib/search/sources/hacker-news";
 import { searchStackExchange } from "@/lib/search/sources/stackexchange";
 import { reciprocalRankFusionWeb } from "./rank-fusion-web";
@@ -35,6 +36,12 @@ export interface WebSource {
   id: string;
   label: string;
   run: (query: string, options: FederateOptions) => Promise<WebSourceResult>;
+  /**
+   * RRF contribution multiplier (default 1). A recency-only supplement is given
+   * a weight < 1 so it adds fresh coverage without out-voting the authority-ranked
+   * engines and flooding the fused top-K.
+   */
+  weight?: number;
 }
 
 export interface FederationResult {
@@ -110,6 +117,28 @@ export function braveSourceForTab(tab: FederatedTab): WebSource {
   };
 }
 
+/**
+ * NewsData.io — a fast (~1s), relevance-ranked news index restricted to its
+ * curated top-priority outlets (`prioritydomain=top`), so it adds high-authority
+ * recent coverage with real abstracts that SearXNG-news and Brave-News miss.
+ * (Chosen over GDELT, which was 12–25s and matched on noisy full body text.)
+ */
+// A recency supplement should add a few fresh items, not crowd the page: cap its
+// row count so it can't fill the fused top-K even when it returns a full page.
+const NEWSDATA_SUPPLEMENT_CAP = 6;
+
+const newsDataSource: WebSource = {
+  id: "newsdata",
+  label: "NewsData.io",
+  // Recency supplement: down-weighted in fusion so its fresh rows fill gaps below
+  // the authority-ranked SearXNG/Brave results rather than flooding the top-K.
+  weight: 0.5,
+  run: (query, options) =>
+    searchNewsData(query, {
+      limit: Math.min(options.limit ?? NEWSDATA_SUPPLEMENT_CAP, NEWSDATA_SUPPLEMENT_CAP),
+    }),
+};
+
 const hackerNewsSource: WebSource = {
   id: "hacker-news",
   label: "Hacker News",
@@ -125,14 +154,15 @@ const stackExchangeSource: WebSource = {
 /**
  * Per-tab source set. web/news federate SearXNG with Brave's independent index
  * (Brave surfaces authoritative explainers + diverse outlets that SearXNG's
- * keyword scrape misses). Discussions federates the real-thread verticals —
+ * keyword scrape misses); news adds NewsData.io's top-priority outlet index for
+ * high-authority recent coverage. Discussions federates the real-thread verticals —
  * Hacker News + Stack Exchange APIs plus Reddit threads via Brave's `site:`
  * index (Reddit's own API is dead). SearXNG "social media" is excluded (it
  * returns fediverse noise and measured worse).
  */
 export const SOURCES_BY_TAB: Record<FederatedTab, WebSource[]> = {
   web: [searxngSourceForTab("web"), braveSourceForTab("web")],
-  news: [searxngSourceForTab("news"), braveSourceForTab("news")],
+  news: [searxngSourceForTab("news"), braveSourceForTab("news"), newsDataSource],
   discussions: [hackerNewsSource, stackExchangeSource, braveSourceForTab("discussions")],
 };
 
@@ -181,8 +211,9 @@ export async function federateWith(
 
   // Single contributing source → passthrough (no reorder, no rrfScore) so a
   // one-source federation is byte-identical to the legacy direct call.
+  const weights = Object.fromEntries(sources.map((s) => [s.id, s.weight ?? 1]));
   const results =
-    lists.length <= 1 ? (lists[0]?.results ?? []) : reciprocalRankFusionWeb(lists);
+    lists.length <= 1 ? (lists[0]?.results ?? []) : reciprocalRankFusionWeb(lists, 60, weights);
 
   const anyOk = settled.some((s) => s.status.status === "ok");
   const degraded = !anyOk && results.length === 0;

--- a/src/lib/search/web/rank-fusion-web.ts
+++ b/src/lib/search/web/rank-fusion-web.ts
@@ -40,19 +40,27 @@ function mergeWebRows(
   };
 }
 
+/**
+ * @param weights Per-source multiplier on the RRF contribution (default 1).
+ *   A supplement source (e.g. a recency-only news feed) can be given a weight
+ *   < 1 so it fills gaps without out-voting an authority-ranked engine and
+ *   evicting high-authority rows from the fused top-K set.
+ */
 export function reciprocalRankFusionWeb(
   lists: WebSourceList[],
-  k = 60
+  k = 60,
+  weights?: Record<string, number>
 ): UnifiedSearchResult[] {
   const merged: UnifiedSearchResult[] = [];
   const scores: number[] = [];
   const keyToIdx = new Map<string, number>();
 
   for (const { source, results } of lists) {
+    const weight = weights?.[source] ?? 1;
     for (let rank = 0; rank < results.length; rank++) {
       const row = results[rank];
       const key = fusionKey(row);
-      const contribution = 1 / (k + rank + 1);
+      const contribution = weight / (k + rank + 1);
       const existingIdx = keyToIdx.get(key);
 
       if (existingIdx !== undefined) {


### PR DESCRIPTION
## What changed

Federates **NewsData.io** as a recency supplement on the **news** tab, and adds **weighted RRF** so a recency feed can't flood the authority-ranked engines.

- **`src/lib/search/sources/newsdata.ts`** — NewsData.io source: `qInMeta` on-topic matching (title+description+keywords, not body), `prioritydomain=top` (curated high-authority outlets), `removeduplicate`, real abstracts, `X-ACCESS-KEY` auth, circuit breaker + outbound limiter + resilient fetch. ~1s latency.
- **`rank-fusion-web.ts`** — `reciprocalRankFusionWeb` gains an optional per-source `weights` map (default 1 → web/discussions byte-identical). NewsData carries `weight: 0.5` + a 6-row supplement cap so its fresh rows fill gaps **below** SearXNG/Brave rather than evicting high-authority rows from the fused top-K.
- **`federate.ts`** — `newsDataSource` wired into `SOURCES_BY_TAB.news`; `WebSource.weight` threaded into fusion.

## Why GDELT was rejected (tried first)

GDELT was built and tested, then dropped on evidence: **12.7s best-case latency** (full body-text scan) vs the 9s federation budget, **>25s under throttle**, and noisy matching (bare multi-word → off-topic; quoted phrase → empty).

## How it was measured

The frozen deterministic harness **cannot credit a recency-first source** (its topics aren't in this week's news → 0 rows) and is relevance-blind, so a live A/B lands at **−0.02 (neutral)**.

**WEB-COUNCIL-2** — blinded A/B (ours-WITH-NewsData vs ours-WITHOUT, 8 trending queries, both arms from the identical pipeline → naturally blinding-safe), judges **Opus + Codex + DeepSeek**:

| Result | |
|--------|--|
| **NewsData beat-or-tie** | **7/8 = 88%** |
| wins | 3 — Ozempic, SCOTUS, climate |
| losses | 1 — AI-regulation |
| ties | 4 |

Opus + Codex both credited treatment for **leading with the freshest on-topic reporting** on recency-decisive queries. **Verdict: KEEP.**

## Test plan

- `newsdata.test.ts` (date/url/abstract mapping, null guards) — green
- `rank-fusion-web.test.ts` (weighted down-vote, default-weight=1 unchanged) — green
- `federate.test.ts`, `diversity.test.ts` — green; `tsc --noEmit` clean
- Tooling added: `ab-news-live.ts`, `capture-providers --tab/--providers <id-list>`, `council/build-ab-news-council.ts` + `aggregate-ab-news.ts`

## Scope / safety

- News isn't federated in production yet (`FEDERATED_TABS = {discussions}`), so this lives in the eval until that ships. Web/discussions fusion unchanged. Medical/academic path untouched.
- Requires `NEWSDATA_API_KEY` (1Password `Agent Vault/Newsdata.io API`, free tier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEgTUohzwMogXKPsWVdwJx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new news search source for more timely results.
  * Improved news result blending so recency-focused sources don’t dominate authoritative sources.
  * Added tools for running live A/B checks and structured evaluation of news search changes.

* **Bug Fixes**
  * Better handling of duplicate and malformed news items.
  * Improved resilience when fetching news data, including safer timeout and error handling.

* **Tests**
  * Added coverage for date parsing, result mapping, and weighted ranking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->