### PR TITLE
feat(search): enable semantic web reranker, gated to the web tab (CYCLE 5)

### DIFF
--- a/docs/web-search/SEARCH-AGENT-HANDOVER.md
+++ b/docs/web-search/SEARCH-AGENT-HANDOVER.md
@@ -297,7 +297,47 @@ all 8 (coarse). **Verdict: KEEP** — the council confirms the news-tab lift the
 deterministic gate is blind to. Value concentrates on breaking/recency-decisive
 queries; on topics SearXNG+Brave already cover, NewsData is a harmless tie.
 
-**Tooling added:** `eval/web-search/ab-news-live.ts` (live deterministic A/B on the
+**Tooling added (CYCLE 4):** `eval/web-search/ab-news-live.ts` (live deterministic A/B on the
 gold-independent dims), `capture-providers.ts --tab/--providers <id-list>` (one-source-
 in/out A/B at a fixed timestamp), `council/build-ab-news-council.ts` +
 `aggregate-ab-news.ts` (reusable A/B council).
+
+---
+
+## 10. CYCLE 5 — semantic web reranker, gated to the web tab (2026-06-29)
+
+The bge-reranker-v2-m3 cross-encoder (`WEB_RERANK_URL`, deployed in CYCLE 1, Modal
+scale-to-zero) is now **ENABLED for the web tab**. It was previously disabled because
+the **set-based deterministic gate can't credit ordering** — a reorder only looks like
+gold-eviction to it (it regressed the gate web 5.6→4.6). The right instrument is the
+council.
+
+**WEB-COUNCIL-3** — blinded A/B, reranker ON vs OFF on the **same frozen web+news
+pools** (identical input → isolates the reorder exactly; `build-reranker-council.ts`
+toggles `WEB_RERANK_URL` in-process), judges Opus + Codex + DeepSeek:
+
+| Tab | reranker beat-or-tie | detail |
+|-----|---------------------|--------|
+| **web** | **3/4 (75%)** ✅ | crispr, reproducibility, aspirin win; gut-microbiome the one loss |
+| news | 2/4 (50%) — wash | demotes fresh items on a recency-first tab (retraction −0.72) |
+
+The standout: **web-reproducibility 2.22 → 4.22** — without the reranker the top result
+was a catastrophic off-topic ("Japan travel pollution"); the cross-encoder demoted it.
+That is the semantic-relevance lift the keyword stack can't do — the real Exa gap.
+
+**Wiring:** `route.ts → rerankWebTabOnly()` gates the cross-encoder to the **web tab**;
+news (recency-first) and discussions (already 100%) keep their recency/diversity
+ordering. **Fail-open-fast:** the web reranker fetch uses a 4s ceiling + no retry, so a
+scale-from-zero cold start (~20s) degrades to un-reranked results *instantly* instead of
+stalling the search — keeping a GPU warm 24/7 isn't worth it at this scale. A warm rerank
+returns in well under a second.
+
+**Eval note:** `WEB_RERANK_URL` is now in `dev.env`, so the deterministic gate's clean
+(un-reranked) baseline command must also unset it:
+`env -u MEDCPT_RERANK_URL -u COHERE_API_KEY -u WEB_RERANK_URL`. Warm the endpoint with one
+request before a reranker council run (first hit cold-starts ~20s).
+
+**Where this leaves the Exa gap:** web/news federation (cycles 2–4) lifted retrieval;
+the reranker (cycle 5) is the first **semantic-ordering** lever and it wins on web where
+relevance is king. The next quantitative step is a fresh ours-vs-**Exa** web council to
+re-measure the 25% web parity number now that reranking is on.

--- a/eval/web-search/council/aggregate-ab-news.ts
+++ b/eval/web-search/council/aggregate-ab-news.ts
@@ -43,12 +43,13 @@ function main() {
   if (judges.length < 3) throw new Error(`need >=3 valid judges, got ${judges.length} (${judges.join(",")})`);
 
   const result = aggregate({ key, verdicts, queriesById });
-  // Relabel ours/exa → treatment/control for the report.
-  const T = "treatment(+newsdata)";
-  const C = "control(no-newsdata)";
+  // Relabel ours/exa → the run's own legend (e.g. with/without a source or reranker).
+  const T = `treatment(${key.legend?.ours ?? "ours"})`;
+  const C = `control(${key.legend?.exa ?? "exa"})`;
   const relabel = (s: string) => (s === "ours" ? T : s === "exa" ? C : s);
 
-  console.log(`\n=== WEB-COUNCIL-2 — NewsData A/B (${judges.length} judges: ${judges.join(", ")}) ===\n`);
+  console.log(`\n=== ${dir} — A/B (${judges.length} judges: ${judges.join(", ")}) ===`);
+  console.log(`legend: treatment=${key.legend?.ours ?? "ours"}, control=${key.legend?.exa ?? "exa"}\n`);
   for (const r of result.rows) {
     const w = result.rows.find((x) => x.id === r.id)!;
     console.log(

--- a/eval/web-search/council/build-reranker-council.ts
+++ b/eval/web-search/council/build-reranker-council.ts
@@ -1,0 +1,95 @@
+/**
+ * WEB-COUNCIL-3 — blinded A/B for the semantic reranker: ours-WITH-reranker
+ * (bge-reranker-v2-m3 via WEB_RERANK_URL) vs ours-WITHOUT, on the SAME frozen
+ * web+news pools. Identical input pool → the only difference is the cross-encoder
+ * reorder, so the A/B isolates the reranker exactly. Blinding-safe (both arms from
+ * the identical pipeline + row format).
+ *
+ * The deterministic gate is set-based and ordering-blind (a reorder can only evict
+ * gold from the top-10 in its eyes), so it CANNOT credit a better ordering — only a
+ * council that reads the lists can. WEB_RERANK_URL is toggled in-process (it is a
+ * non-secret public Modal endpoint); run with COHERE/MEDCPT unset so the ONLY
+ * reranker in play is the self-hosted web cross-encoder.
+ *
+ *   env -u COHERE_API_KEY -u MEDCPT_RERANK_URL \
+ *     npx tsx eval/web-search/council/build-reranker-council.ts --out WEB-COUNCIL-3 --salt webcouncil3
+ */
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { BENCHMARK_QUERIES } from "../queries";
+import { cacheKey } from "../capture-searxng";
+import { applyQualityLayer, toPacketRows } from "../quality";
+import { diversifyForTab } from "@/lib/search/diversity";
+import type { WebBenchmarkQuery, CommonRow } from "../types";
+import type { UnifiedSearchResult } from "@/types/search";
+import { buildPacket, type EnginePair } from "./build-blinded-packet";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CACHE = join(HERE, "..", "cache");
+const WEB_RERANK_URL = "https://shailesh-greatest--manan-web-reranker-webreranker-rerank.modal.run";
+
+async function pipeline(query: string, pool: UnifiedSearchResult[], tab: "web" | "news"): Promise<CommonRow[]> {
+  const ranked = await applyQualityLayer(query, pool);
+  const diversified = diversifyForTab(ranked, tab);
+  return toPacketRows(diversified);
+}
+
+function parseArgs(argv: string[]): { out: string; salt: string } {
+  let out = "WEB-COUNCIL-3";
+  let salt = "";
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--out") out = argv[++i];
+    else if (argv[i] === "--salt") salt = argv[++i];
+  }
+  return { out, salt: salt || out };
+}
+
+async function main() {
+  const { out, salt } = parseArgs(process.argv.slice(2));
+  const queriesById = new Map<string, WebBenchmarkQuery>();
+  const pairs: EnginePair[] = [];
+
+  const targets = BENCHMARK_QUERIES.filter((q) => q.tab === "web" || q.tab === "news");
+  for (const q of targets) {
+    const path = join(CACHE, cacheKey(q.tab, q.query));
+    if (!existsSync(path)) {
+      console.log(`  ✗ ${q.id} — no frozen pool, skipped`);
+      continue;
+    }
+    const pool = (JSON.parse(readFileSync(path, "utf8")) as { results: UnifiedSearchResult[] }).results;
+    const tab = q.tab as "web" | "news";
+
+    // Control: no reranker in play.
+    delete process.env.WEB_RERANK_URL;
+    const control = await pipeline(q.query, pool, tab);
+
+    // Treatment: self-hosted web cross-encoder ON.
+    process.env.WEB_RERANK_URL = WEB_RERANK_URL;
+    const treatment = await pipeline(q.query, pool, tab);
+    delete process.env.WEB_RERANK_URL;
+
+    const changed = treatment.some((r, i) => r.url !== control[i]?.url);
+    queriesById.set(q.id, q);
+    // "ours" = with-reranker (treatment); "exa" = without (control).
+    pairs.push({ id: q.id, tab: q.tab, ours: treatment, exa: control });
+    console.log(`  ✓ ${q.id.padEnd(30)} ${tab}  reorder=${changed ? "YES" : "none"}`);
+  }
+
+  const { packet, key } = buildPacket({ pairs, queriesById, salt });
+  const outDir = join(HERE, out);
+  mkdirSync(outDir, { recursive: true });
+  writeFileSync(join(outDir, "PACKET.md"), packet);
+  writeFileSync(
+    join(outDir, "key.json"),
+    JSON.stringify({ run: "reranker-ab", salt, generatedFrom: "build-reranker-council.ts", legend: { ours: "with-reranker", exa: "without-reranker" }, aIs: key }, null, 2),
+  );
+  writeFileSync(join(outDir, "queries.json"), JSON.stringify([...queriesById.values()], null, 2));
+  console.log(`\n[reranker-council] wrote ${join(outDir, "PACKET.md")} (${pairs.length} queries, salt=${salt})`);
+  console.log(`[reranker-council] key.json legend: ours=with-reranker, exa=without-reranker — KEEP FROM JUDGES`);
+}
+
+main().catch((e) => {
+  console.error("[reranker-council] fatal:", e);
+  process.exit(1);
+});

--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -210,6 +210,23 @@ function applyDomainPreferences(
     .map(({ result }) => result);
 }
 
+/**
+ * Semantic cross-encoder reranking is gated to the WEB tab. WEB-COUNCIL-3 (blinded
+ * A/B): web 3-1 with the reranker (incl. demoting a catastrophic off-topic result),
+ * but news is a 2-2 wash where it demotes fresh items on a recency-first tab, and it
+ * regressed discussions. News/discussions keep their recency/diversity ordering.
+ * Fail-open: returns the input unchanged off-tab or if the reranker is down.
+ */
+async function rerankWebTabOnly(
+  query: string,
+  results: UnifiedSearchResult[],
+  isWebTab: boolean
+): Promise<UnifiedSearchResult[]> {
+  return isWebTab
+    ? rerankResults(query, results, undefined, { domain: "web" })
+    : results;
+}
+
 async function fetchNonAcademicResults(
   query: string,
   category: SearXNGCategory,
@@ -229,13 +246,14 @@ async function fetchNonAcademicResults(
       ? Math.min(Math.max(requestedVisibleCount * 3, perPage), MAX_NON_ACADEMIC_RESULTS)
       : Math.min(requestedVisibleCount, MAX_NON_ACADEMIC_RESULTS);
 
+  const isWebTab = category !== "news";
   let response = await searchSearXNG(query, {
     category,
     limit,
     timeRange,
   });
-  // Rerank web results with the self-hosted general reranker (domain-routed, not the biomedical model)
-  let rerankedResults = await rerankResults(query, response.results, undefined, { domain: "web" });
+  // Semantic rerank is gated to the web tab (see rerankWebTabOnly).
+  let rerankedResults = await rerankWebTabOnly(query, response.results, isWebTab);
   let rankedResults = applyDomainPreferences(rerankedResults, preferences);
 
   while (!response.degraded) {
@@ -261,7 +279,7 @@ async function fetchNonAcademicResults(
       category,
       limit,
     });
-    rerankedResults = await rerankResults(query, response.results, undefined, { domain: "web" });
+    rerankedResults = await rerankWebTabOnly(query, response.results, isWebTab);
     rankedResults = applyDomainPreferences(rerankedResults, preferences);
   }
 
@@ -308,7 +326,7 @@ async function fetchFederatedNonAcademicResults(
     limit: MAX_NON_ACADEMIC_RESULTS,
     timeRange,
   });
-  const reranked = await rerankResults(query, federation.results, undefined, { domain: "web" });
+  const reranked = await rerankWebTabOnly(query, federation.results, tab === "web");
   const ranked = applyDomainPreferences(reranked, preferences);
   const diversified = diversifyForTab(ranked, tab);
 

--- a/src/lib/search/rerank.ts
+++ b/src/lib/search/rerank.ts
@@ -44,7 +44,8 @@ async function rerankSelfHosted(
   query: string,
   documents: string[],
   topN: number,
-  service: string
+  service: string,
+  fetchOpts: { timeout: number; maxRetries: number } = { timeout: 15000, maxRetries: 1 }
 ): Promise<RerankScore[]> {
   const res = await resilientFetch(
     url,
@@ -53,7 +54,7 @@ async function rerankSelfHosted(
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ query, documents }),
     },
-    { service, timeout: 15000, maxRetries: 1 }
+    { service, ...fetchOpts }
   );
   const data: { scores?: number[] } = await res.json();
   const scores = Array.isArray(data?.scores) ? data.scores : [];
@@ -134,7 +135,12 @@ export async function rerankResults(
           query,
           documents,
           limit,
-          isWeb ? "Web-Rerank" : "MedCPT-Rerank"
+          isWeb ? "Web-Rerank" : "MedCPT-Rerank",
+          // The web reranker is GPU scale-to-zero; keeping it warm 24/7 isn't worth
+          // it at this scale. Fail-open-fast: a short ceiling + no retry means a
+          // cold start degrades to un-reranked results instantly instead of making
+          // the user wait ~30s. A warm rerank returns in well under a second.
+          isWeb ? { timeout: 4000, maxRetries: 0 } : { timeout: 15000, maxRetries: 1 }
         ),
     });
   if (cohereKey)


### PR DESCRIPTION
## What changed

Enables the deployed **bge-reranker-v2-m3** cross-encoder (`WEB_RERANK_URL`, Modal scale-to-zero) for the **web tab only**, and makes the call **fail-open-fast** so a cold start never stalls a search.

- **`route.ts`** — new `rerankWebTabOnly()` gates the cross-encoder to the web tab. News (recency-first) and discussions (already 100%) keep their recency/diversity ordering. The three non-academic rerank call sites now route through it.
- **`rerank.ts`** — `rerankSelfHosted` takes a per-call fetch budget. Web reranker = **4s timeout + 0 retries** → a scale-from-zero cold start (~20s) degrades to un-reranked results *instantly* rather than making the user wait ~30s. Literature (MedCPT) keeps 15s + 1 retry. A warm rerank returns in <1s.

## Why gated to web (not blanket-on)

The set-based deterministic gate can't credit ordering (a reorder only looks like gold-eviction to it — that's why this was disabled before). The right instrument is the council.

**WEB-COUNCIL-3** — blinded A/B, reranker ON vs OFF on the **same frozen web+news pools** (identical input → isolates the reorder exactly), judges Opus + Codex + DeepSeek:

| Tab | reranker beat-or-tie | detail |
|-----|---------------------|--------|
| **web** | **3/4 = 75%** ✅ | wins crispr, reproducibility, aspirin; one loss (gut-microbiome) |
| news | 2/4 = 50% (wash) | demotes fresh items on a recency-first tab (retraction −0.72) |

Standout: **web-reproducibility 2.22 → 4.22** — without the reranker the top hit was a catastrophic off-topic ("Japan travel pollution"); the cross-encoder demoted it. That's the semantic-relevance lift the keyword stack can't do — the real Exa gap.

## Test plan

- `rerank.test.ts` (14), route + search integration (40), `tsc --noEmit` — all green
- Validated end-to-end by WEB-COUNCIL-3 (above)
- Tooling: `council/build-reranker-council.ts` (in-process `WEB_RERANK_URL` toggle A/B); `aggregate-ab-news.ts` now reads the run's legend for labels

## Scope / safety

- Web tab only; news/discussions/academic ordering unchanged. Fail-open on cold start or reranker-down.
- Requires `WEB_RERANK_URL` (non-secret public Modal endpoint; now in dev.env). Eval clean-baseline must also unset it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEgTUohzwMogXKPsWVdwJx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added gated semantic reranking for the **web** tab, with improved handling for non-web searches.
  * Introduced updated evaluation tooling for comparing reranking behavior on frozen search result sets.

* **Bug Fixes**
  * Made reranking fail open more quickly when the web reranker is unavailable.
  * Improved search result processing so reranking no longer affects tabs outside web search.

* **Documentation**
  * Updated internal handover notes with the latest evaluation results and search-routing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->