### PR TITLE
feat(search): federate all non-academic tabs in production (CYCLE 6)

### DIFF
--- a/docs/web-search/SEARCH-AGENT-HANDOVER.md
+++ b/docs/web-search/SEARCH-AGENT-HANDOVER.md
@@ -341,3 +341,40 @@ request before a reranker council run (first hit cold-starts ~20s).
 the reranker (cycle 5) is the first **semantic-ordering** lever and it wins on web where
 relevance is king. The next quantitative step is a fresh ours-vs-**Exa** web council to
 re-measure the 25% web parity number now that reranking is on.
+
+---
+
+## 11. CYCLE 6 — production federation gate + web-vs-Exa re-measure (2026-06-29)
+
+**Gate opened.** `FEDERATED_TABS` now = `{web, news, discussions}` — all three
+non-academic tabs federate in **production**, matching the eval. Cycles 2–5 (Brave,
+NewsData, MMR, web reranker) now reach real users instead of living only in the harness.
+The single-source SearXNG path (`fetchNonAcademicResults`) is removed as dead code; the
+non-academic dispatch always federates. Each source is fail-open, so a missing key in
+prod degrades to the remaining sources rather than erroring.
+
+> **Prod deploy note:** for the full benefit, `BRAVE_API_KEY`, `NEWSDATA_API_KEY`, and
+> `SEARXNG_URL` must be set in the **Vercel** environment (not just local `dev.env`).
+> Without them the federation still runs but on fewer sources.
+
+**WEB-COUNCIL-4 — reranked web vs Exa** (4 web benchmark queries, salt `webcouncil4`,
+Opus + Codex + DeepSeek, `build-blinded-packet.ts --tab web` on the reranked run):
+
+| | beat-or-tie vs Exa |
+|--|--|
+| **WEB-COUNCIL-1** (un-reranked web) | 1/4 = **25%** |
+| **WEB-COUNCIL-4** (reranked web) | 0/4 win + 1 tie = **25%** |
+
+**The reranker does NOT close the Exa gap** — even though WEB-COUNCIL-3 showed it beats
+our *own* un-reranked web 3-1. The reconciliation is the key insight: **reranking
+improves the ORDER of our pool, but Exa wins on RETRIEVAL/RECALL** — its neural index
+surfaces content our keyword sources (SearXNG/Brave) never fetch, and you cannot reorder
+your way to candidates you don't have. Closing the remaining web gap to Exa is a
+*retrieval* problem — an **owned crawl+embed semantic index** — not a ranking one. That
+is a large build and is deliberately deferred at this scale (the reranker remains a real
+quality win on our own stack; it just isn't the Exa-parity lever).
+
+**Net:** the web-search arc has taken every cheap, high-leverage lever — federation +
+diversity + fresh authority + semantic ordering — and shipped them to production.
+Discussions is at Exa parity (100%); web/news trail on neural retrieval, which is the one
+remaining lever and an explicit, costed deferral.

--- a/eval/web-search/council/build-blinded-packet.ts
+++ b/eval/web-search/council/build-blinded-packet.ts
@@ -32,18 +32,20 @@ export interface EnginePair {
   exa: CommonRow[];
 }
 
-function parseArgs(argv: string[]): { run: string; out: string; salt: string; judges: string[] } {
+function parseArgs(argv: string[]): { run: string; out: string; salt: string; judges: string[]; tab: string | null } {
   let run = "baseline";
   let out = "baseline";
   let salt = "";
   let judges = "opus,codex,grok";
+  let tab: string | null = null;
   for (let i = 0; i < argv.length; i++) {
     if (argv[i] === "--run") run = argv[++i];
     else if (argv[i] === "--out") out = argv[++i];
     else if (argv[i] === "--salt") salt = argv[++i];
     else if (argv[i] === "--judges") judges = argv[++i];
+    else if (argv[i] === "--tab") tab = argv[++i];
   }
-  return { run, out, salt: salt || out, judges: judges.split(",").map((s) => s.trim()).filter(Boolean) };
+  return { run, out, salt: salt || out, judges: judges.split(",").map((s) => s.trim()).filter(Boolean), tab };
 }
 
 /** Deterministic per-query coin flip: is OUR engine shown as Engine A for this id? */
@@ -122,14 +124,15 @@ function exaToCommon(items: ExaFixtureItem[]): CommonRow[] {
 }
 
 function main() {
-  const { run, out, salt, judges } = parseArgs(process.argv.slice(2));
-  const queriesById = new Map(BENCHMARK_QUERIES.map((q) => [q.id, q]));
+  const { run, out, salt, judges, tab } = parseArgs(process.argv.slice(2));
+  const benchQueries = tab ? BENCHMARK_QUERIES.filter((q) => q.tab === tab) : BENCHMARK_QUERIES;
+  const queriesById = new Map(benchQueries.map((q) => [q.id, q]));
   const fixtures = JSON.parse(
     readFileSync(join(HERE, "..", "exa", "fixtures.json"), "utf8"),
   ) as Record<string, ExaFixtureItem[]>;
 
   const pairs: EnginePair[] = [];
-  for (const q of BENCHMARK_QUERIES) {
+  for (const q of benchQueries) {
     const exa = fixtures[q.id];
     if (!Array.isArray(exa) || exa.length === 0) continue; // no opponent → skip (fair comparison)
     const oursPath = join(HERE, "..", "runs", run, "queries", `${q.id}.json`);

--- a/src/app/api/search/unified/__tests__/route.test.ts
+++ b/src/app/api/search/unified/__tests__/route.test.ts
@@ -245,23 +245,25 @@ describe("GET /api/search/unified", () => {
     expect(mockSearchPubMed).toHaveBeenCalled();
   });
 
-  it("routes the web tab through SearXNG general search", async () => {
+  it("routes the web tab through the multi-source federation, not SearXNG directly", async () => {
     const res = await GET(makeRequest({ q: "climate change", tab: "web" }));
     const body = await res.json();
 
     expect(res.status).toBe(200);
-    expect(mockSearchSearXNG).toHaveBeenCalledWith("climate change", {
-      category: "general",
-      limit: 20,
-    });
+    expect(mockFederateNonAcademic).toHaveBeenCalledWith(
+      "climate change",
+      "web",
+      expect.objectContaining({ limit: 100 })
+    );
+    expect(mockSearchSearXNG).not.toHaveBeenCalled();
     expect(mockSearchPubMed).not.toHaveBeenCalled();
     expect(body.results).toHaveLength(1);
     expect(body.sourceCounts).toEqual({ web: 1 });
     expect(body.searxngUnavailable).toBe(false);
   });
 
-  it("requests enough SearXNG results to paginate page 2 and slices in the route", async () => {
-    mockSearchSearXNG.mockResolvedValueOnce({
+  it("fetches the full federation pool once and slices it to serve page 2", async () => {
+    mockFederateNonAcademic.mockResolvedValueOnce({
       results: Array.from({ length: 40 }, (_, index) => ({
         title: `Result ${index + 1}`,
         authors: [],
@@ -272,8 +274,11 @@ describe("GET /api/search/unified", () => {
         publicationTypes: ["web"],
         isOpenAccess: false,
         sources: ["web"],
+        url: `https://example.com/result-${index + 1}`,
+        domain: "example.com",
       })),
-      total: 57,
+      perSource: [],
+      perSourceRows: [],
       degraded: false,
     });
 
@@ -283,15 +288,19 @@ describe("GET /api/search/unified", () => {
     const body = await res.json();
 
     expect(res.status).toBe(200);
-    expect(mockSearchSearXNG).toHaveBeenCalledWith("climate change", {
-      category: "general",
-      limit: 40,
-    });
+    // Federated path calls federateNonAcademic once with limit: 100 — no incremental re-fetch.
+    expect(mockFederateNonAcademic).toHaveBeenCalledWith(
+      "climate change",
+      "web",
+      expect.objectContaining({ limit: 100 })
+    );
+    expect(mockFederateNonAcademic).toHaveBeenCalledTimes(1);
     expect(body.results).toHaveLength(20);
     expect(body.results[0].title).toBe("Result 21");
-    expect(body.total).toBe(57);
-    expect(body.hasMore).toBe(true);
-    expect(body.sourceCounts).toEqual({ web: 57 });
+    // total = diversified.length (fused pool size after preference/diversity pass), not upstream total
+    expect(body.total).toBe(40);
+    expect(body.hasMore).toBe(false);
+    expect(body.sourceCounts).toEqual({ web: 40 });
   });
 
   it("routes the discussions tab through the multi-source federation, not SearXNG", async () => {
@@ -328,10 +337,11 @@ describe("GET /api/search/unified", () => {
     expect(body.searxngUnavailable).toBe(true);
   });
 
-  it("returns empty results with a degradation flag when SearXNG is unavailable", async () => {
-    mockSearchSearXNG.mockResolvedValueOnce({
+  it("surfaces federation degradation as searxngUnavailable on the news tab", async () => {
+    mockFederateNonAcademic.mockResolvedValueOnce({
       results: [],
-      total: 0,
+      perSource: [],
+      perSourceRows: [],
       degraded: true,
     });
 
@@ -346,7 +356,7 @@ describe("GET /api/search/unified", () => {
   });
 
   it("adds trust tiers to web results", async () => {
-    mockSearchSearXNG.mockResolvedValueOnce({
+    mockFederateNonAcademic.mockResolvedValueOnce({
       results: [
         {
           title: "Reuters climate report",
@@ -362,7 +372,8 @@ describe("GET /api/search/unified", () => {
           domain: "reuters.com",
         },
       ],
-      total: 1,
+      perSource: [],
+      perSourceRows: [],
       degraded: false,
     });
 
@@ -380,7 +391,7 @@ describe("GET /api/search/unified", () => {
         level: "mute",
       },
     ]);
-    mockSearchSearXNG.mockResolvedValueOnce({
+    mockFederateNonAcademic.mockResolvedValueOnce({
       results: [
         {
           title: "Keep me",
@@ -409,7 +420,8 @@ describe("GET /api/search/unified", () => {
           domain: "reddit.com",
         },
       ],
-      total: 2,
+      perSource: [],
+      perSourceRows: [],
       degraded: false,
     });
 
@@ -417,7 +429,10 @@ describe("GET /api/search/unified", () => {
     const body = await res.json();
 
     expect(res.status).toBe(200);
-    expect(body.total).toBe(2);
+    // The federated path filters muted domains before computing total (total = diversified pool
+    // size after preference filtering), so the muted reddit.com result is excluded from both
+    // the results and the total count.
+    expect(body.total).toBe(1);
     expect(body.hasMore).toBe(false);
     expect(body.results).toHaveLength(1);
     expect(body.results[0].domain).toBe("reuters.com");
@@ -430,7 +445,7 @@ describe("GET /api/search/unified", () => {
         level: "prefer",
       },
     ]);
-    mockSearchSearXNG.mockResolvedValueOnce({
+    mockFederateNonAcademic.mockResolvedValueOnce({
       results: [
         {
           title: "Neutral result",
@@ -459,7 +474,8 @@ describe("GET /api/search/unified", () => {
           domain: "reuters.com",
         },
       ],
-      total: 2,
+      perSource: [],
+      perSourceRows: [],
       degraded: false,
     });
 
@@ -471,78 +487,49 @@ describe("GET /api/search/unified", () => {
     expect(body.results[1].domain).toBe("example.com");
   });
 
-  it("fetches more upstream results when muted domains thin out a later page", async () => {
+  it("federated pool is filtered by muted domains and paged correctly on a later page", async () => {
     mockGetDomainPreferences.mockResolvedValueOnce([
       {
         domain: "reddit.com",
         level: "mute",
       },
     ]);
-    mockSearchSearXNG
-      .mockResolvedValueOnce({
-        results: [
-          ...Array.from({ length: 45 }, (_, index) => ({
-            title: `Muted ${index + 1}`,
-            authors: [],
-            journal: "Reddit",
-            year: 2026,
-            abstract: "Muted result",
-            citationCount: 0,
-            publicationTypes: ["news"],
-            isOpenAccess: false,
-            sources: ["news"],
-            url: `https://www.reddit.com/r/science/comments/${index + 1}`,
-            domain: "reddit.com",
-          })),
-          ...Array.from({ length: 15 }, (_, index) => ({
-            title: `Visible ${index + 1}`,
-            authors: [],
-            journal: "Reuters",
-            year: 2026,
-            abstract: "Visible result",
-            citationCount: 0,
-            publicationTypes: ["news"],
-            isOpenAccess: false,
-            sources: ["news"],
-            url: `https://www.reuters.com/world/climate-${index + 1}`,
-            domain: "reuters.com",
-          })),
-        ],
-        total: 80,
-        degraded: false,
-      })
-      .mockResolvedValueOnce({
-        results: [
-          ...Array.from({ length: 45 }, (_, index) => ({
-            title: `Muted ${index + 1}`,
-            authors: [],
-            journal: "Reddit",
-            year: 2026,
-            abstract: "Muted result",
-            citationCount: 0,
-            publicationTypes: ["news"],
-            isOpenAccess: false,
-            sources: ["news"],
-            url: `https://www.reddit.com/r/science/comments/${index + 1}`,
-            domain: "reddit.com",
-          })),
-          ...Array.from({ length: 35 }, (_, index) => ({
-            title: `Visible ${index + 1}`,
-            authors: [],
-            journal: "Reuters",
-            year: 2026,
-            abstract: "Visible result",
-            citationCount: 0,
-            publicationTypes: ["news"],
-            isOpenAccess: false,
-            sources: ["news"],
-            url: `https://www.reuters.com/world/climate-${index + 1}`,
-            domain: "reuters.com",
-          })),
-        ],
-        total: 80,
-        degraded: false,
-      });
+    // The federation returns a single pool — 45 muted + 35 visible = 80 items total.
+    // After muted-domain filtering, 35 visible items remain. Page 1, perPage 10 slices
+    // items 11-20 of the visible set (hasMore = 35 > 20 = true).
+    mockFederateNonAcademic.mockResolvedValueOnce({
+      results: [
+        ...Array.from({ length: 45 }, (_, index) => ({
+          title: `Muted ${index + 1}`,
+          authors: [],
+          journal: "Reddit",
+          year: 2026,
+          abstract: "Muted result",
+          citationCount: 0,
+          publicationTypes: ["news"],
+          isOpenAccess: false,
+          sources: ["news"],
+          url: `https://www.reddit.com/r/science/comments/${index + 1}`,
+          domain: "reddit.com",
+        })),
+        ...Array.from({ length: 35 }, (_, index) => ({
+          title: `Visible ${index + 1}`,
+          authors: [],
+          journal: "Reuters",
+          year: 2026,
+          abstract: "Visible result",
+          citationCount: 0,
+          publicationTypes: ["news"],
+          isOpenAccess: false,
+          sources: ["news"],
+          url: `https://www.reuters.com/world/climate-${index + 1}`,
+          domain: "reuters.com",
+        })),
+      ],
+      perSource: [],
+      perSourceRows: [],
+      degraded: false,
+    });
 
     const res = await GET(
       makeRequest({ q: "climate change", tab: "news", page: "1", perPage: "10" })
@@ -550,18 +537,18 @@ describe("GET /api/search/unified", () => {
     const body = await res.json();
 
     expect(res.status).toBe(200);
-    expect(mockSearchSearXNG).toHaveBeenNthCalledWith(1, "climate change", {
-      category: "news",
-      limit: 60,
-    });
-    expect(mockSearchSearXNG).toHaveBeenNthCalledWith(2, "climate change", {
-      category: "news",
-      limit: 80,
-    });
+    // Federated path fetches once, no incremental re-fetch loop.
+    expect(mockFederateNonAcademic).toHaveBeenCalledTimes(1);
+    expect(mockFederateNonAcademic).toHaveBeenCalledWith(
+      "climate change",
+      "news",
+      expect.objectContaining({ limit: 100 })
+    );
     expect(body.results).toHaveLength(10);
     expect(body.results[0].title).toBe("Visible 11");
     expect(body.results[9].title).toBe("Visible 20");
-    expect(body.total).toBe(80);
+    // total = diversified pool size after muted-domain filter (35 visible remain)
+    expect(body.total).toBe(35);
     expect(body.hasMore).toBe(true);
   });
 
@@ -653,16 +640,16 @@ describe("GET /api/search/unified", () => {
 
   // ── Phase 4: Filter pills + Scope constraints ────────────────────
 
-  it("passes timeRange to SearXNG for non-academic tabs", async () => {
+  it("passes timeRange to the federation for non-academic tabs", async () => {
     const res = await GET(
       makeRequest({ q: "climate news", tab: "news", timeRange: "week" })
     );
     expect(res.status).toBe(200);
-    expect(mockSearchSearXNG).toHaveBeenCalledWith("climate news", {
-      category: "news",
-      limit: expect.any(Number),
-      timeRange: "week",
-    });
+    expect(mockFederateNonAcademic).toHaveBeenCalledWith(
+      "climate news",
+      "news",
+      expect.objectContaining({ limit: 100, timeRange: "week" })
+    );
   });
 
   it("wraps query in quotes when exactMatch is true", async () => {
@@ -670,9 +657,10 @@ describe("GET /api/search/unified", () => {
       makeRequest({ q: "climate policy", tab: "web", exactMatch: "true" })
     );
     expect(res.status).toBe(200);
-    expect(mockSearchSearXNG).toHaveBeenCalledWith(
+    expect(mockFederateNonAcademic).toHaveBeenCalledWith(
       '"climate policy"',
-      expect.objectContaining({ category: "general" })
+      "web",
+      expect.objectContaining({ limit: 100 })
     );
   });
 
@@ -826,10 +814,11 @@ describe("GET /api/search/unified", () => {
       makeRequest({ q: 'injection "attack" test', tab: "web", exactMatch: "true" })
     );
     expect(res.status).toBe(200);
-    // Should wrap sanitized query (no inner quotes) in double quotes
-    expect(mockSearchSearXNG).toHaveBeenCalledWith(
+    // Should strip inner quotes first, then wrap in double quotes to prevent injection
+    expect(mockFederateNonAcademic).toHaveBeenCalledWith(
       '"injection attack test"',
-      expect.objectContaining({ category: "general" })
+      "web",
+      expect.objectContaining({ limit: 100 })
     );
   });
 });

--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -5,7 +5,6 @@ import { searchSemanticScholar } from "@/lib/search/sources/semantic-scholar";
 import { searchOpenAlex } from "@/lib/search/sources/openalex";
 import { searchClinicalTrials } from "@/lib/search/sources/clinical-trials";
 import { searchArxiv } from "@/lib/search/sources/arxiv";
-import { searchSearXNG, type SearXNGCategory } from "@/lib/search/sources/searxng";
 import { federateNonAcademic } from "@/lib/search/web/federate";
 import { reciprocalRankFusion } from "@/lib/search/rank-fusion";
 import { rerankResults } from "@/lib/search/rerank";
@@ -51,15 +50,6 @@ type SourceDefinition = {
   sourceId: SourceId;
   label: string;
   run: () => Promise<SourceSearchResponse>;
-};
-
-const SEARXNG_CATEGORY_BY_TAB: Record<
-  Exclude<SearchTab, "academic">,
-  SearXNGCategory
-> = {
-  web: "general",
-  news: "news",
-  discussions: "social media",
 };
 
 const DOMAIN_PREFERENCE_WEIGHT: Record<ResultDomainPreferenceLevel, number> = {
@@ -227,81 +217,6 @@ async function rerankWebTabOnly(
     : results;
 }
 
-async function fetchNonAcademicResults(
-  query: string,
-  category: SearXNGCategory,
-  page: number,
-  perPage: number,
-  preferences: Awaited<ReturnType<typeof getDomainPreferences>>,
-  timeRange?: "24h" | "week" | "month" | "year"
-): Promise<{
-  results: UnifiedSearchResult[];
-  total: number;
-  hasMore: boolean;
-  degraded: boolean;
-}> {
-  const requestedVisibleCount = (page + 1) * perPage;
-  let limit =
-    preferences.length > 0
-      ? Math.min(Math.max(requestedVisibleCount * 3, perPage), MAX_NON_ACADEMIC_RESULTS)
-      : Math.min(requestedVisibleCount, MAX_NON_ACADEMIC_RESULTS);
-
-  const isWebTab = category !== "news";
-  let response = await searchSearXNG(query, {
-    category,
-    limit,
-    timeRange,
-  });
-  // Semantic rerank is gated to the web tab (see rerankWebTabOnly).
-  let rerankedResults = await rerankWebTabOnly(query, response.results, isWebTab);
-  let rankedResults = applyDomainPreferences(rerankedResults, preferences);
-
-  while (!response.degraded) {
-    const fetchCeiling = Math.min(response.total, MAX_NON_ACADEMIC_RESULTS);
-    const hasEnoughVisibleResults = rankedResults.length >= requestedVisibleCount;
-    const canFetchMore = limit < fetchCeiling;
-
-    if (hasEnoughVisibleResults || !canFetchMore) {
-      break;
-    }
-
-    const nextLimit = Math.min(
-      fetchCeiling,
-      Math.max(limit + perPage * 3, requestedVisibleCount + perPage)
-    );
-
-    if (nextLimit <= limit) {
-      break;
-    }
-
-    limit = nextLimit;
-    response = await searchSearXNG(query, {
-      category,
-      limit,
-    });
-    rerankedResults = await rerankWebTabOnly(query, response.results, isWebTab);
-    rankedResults = applyDomainPreferences(rerankedResults, preferences);
-  }
-
-  const tab = category === "news" ? "news" : "web";
-  const diversified = diversifyForTab(rankedResults, tab);
-
-  const start = page * perPage;
-  const paged = diversified.slice(start, start + perPage);
-  const fetchCeiling = Math.min(response.total, MAX_NON_ACADEMIC_RESULTS);
-  const canFetchMore = !response.degraded && limit < fetchCeiling;
-  const hasMore = diversified.length > start + perPage || canFetchMore;
-
-  return {
-    results: paged,
-    total: response.total,
-    hasMore,
-    degraded: response.degraded,
-  };
-}
-
-/** Tabs served by the multi-source federation rather than a single SearXNG call. */
-const FEDERATED_TABS = new Set<SearchTab>(["discussions"]);
 
 /**
  * Federated non-academic path: fan out across the tab's source set, RRF-fuse on
@@ -416,7 +331,6 @@ export async function GET(req: Request) {
       const userDomainPreferences = usePreferences
         ? await getDomainPreferences()
         : [];
-      const category = SEARXNG_CATEGORY_BY_TAB[tabParam];
       // Wrap query in quotes for exact match (strip existing quotes to prevent injection)
       const sanitized = q.replace(/"/g, "");
       const effectiveQuery = exactMatch ? `"${sanitized}"` : q;
@@ -425,23 +339,14 @@ export async function GET(req: Request) {
         total: visibleTotal,
         hasMore,
         degraded,
-      } = FEDERATED_TABS.has(tabParam)
-        ? await fetchFederatedNonAcademicResults(
-            effectiveQuery,
-            tabParam,
-            page,
-            perPage,
-            userDomainPreferences,
-            timeRange as "24h" | "week" | "month" | "year" | undefined
-          )
-        : await fetchNonAcademicResults(
-            effectiveQuery,
-            category,
-            page,
-            perPage,
-            userDomainPreferences,
-            timeRange as "24h" | "week" | "month" | "year" | undefined
-          );
+      } = await fetchFederatedNonAcademicResults(
+        effectiveQuery,
+        tabParam,
+        page,
+        perPage,
+        userDomainPreferences,
+        timeRange as "24h" | "week" | "month" | "year" | undefined
+      );
 
       // Apply scope domain constraints if a custom scope is active
       let scopeFilteredResults = paged;


### PR DESCRIPTION
## What changed

Opens the **production federation gate**: `FEDERATED_TABS` now covers `web`, `news`, and `discussions`, so every non-academic tab uses the multi-source federation (SearXNG + Brave + NewsData + web reranker) in production — matching the eval. Cycles 2–5 now reach real users instead of living only in the harness.

- **`route.ts`** — removes the now-dead single-source SearXNG path (`fetchNonAcademicResults`, `FEDERATED_TABS`, `SEARXNG_CATEGORY_BY_TAB`) and routes the non-academic branch unconditionally through `fetchFederatedNonAcademicResults`. Each source is fail-open → a missing key degrades to the remaining sources.
- **`route.test.ts`** — migrates the 10 tests that encoded the SearXNG-only path to the federated path. **Every behavioral assertion preserved** (independently verified, not weakened): trust tiers added, muted domains filtered, preferred domains boosted, `exactMatch` quoting, `timeRange` passthrough, degradation → `searxngUnavailable`. 35/35 route tests green; 442/442 across the search suite.
- **`build-blinded-packet.ts`** — `--tab` filter for tab-scoped councils.

## Re-measure (WEB-COUNCIL-4): the honest result

Reranked web vs Exa = **25%** — unchanged from WEB-COUNCIL-1.

The reranker beats our *own* un-reranked web 3-1 (WEB-COUNCIL-3) but does **not** close the Exa gap. Reconciliation: reranking improves the *order* of our pool, but Exa wins on **retrieval/recall** — its neural index surfaces content our keyword sources never fetch. You can't reorder your way to candidates you don't have. Closing the web gap needs an **owned semantic index** (a large build, deliberately deferred at this scale). The reranker stays — it's a real quality win on our stack, just not the Exa-parity lever.

## Test plan

- `route.test.ts` 35/35, full `src/lib/search` + `src/app/api/search` suite 442/442, `tsc --noEmit` clean
- Dead code removal verified (0 refs to removed symbols)

## Scope / safety

- Academic/medical path untouched. Federation is fail-open per source.
- **Prod deploy:** set `BRAVE_API_KEY` / `NEWSDATA_API_KEY` / `SEARXNG_URL` in the **Vercel** env for full benefit (degrades to available sources without them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEgTUohzwMogXKPsWVdwJx