### PR TITLE
fix(deep-research): retry S2 citation traversal + fail over evidence extraction

### DIFF
--- a/src/lib/ai/__tests__/models.test.ts
+++ b/src/lib/ai/__tests__/models.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { getSmallModelFallback } from "../models";
+
+describe("getSmallModelFallback", () => {
+  const original = process.env.DEEPSEEK_API_KEY;
+  beforeEach(() => {
+    delete process.env.DEEPSEEK_API_KEY;
+  });
+  afterEach(() => {
+    if (original === undefined) delete process.env.DEEPSEEK_API_KEY;
+    else process.env.DEEPSEEK_API_KEY = original;
+  });
+
+  it("returns null when DEEPSEEK_API_KEY is unset (no fallback available)", () => {
+    expect(getSmallModelFallback()).toBeNull();
+  });
+
+  it("returns a model when DEEPSEEK_API_KEY is set", () => {
+    process.env.DEEPSEEK_API_KEY = "sk-test-deepseek";
+    expect(getSmallModelFallback()).not.toBeNull();
+  });
+});

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -44,6 +44,18 @@ function getOpenAI() {
   return _openai;
 }
 
+// DeepSeek is OpenAI-compatible — used only as the small-model FALLBACK (below).
+let _deepseek: ReturnType<typeof createOpenAI> | null = null;
+function getDeepSeek() {
+  if (!_deepseek) {
+    _deepseek = createOpenAI({
+      baseURL: "https://api.deepseek.com",
+      apiKey: process.env.DEEPSEEK_API_KEY!,
+    });
+  }
+  return _deepseek;
+}
+
 // ── LangFuse tracing helper ────────────────────────────────────────
 // Creates a LangFuse trace for each model invocation.
 // Call traceGeneration() before your LLM call, end it after.
@@ -136,6 +148,18 @@ export function getSmallModel() {
   }
   // GLM-4-Flash retired; use GLM-5
   return getZhipu()("glm-5");
+}
+
+/**
+ * Funded fallback for the small-model tasks (deep-research extraction/perspectives)
+ * when the {@link getSmallModel} provider errors — e.g. a dead or throttled key that
+ * would otherwise SILENTLY zero the evidence tables. DeepSeek V4 Flash (cheap, fast)
+ * via its OpenAI-compatible /chat/completions endpoint (`.chat()`); overridable with
+ * DEEPSEEK_MODEL. Returns null when DEEPSEEK_API_KEY is unset (no fallback available).
+ */
+export function getSmallModelFallback() {
+  if (!process.env.DEEPSEEK_API_KEY) return null;
+  return getDeepSeek().chat(process.env.DEEPSEEK_MODEL || "deepseek-v4-flash");
 }
 
 /** High-quality model for complex reasoning (deep research, analysis). */

--- a/src/lib/deep-research/__tests__/citation-traversal.test.ts
+++ b/src/lib/deep-research/__tests__/citation-traversal.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { traverseCitationGraph } from "../citation-traversal";
+import type { UnifiedSearchResult } from "@/types/search";
+
+function jsonResponse(body: unknown, status = 200) {
+  return { ok: status >= 200 && status < 300, status, json: async () => body } as unknown as Response;
+}
+
+const citingPaper = {
+  paperId: "c1",
+  title: "A citing paper",
+  authors: [{ name: "Author A" }],
+  year: 2023,
+  abstract: "abstract",
+  citationCount: 5,
+  journal: { name: "Journal" },
+  externalIds: { DOI: "10.1/c1" },
+  isOpenAccess: true,
+};
+
+const seed: UnifiedSearchResult = {
+  title: "Seed",
+  authors: [],
+  journal: "",
+  year: 2020,
+  s2Id: "seed1",
+  abstract: "seed abstract",
+  citationCount: 100,
+  isOpenAccess: true,
+  publicationTypes: [],
+  sources: ["semantic_scholar"],
+};
+
+describe("traverseCitationGraph — S2 retry/backoff", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("retries after a 429 and recovers the citation papers", async () => {
+    vi.useFakeTimers();
+    let citationsCall = 0;
+    const fetchMock = vi.fn(async (url: string) => {
+      if (String(url).includes("/citations")) {
+        citationsCall++;
+        // First attempt throttled, second succeeds.
+        return citationsCall === 1
+          ? jsonResponse({}, 429)
+          : jsonResponse({ data: [{ citingPaper }] });
+      }
+      return jsonResponse({ data: [] }); // references: empty
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const promise = traverseCitationGraph([seed]);
+    await vi.advanceTimersByTimeAsync(2000); // flush the backoff sleep
+    const result = await promise;
+
+    expect(citationsCall).toBe(2); // retried exactly once
+    expect(result.map((r) => r.s2Id)).toContain("c1"); // recovered, not silently zeroed
+  });
+
+  it("returns [] (no throw) when S2 stays throttled across all attempts", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(async () => jsonResponse({}, 429));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const promise = traverseCitationGraph([seed]);
+    await vi.advanceTimersByTimeAsync(10000);
+    const result = await promise;
+
+    expect(result).toEqual([]);
+  });
+});

--- a/src/lib/deep-research/__tests__/data-extraction.test.ts
+++ b/src/lib/deep-research/__tests__/data-extraction.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { UnifiedSearchResult } from "@/types/search";
+
+const getSmallModel = vi.fn();
+const getSmallModelFallback = vi.fn();
+const generateText = vi.fn();
+
+vi.mock("@/lib/ai/models", () => ({
+  AI_PROVIDER: "anthropic",
+  getSmallModel: () => getSmallModel(),
+  getSmallModelFallback: () => getSmallModelFallback(),
+}));
+vi.mock("ai", () => ({ generateText: (args: unknown) => generateText(args) }));
+
+import { extractStructuredData } from "../data-extraction";
+
+function paper(title: string): UnifiedSearchResult {
+  return {
+    title,
+    authors: ["A"],
+    journal: "J",
+    year: 2023,
+    abstract: "A randomized controlled trial of 100 patients.",
+    citationCount: 1,
+    isOpenAccess: false,
+    publicationTypes: [],
+    sources: ["pubmed"],
+    doi: `10.1/${title}`,
+  };
+}
+
+describe("extractStructuredData — fallback + alarm", () => {
+  beforeEach(() => {
+    getSmallModel.mockReturnValue({ __id: "primary" });
+    getSmallModelFallback.mockReturnValue({ __id: "fallback" });
+    generateText.mockReset();
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it("fails over to the fallback model when the primary throws", async () => {
+    generateText.mockImplementation(async ({ model }: { model: { __id: string } }) => {
+      if (model.__id === "primary") throw new Error("credit balance too low");
+      return { text: JSON.stringify({ studyDesign: "RCT", sampleSize: 100 }) };
+    });
+
+    const out = await extractStructuredData([paper("p1")]);
+    expect(out.size).toBe(1);
+    expect(out.get("10.1/p1")?.studyDesign).toBe("RCT");
+  });
+
+  it("logs a loud alarm when primary and fallback both fail (no silent zero)", async () => {
+    generateText.mockRejectedValue(new Error("all providers down"));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const out = await extractStructuredData([paper("p1"), paper("p2")]);
+
+    expect(out.size).toBe(0);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("0/2 papers extracted"));
+  });
+
+  it("does not alarm on a normal successful run", async () => {
+    generateText.mockResolvedValue({ text: JSON.stringify({ studyDesign: "cohort" }) });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const out = await extractStructuredData([paper("p1")]);
+
+    expect(out.size).toBe(1);
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/deep-research/citation-traversal.ts
+++ b/src/lib/deep-research/citation-traversal.ts
@@ -49,6 +49,38 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/**
+ * Fetch from Semantic Scholar with retry/backoff. S2's unauthenticated graph API
+ * rate-limits aggressively (HTTP 429), and a single 429 used to silently zero a
+ * whole traversal. Retry on 429 / 5xx / network error with exponential backoff so
+ * transient throttling recovers instead of dropping ~80 citation papers. Returns
+ * the final Response (which the caller still checks for `.ok`), or null if every
+ * attempt threw.
+ */
+async function fetchS2WithRetry(url: string, attempts = 3): Promise<Response | null> {
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    try {
+      const res = await fetch(url, {
+        headers: getS2Headers(),
+        signal: AbortSignal.timeout(15000),
+      });
+      if ((res.status === 429 || res.status >= 500) && attempt < attempts - 1) {
+        await sleep(800 * 2 ** attempt);
+        continue;
+      }
+      return res;
+    } catch (error) {
+      if (attempt < attempts - 1) {
+        await sleep(800 * 2 ** attempt);
+        continue;
+      }
+      console.warn(`[CitationTraversal] fetch failed after ${attempts} attempts (${url}):`, error);
+      return null;
+    }
+  }
+  return null;
+}
+
 function mapCitationPaper(paper: S2CitationPaper): UnifiedSearchResult | null {
   if (!paper.title || !paper.paperId) return null;
 
@@ -80,13 +112,9 @@ async function fetchCitations(
   const url = `https://api.semanticscholar.org/graph/v1/paper/${encodeURIComponent(paperId)}/citations?fields=${CITATION_FIELDS}&limit=${limit}`;
 
   try {
-    const res = await fetch(url, {
-      headers: getS2Headers(),
-      signal: AbortSignal.timeout(15000),
-    });
-
-    if (!res.ok) {
-      console.warn(`[CitationTraversal] Citations fetch failed for ${paperId}: HTTP ${res.status}`);
+    const res = await fetchS2WithRetry(url);
+    if (!res || !res.ok) {
+      if (res) console.warn(`[CitationTraversal] Citations fetch failed for ${paperId}: HTTP ${res.status}`);
       return [];
     }
 
@@ -118,13 +146,9 @@ async function fetchReferences(
   const url = `https://api.semanticscholar.org/graph/v1/paper/${encodeURIComponent(paperId)}/references?fields=${CITATION_FIELDS}&limit=${limit}`;
 
   try {
-    const res = await fetch(url, {
-      headers: getS2Headers(),
-      signal: AbortSignal.timeout(15000),
-    });
-
-    if (!res.ok) {
-      console.warn(`[CitationTraversal] References fetch failed for ${paperId}: HTTP ${res.status}`);
+    const res = await fetchS2WithRetry(url);
+    if (!res || !res.ok) {
+      if (res) console.warn(`[CitationTraversal] References fetch failed for ${paperId}: HTTP ${res.status}`);
       return [];
     }
 

--- a/src/lib/deep-research/data-extraction.ts
+++ b/src/lib/deep-research/data-extraction.ts
@@ -1,13 +1,16 @@
 /**
  * Structured Data Extraction for Deep Research.
  *
- * Uses AI (claude-haiku via getSmallModel) to extract structured data
- * from paper abstracts: study design, sample size, effect sizes,
- * p-values, population characteristics, and follow-up duration.
+ * Uses the small model (via getSmallModel) to extract structured data from paper
+ * abstracts: study design, sample size, effect sizes, p-values, population
+ * characteristics, and follow-up duration. Fails over to a funded fallback model
+ * (DeepSeek V4 Flash) so a dead/throttled primary key can't silently empty the
+ * evidence tables.
  */
 
+import type { LanguageModel } from "ai";
 import { generateText } from "ai";
-import { getSmallModel } from "@/lib/ai/models";
+import { AI_PROVIDER, getSmallModel, getSmallModelFallback } from "@/lib/ai/models";
 import type { UnifiedSearchResult } from "@/types/search";
 import type { ExtractedPaperData, ResearchProgressCallback } from "./types";
 
@@ -56,8 +59,44 @@ function parseExtractionJSON(text: string): Partial<ExtractedPaperData> | null {
   }
 }
 
+/** Run one extraction against a given model; null when nothing extractable. */
+async function runExtraction(
+  model: LanguageModel,
+  paper: UnifiedSearchResult,
+  paperId: string
+): Promise<ExtractedPaperData | null> {
+  const { text } = await generateText({
+    model,
+    system: EXTRACTION_SYSTEM_PROMPT,
+    prompt: `Paper title: "${paper.title}"
+Authors: ${paper.authors?.slice(0, 5).join(", ") || "Unknown"}
+Year: ${paper.year || "Unknown"}
+Journal: ${paper.journal || "Unknown"}
+
+Abstract:
+${paper.abstract}`,
+    maxOutputTokens: 1000,
+  });
+
+  const parsed = parseExtractionJSON(text);
+  if (!parsed || Object.keys(parsed).length === 0) return null;
+
+  return {
+    paperId,
+    studyDesign: parsed.studyDesign,
+    sampleSize: parsed.sampleSize,
+    effectSizes: parsed.effectSizes,
+    pValues: parsed.pValues,
+    populationCharacteristics: parsed.populationCharacteristics,
+    followUpDuration: parsed.followUpDuration,
+    keyFindings: parsed.keyFindings,
+  };
+}
+
 /**
- * Extract structured data from a single paper's abstract.
+ * Extract structured data from a single paper's abstract. Tries the primary
+ * small model; on error (e.g. a dead/throttled provider key) it fails over to the
+ * funded fallback so the evidence tables don't silently come back empty.
  */
 async function extractSinglePaper(
   paper: UnifiedSearchResult
@@ -67,34 +106,24 @@ async function extractSinglePaper(
   const paperId = paper.doi || paper.pmid || paper.s2Id || paper.title.slice(0, 50);
 
   try {
-    const { text } = await generateText({
-      model: getSmallModel(),
-      system: EXTRACTION_SYSTEM_PROMPT,
-      prompt: `Paper title: "${paper.title}"
-Authors: ${paper.authors?.slice(0, 5).join(", ") || "Unknown"}
-Year: ${paper.year || "Unknown"}
-Journal: ${paper.journal || "Unknown"}
-
-Abstract:
-${paper.abstract}`,
-      maxOutputTokens: 1000,
-    });
-
-    const parsed = parseExtractionJSON(text);
-    if (!parsed || Object.keys(parsed).length === 0) return null;
-
-    return {
-      paperId,
-      studyDesign: parsed.studyDesign,
-      sampleSize: parsed.sampleSize,
-      effectSizes: parsed.effectSizes,
-      pValues: parsed.pValues,
-      populationCharacteristics: parsed.populationCharacteristics,
-      followUpDuration: parsed.followUpDuration,
-      keyFindings: parsed.keyFindings,
-    };
-  } catch (error) {
-    console.warn(`[DataExtraction] Failed to extract data for "${paper.title}":`, error);
+    return await runExtraction(getSmallModel(), paper, paperId);
+  } catch (primaryError) {
+    const fallback = getSmallModelFallback();
+    if (fallback) {
+      try {
+        return await runExtraction(fallback, paper, paperId);
+      } catch (fallbackError) {
+        console.warn(
+          `[DataExtraction] primary and fallback both failed for "${paper.title}":`,
+          fallbackError
+        );
+        return null;
+      }
+    }
+    console.warn(
+      `[DataExtraction] Failed to extract data for "${paper.title}" (no fallback configured):`,
+      primaryError
+    );
     return null;
   }
 }
@@ -160,6 +189,17 @@ export async function extractStructuredData(
     if (i + batchSize < papersWithAbstracts.length) {
       await sleep(200);
     }
+  }
+
+  // Loud alarm: extracting from real abstracts but getting nothing back means the
+  // small model AND its fallback are failing (dead/throttled keys) — the evidence
+  // tables would silently be empty. Make that visible instead of swallowing it.
+  if (papersWithAbstracts.length > 0 && results.size === 0) {
+    console.error(
+      `[DataExtraction] 0/${papersWithAbstracts.length} papers extracted — the small model ` +
+        `(AI_PROVIDER=${AI_PROVIDER}) and DeepSeek fallback both produced nothing. ` +
+        `Evidence tables will be empty; check the provider/DEEPSEEK_API_KEY keys.`
+    );
   }
 
   onProgress?.(


### PR DESCRIPTION
## What
Two reliability fixes surfaced by the Phase 0 deep-research assessment — where one of three identical-quality runs lost **all ~80 citation-traversal papers**, and another silently produced **zero evidence-table rows**.

### 1. Citation traversal — retry on rate-limit
Semantic Scholar's unauthenticated graph API rate-limits hard (HTTP 429), and a single 429 used to silently zero an entire traversal (q2 got 0 vs q1/q3's 87/83). Added `fetchS2WithRetry` — retry on **429 / 5xx / network error** with exponential backoff — so transient throttling recovers instead of dropping the citation papers.

### 2. Evidence extraction — fail over instead of silently emptying
Structured extraction ran only on `getSmallModel()`, so a **dead or throttled `AI_PROVIDER` key** silently emptied the evidence tables (the report still wrote fine on the separate gpt-5.2 synthesis path, hiding the failure). Now:
- Added `getSmallModelFallback()` → **DeepSeek V4 Flash** via its OpenAI-compatible `/chat/completions` endpoint (mirrors the existing `hyde.ts` pattern; `DEEPSEEK_MODEL`-overridable; `null` when unkeyed).
- `extractSinglePaper` fails over to it on primary error.
- A **loud `console.error`** fires when `0/N` papers extract, so the failure can never hide again.

## Test
- `citation-traversal.test.ts` — retries once after a 429 and recovers the paper; returns `[]` (no throw) when throttled across all attempts.
- `data-extraction.test.ts` — fails over to the fallback when primary throws; alarms on total failure; stays quiet on success.
- `models.test.ts` — `getSmallModelFallback` null without key, model with key.
- Full deep-research + ai suites green (32 tests); tsc + eslint clean.

## Rollout
Needs `DEEPSEEK_API_KEY` in Vercel (prod + preview) for the fallback to be available in production — I'll add it from the vault after merge. Without it the fallback is simply `null` (current behavior, no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEgTUohzwMogXKPsWVdwJx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a backup AI model option for structured data extraction when the primary model is unavailable.
  * Improved citation and reference lookups with automatic retry handling for temporary service errors.

* **Bug Fixes**
  * Extraction now surfaces clearer errors when processing fails instead of quietly returning no results.
  * Citation fetching now returns safely after repeated throttling or network failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->