### PR TITLE
feat(search): YouTube videos discovery tab (study-material MVP, part 1)

### DIFF
--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -6,6 +6,7 @@ import { searchOpenAlex } from "@/lib/search/sources/openalex";
 import { searchClinicalTrials } from "@/lib/search/sources/clinical-trials";
 import { searchArxiv } from "@/lib/search/sources/arxiv";
 import { federateNonAcademic } from "@/lib/search/web/federate";
+import { searchYouTube } from "@/lib/search/sources/youtube";
 import { reciprocalRankFusion } from "@/lib/search/rank-fusion";
 import { rerankResults } from "@/lib/search/rerank";
 import { diversifyForTab } from "@/lib/search/diversity";
@@ -44,7 +45,7 @@ type ResultDomainPreferenceLevel = NonNullable<
   UnifiedSearchResult["domainPreferenceLevel"]
 >;
 
-type SearchTab = "academic" | "web" | "news" | "discussions";
+type SearchTab = "academic" | "web" | "news" | "discussions" | "videos";
 
 type SourceDefinition = {
   sourceId: SourceId;
@@ -76,7 +77,8 @@ function isSearchTab(tab: string): tab is SearchTab {
     tab === "academic" ||
     tab === "web" ||
     tab === "news" ||
-    tab === "discussions"
+    tab === "discussions" ||
+    tab === "videos"
   );
 }
 
@@ -226,7 +228,7 @@ async function rerankWebTabOnly(
  */
 async function fetchFederatedNonAcademicResults(
   query: string,
-  tab: "web" | "news" | "discussions",
+  tab: "web" | "news" | "discussions" | "videos",
   page: number,
   perPage: number,
   preferences: Awaited<ReturnType<typeof getDomainPreferences>>,
@@ -237,6 +239,19 @@ async function fetchFederatedNonAcademicResults(
   hasMore: boolean;
   degraded: boolean;
 }> {
+  // Videos is a single-source tab (YouTube) — no federation/rerank/diversity, just
+  // YouTube's own relevance order paged through the shared response pipeline.
+  if (tab === "videos") {
+    const yt = await searchYouTube(query, { limit: MAX_NON_ACADEMIC_RESULTS });
+    const start = page * perPage;
+    return {
+      results: yt.results.slice(start, start + perPage),
+      total: yt.results.length,
+      hasMore: yt.results.length > start + perPage,
+      degraded: yt.status.status !== "ok" && yt.results.length === 0,
+    };
+  }
+
   const federation = await federateNonAcademic(query, tab, {
     limit: MAX_NON_ACADEMIC_RESULTS,
     timeRange,
@@ -330,7 +345,7 @@ export async function GET(req: Request) {
 
   if (!isSearchTab(tabParam)) {
     return NextResponse.json(
-      { error: "Query parameter 'tab' must be academic, web, news, or discussions" },
+      { error: "Query parameter 'tab' must be academic, web, news, discussions, or videos" },
       { status: 400 }
     );
   }

--- a/src/lib/search/sources/__tests__/youtube.test.ts
+++ b/src/lib/search/sources/__tests__/youtube.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { mapYouTubeResult } from "../youtube";
+
+describe("mapYouTubeResult", () => {
+  it("maps a search item to a UnifiedSearchResult with a watch URL and channel as label", () => {
+    const m = mapYouTubeResult({
+      id: { videoId: "47pkFey3CZ0" },
+      snippet: {
+        publishedAt: "2017-11-04T23:39:36Z",
+        channelTitle: "Innovative Genomics Institute",
+        title: "Jennifer Doudna: CRISPR Basics",
+        description: "Jennifer Doudna explains the basics of CRISPR immunity.",
+      },
+    })!;
+    expect(m.title).toBe("Jennifer Doudna: CRISPR Basics");
+    expect(m.url).toBe("https://www.youtube.com/watch?v=47pkFey3CZ0");
+    expect(m.domain).toBe("youtube.com");
+    expect(m.sourceLabel).toBe("Innovative Genomics Institute");
+    expect(m.abstract).toBe("Jennifer Doudna explains the basics of CRISPR immunity.");
+    expect(m.year).toBe(2017);
+    expect(m.publishedAt).toBe("2017-11-04T23:39:36Z");
+    expect(m.sources).toEqual(["videos"]);
+  });
+
+  it("decodes HTML entities in the title and description", () => {
+    const m = mapYouTubeResult({
+      id: { videoId: "abc123" },
+      snippet: {
+        channelTitle: "MIT OpenCourseWare",
+        title: "Diabetes &amp; the Heart: What&#39;s the link?",
+        description: "Q&amp;A on &quot;statins&quot;",
+      },
+    })!;
+    expect(m.title).toBe("Diabetes & the Heart: What's the link?");
+    expect(m.abstract).toBe('Q&A on "statins"');
+  });
+
+  it("returns null when videoId or title is missing", () => {
+    expect(mapYouTubeResult({ id: {}, snippet: { title: "no id" } })).toBeNull();
+    expect(mapYouTubeResult({ id: { videoId: "x" }, snippet: { title: "" } })).toBeNull();
+  });
+});

--- a/src/lib/search/sources/youtube.ts
+++ b/src/lib/search/sources/youtube.ts
@@ -1,0 +1,153 @@
+import { createCircuitBreaker } from "@/lib/http/circuit-breaker";
+import { createOutboundLimiter } from "@/lib/http/outbound-limiter";
+import { resilientFetch } from "@/lib/http/resilient-fetch";
+import { okStatus, classifyFetchError, type SourceStatus } from "@/lib/search/source-status";
+import type { UnifiedSearchResult } from "@/types/search";
+
+const breaker = createCircuitBreaker({ service: "YouTube", failureThreshold: 5 });
+
+// YouTube Data API quota is metered per DAY (10k units; search = 100 units → ~100
+// searches/day free), not per second. Pace modestly to smooth bursts; the real
+// cost control is the opt-in Videos tab (we only call when the user asks for it).
+const limiter = createOutboundLimiter({
+  service: "YouTube",
+  requestsPerSecond: 5,
+  burst: 2,
+});
+
+const ENDPOINT = "https://www.googleapis.com/youtube/v3/search";
+
+// search = 100 units; capped at the API max of 50 results per call.
+const YOUTUBE_RESULT_CAP = 25;
+
+export interface YouTubeSearchOptions {
+  limit?: number;
+}
+
+interface YouTubeThumbnail {
+  url?: string;
+}
+interface YouTubeSnippet {
+  publishedAt?: string;
+  channelId?: string;
+  channelTitle?: string;
+  title?: string;
+  description?: string;
+  thumbnails?: { default?: YouTubeThumbnail; medium?: YouTubeThumbnail; high?: YouTubeThumbnail };
+}
+interface YouTubeSearchItem {
+  id?: { videoId?: string };
+  snippet?: YouTubeSnippet;
+}
+interface YouTubeSearchResponse {
+  items?: YouTubeSearchItem[];
+  pageInfo?: { totalResults?: number };
+  error?: { message?: string };
+}
+
+/** YouTube snippet text is HTML-entity-escaped (&amp; &#39; &quot; …) — decode it. */
+function decodeEntities(text: string): string {
+  return text
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#0*39;|&#x0*27;|&apos;/gi, "'")
+    .replace(/&nbsp;/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function mapYouTubeResult(item: YouTubeSearchItem, tag = "videos"): UnifiedSearchResult | null {
+  const videoId = item.id?.videoId;
+  const title = decodeEntities(item.snippet?.title ?? "");
+  if (!videoId || !title) return null;
+
+  const snippet = item.snippet ?? {};
+  const channel = decodeEntities(snippet.channelTitle ?? "");
+  const description = decodeEntities(snippet.description ?? "");
+  const publishedAt = snippet.publishedAt || undefined;
+  const year = publishedAt ? parseInt(publishedAt.slice(0, 4), 10) || 0 : 0;
+
+  return {
+    title,
+    authors: channel ? [channel] : [],
+    journal: channel,
+    url: `https://www.youtube.com/watch?v=${videoId}`,
+    domain: "youtube.com",
+    year,
+    publishedAt,
+    sourceLabel: channel || "YouTube",
+    abstract: description || undefined,
+    citationCount: 0,
+    publicationTypes: [tag],
+    isOpenAccess: true,
+    sources: [tag],
+  };
+}
+
+export async function searchYouTube(
+  query: string,
+  options: YouTubeSearchOptions = {}
+): Promise<{ results: UnifiedSearchResult[]; total: number; status: SourceStatus }> {
+  const key = process.env.YOUTUBE_API_KEY;
+  if (!key) {
+    return {
+      results: [],
+      total: 0,
+      status: { status: "missing_config", message: "YOUTUBE_API_KEY not set" },
+    };
+  }
+  if (!breaker.canRequest()) {
+    return {
+      results: [],
+      total: 0,
+      status: { status: "error", message: "Circuit breaker open — recent YouTube failures" },
+    };
+  }
+
+  const maxResults = Math.min(options.limit ?? YOUTUBE_RESULT_CAP, 50);
+  const url = new URL(ENDPOINT);
+  url.searchParams.set("part", "snippet");
+  url.searchParams.set("q", query);
+  url.searchParams.set("type", "video");
+  url.searchParams.set("order", "relevance");
+  url.searchParams.set("relevanceLanguage", "en");
+  url.searchParams.set("safeSearch", "moderate");
+  url.searchParams.set("maxResults", String(maxResults));
+  url.searchParams.set("key", key);
+
+  try {
+    await limiter.acquire();
+    const res = await resilientFetch(
+      url.toString(),
+      { headers: { Accept: "application/json" } },
+      { service: "YouTube", timeout: 8000, baseDelay: 600, maxRetries: 1 }
+    );
+    const data = (await res.json()) as YouTubeSearchResponse;
+
+    if (data.error) {
+      breaker.onFailure();
+      return {
+        results: [],
+        total: 0,
+        status: { status: "error", message: `YouTube: ${data.error.message ?? "API error"}` },
+      };
+    }
+
+    const results = (data.items ?? [])
+      .map((item) => mapYouTubeResult(item, "videos"))
+      .filter((r): r is UnifiedSearchResult => r !== null);
+
+    breaker.onSuccess();
+    return { results, total: data.pageInfo?.totalResults ?? results.length, status: okStatus() };
+  } catch (error) {
+    breaker.onFailure();
+    console.error("[YouTube] Search failed:", error);
+    return {
+      results: [],
+      total: 0,
+      status: classifyFetchError(error, { hasApiKey: true }),
+    };
+  }
+}


### PR DESCRIPTION
## What
First slice of **YouTube-as-study-material**: a curated **`videos`** search tab backed by the YouTube Data API.

- `searchYouTube` → `search.list` (type=video, relevance, en, safeSearch), maps each result to a `UnifiedSearchResult` (watch URL, channel as label/author, description as abstract, HTML entities decoded).
- Circuit breaker + outbound limiter + resilient fetch like the other sources; `YOUTUBE_API_KEY` → `missing_config` so it's **dormant until keyed**.
- Wired as a **standalone single-source tab** in the unified route (not through the multi-source federation): `SearchTab`/`isSearchTab` gain `"videos"`, and `fetchFederatedNonAcademicResults` branches to YouTube's own relevance order paged through the shared non-academic response pipeline — no rerank/diversity (video metadata isn't web docs).

## Verified live
`searchYouTube("type 2 diabetes management lecture")` returns real medical lectures (Dr. Najeeb, Armando Hasudungan, MedNerd). Key works.

## Test
`youtube.test.ts` — mapping (watch URL, channel label, HTML-entity decode, null guards). Route tests (35) + full sources suite (73) green; tsc + eslint clean.

## Next slices
2. Transcript + summary (Supadata → LLM, on-click, cached).
3. Videos tab UI + transcript/summary panel.

## Rollout
Needs `YOUTUBE_API_KEY` in Vercel for the tab to serve in prod (dormant otherwise, no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEgTUohzwMogXKPsWVdwJx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new **Videos** search tab powered by YouTube results.
  * Video results now appear in the unified search experience with standard title, link, source, and date details.
* **Bug Fixes**
  * Improved handling for video search so pagination and result counts behave consistently.
  * Added validation to ensure the new tab is recognized correctly.
* **Tests**
  * Added coverage for YouTube result mapping, including HTML decoding and missing-field handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->