### PR TITLE
feat(youtube): transcript + AI study notes endpoint (study-material MVP, part 2)

### DIFF
--- a/src/app/api/youtube/summary/route.ts
+++ b/src/app/api/youtube/summary/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { isAIConfigured } from "@/lib/ai/models";
+import { getCurrentUserId } from "@/lib/auth";
+import { checkRateLimit, RATE_LIMITS } from "@/lib/rate-limit";
+import { createResultCache } from "@/lib/search/result-cache";
+import { fetchYouTubeTranscript } from "@/lib/search/sources/youtube-transcript";
+import { summarizeTranscript } from "@/lib/youtube/study-notes";
+
+// Transcripts and their summaries are immutable per video → cache hard. First
+// request pays the Supadata + LLM cost; everyone after (any user) is a cache hit.
+const cache = createResultCache();
+const SUMMARY_TTL_SECONDS = 60 * 60 * 24 * 30; // 30 days
+
+// YouTube IDs are 11 chars, but allow a tolerant range; reject anything else so a
+// bad/oversized value never reaches Supadata.
+const VIDEO_ID_RE = /^[A-Za-z0-9_-]{6,20}$/;
+
+type SummaryPayload =
+  | { error: "no_transcript" | "missing_config" | "summarize_failed" | "transcript_error"; message: string }
+  | { lang: string; summary: string; keyPoints: string[]; topics: string[] };
+
+export async function POST(req: NextRequest) {
+  let userId: string;
+  try {
+    userId = await getCurrentUserId();
+  } catch {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const limited = await checkRateLimit(userId, "youtube-summary", RATE_LIMITS.ai);
+  if (limited) return limited;
+
+  if (!isAIConfigured()) {
+    return NextResponse.json({ error: "ai_not_configured" }, { status: 503 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+  const videoId = String((body as { videoId?: unknown })?.videoId ?? "");
+  if (!VIDEO_ID_RE.test(videoId)) {
+    return NextResponse.json({ error: "valid videoId required" }, { status: 400 });
+  }
+
+  try {
+    const { value } = await cache.getOrCompute<SummaryPayload>(
+      `yt-summary:${videoId}`,
+      async () => {
+        const t = await fetchYouTubeTranscript(videoId);
+        if (!t.ok) {
+          return {
+            error: t.reason === "no_transcript" ? "no_transcript" : t.reason === "missing_config" ? "missing_config" : "transcript_error",
+            message: t.message,
+          };
+        }
+        const notes = await summarizeTranscript(t.transcript);
+        if (!notes) {
+          return { error: "summarize_failed", message: "Could not produce study notes from the transcript" };
+        }
+        return { lang: t.transcript.lang, ...notes };
+      },
+      { ttlSeconds: SUMMARY_TTL_SECONDS, shouldCache: (v) => !("error" in v) }
+    );
+
+    if ("error" in value) {
+      const status =
+        value.error === "no_transcript" ? 422 : value.error === "missing_config" ? 503 : 502;
+      return NextResponse.json({ error: value.error, message: value.message }, { status });
+    }
+    return NextResponse.json({ videoId, ...value });
+  } catch (error) {
+    console.error("[youtube/summary] failed:", error);
+    return NextResponse.json({ error: "internal_error" }, { status: 500 });
+  }
+}

--- a/src/lib/search/sources/youtube-transcript.ts
+++ b/src/lib/search/sources/youtube-transcript.ts
@@ -1,0 +1,81 @@
+import { createCircuitBreaker } from "@/lib/http/circuit-breaker";
+import { resilientFetch } from "@/lib/http/resilient-fetch";
+
+const breaker = createCircuitBreaker({ service: "Supadata", failureThreshold: 5 });
+
+const ENDPOINT = "https://api.supadata.ai/v1/youtube/transcript";
+
+export interface YouTubeTranscript {
+  text: string;
+  lang: string;
+  availableLangs: string[];
+}
+
+interface SupadataResponse {
+  content?: string;
+  lang?: string;
+  availableLangs?: string[];
+  error?: string;
+  message?: string;
+}
+
+export type TranscriptResult =
+  | { ok: true; transcript: YouTubeTranscript }
+  | { ok: false; reason: "missing_config" | "no_transcript" | "error"; message: string };
+
+/**
+ * Fetch a YouTube transcript via Supadata's OpenAI-style endpoint. `text=true`
+ * returns the plain transcript string ({@link SupadataResponse.content}). A video
+ * with no caption track is a normal outcome (`no_transcript`), not a server fault,
+ * so the circuit breaker isn't tripped for it — only genuine fetch failures count.
+ */
+export async function fetchYouTubeTranscript(videoId: string): Promise<TranscriptResult> {
+  const key = process.env.SUPADATA_API_KEY;
+  if (!key) {
+    return { ok: false, reason: "missing_config", message: "SUPADATA_API_KEY not set" };
+  }
+  if (!breaker.canRequest()) {
+    return { ok: false, reason: "error", message: "Circuit breaker open — recent Supadata failures" };
+  }
+
+  const url = new URL(ENDPOINT);
+  url.searchParams.set("videoId", videoId);
+  url.searchParams.set("text", "true");
+
+  try {
+    const res = await resilientFetch(
+      url.toString(),
+      { headers: { "x-api-key": key, Accept: "application/json" } },
+      { service: "Supadata", timeout: 30000, baseDelay: 800, maxRetries: 1 }
+    );
+    const data = (await res.json()) as SupadataResponse;
+
+    const text = (data.content ?? "").trim();
+    if (!text) {
+      breaker.onSuccess(); // reachable API, just no captions for this video
+      return {
+        ok: false,
+        reason: "no_transcript",
+        message: data.error || data.message || "No transcript available for this video",
+      };
+    }
+
+    breaker.onSuccess();
+    return {
+      ok: true,
+      transcript: {
+        text,
+        lang: data.lang ?? "en",
+        availableLangs: data.availableLangs ?? [],
+      },
+    };
+  } catch (error) {
+    breaker.onFailure();
+    console.error("[Supadata] transcript fetch failed:", error);
+    return {
+      ok: false,
+      reason: "error",
+      message: error instanceof Error ? error.message : "transcript fetch failed",
+    };
+  }
+}

--- a/src/lib/youtube/__tests__/study-notes.test.ts
+++ b/src/lib/youtube/__tests__/study-notes.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+const generateText = vi.fn();
+vi.mock("ai", () => ({ generateText: (args: unknown) => generateText(args) }));
+vi.mock("@/lib/ai/models", () => ({ getSmallModel: () => ({ __id: "small" }) }));
+
+import { parseStudyNotes, summarizeTranscript } from "../study-notes";
+
+describe("parseStudyNotes", () => {
+  it("parses a bare JSON object", () => {
+    const n = parseStudyNotes('{"summary":"It teaches CRISPR.","keyPoints":["Cas9 cuts DNA"],"topics":["CRISPR"]}')!;
+    expect(n.summary).toBe("It teaches CRISPR.");
+    expect(n.keyPoints).toEqual(["Cas9 cuts DNA"]);
+    expect(n.topics).toEqual(["CRISPR"]);
+  });
+
+  it("parses JSON wrapped in a markdown fence", () => {
+    const n = parseStudyNotes('```json\n{"summary":"X.","keyPoints":[],"topics":[]}\n```')!;
+    expect(n.summary).toBe("X.");
+  });
+
+  it("extracts the outermost object from surrounding prose", () => {
+    const n = parseStudyNotes('Here you go: {"summary":"Y."} hope that helps')!;
+    expect(n.summary).toBe("Y.");
+  });
+
+  it("filters non-string array items and returns null without a summary", () => {
+    const n = parseStudyNotes('{"summary":"Z.","keyPoints":["ok",2,null,"good"]}')!;
+    expect(n.keyPoints).toEqual(["ok", "good"]);
+    expect(parseStudyNotes('{"keyPoints":["a"]}')).toBeNull();
+    expect(parseStudyNotes("not json")).toBeNull();
+  });
+});
+
+describe("summarizeTranscript", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("summarizes a transcript into study notes", async () => {
+    generateText.mockResolvedValue({
+      text: '{"summary":"A lecture on diabetes.","keyPoints":["Insulin resistance"],"topics":["T2DM"]}',
+    });
+    const notes = await summarizeTranscript({ text: "long transcript...", lang: "en", availableLangs: ["en"] });
+    expect(notes?.summary).toBe("A lecture on diabetes.");
+    expect(notes?.keyPoints).toEqual(["Insulin resistance"]);
+  });
+
+  it("returns null when the model output is unparseable", async () => {
+    generateText.mockResolvedValue({ text: "sorry, I cannot do that" });
+    expect(await summarizeTranscript({ text: "x", lang: "en", availableLangs: [] })).toBeNull();
+  });
+});

--- a/src/lib/youtube/study-notes.ts
+++ b/src/lib/youtube/study-notes.ts
@@ -1,0 +1,67 @@
+import { generateText } from "ai";
+import { getSmallModel } from "@/lib/ai/models";
+import type { YouTubeTranscript } from "@/lib/search/sources/youtube-transcript";
+
+export interface VideoStudyNotes {
+  summary: string;
+  keyPoints: string[];
+  topics: string[];
+}
+
+// ~12k input tokens — covers a ~1hr lecture and bounds cost. Multi-hour content is
+// truncated here (chunked summarization is a future enhancement).
+const MAX_TRANSCRIPT_CHARS = 48000;
+
+const SYSTEM_PROMPT = `You are a study assistant. From a video/lecture transcript, produce concise STUDY MATERIAL that is FAITHFUL to the transcript — never invent facts not present in it.
+
+Respond with ONLY a JSON object:
+{
+  "summary": "3-5 sentence overview of what the video teaches",
+  "keyPoints": ["concise takeaway", "..."],
+  "topics": ["key concept or term covered", "..."]
+}
+
+keyPoints: 5-10 items. topics: the main concepts/terms a student should know.`;
+
+/** Tolerant JSON parse: bare object, fenced, or the outermost {...}. */
+export function parseStudyNotes(text: string): VideoStudyNotes | null {
+  const trimmed = text.trim();
+  const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/);
+  const candidate = fenced ? fenced[1].trim() : trimmed;
+  let raw: unknown;
+  try {
+    raw = JSON.parse(candidate);
+  } catch {
+    const start = candidate.indexOf("{");
+    const end = candidate.lastIndexOf("}");
+    if (start === -1 || end <= start) return null;
+    try {
+      raw = JSON.parse(candidate.slice(start, end + 1));
+    } catch {
+      return null;
+    }
+  }
+  if (typeof raw !== "object" || raw === null) return null;
+  const obj = raw as Record<string, unknown>;
+  const summary = typeof obj.summary === "string" ? obj.summary.trim() : "";
+  if (!summary) return null;
+  const toStrings = (v: unknown): string[] =>
+    Array.isArray(v) ? v.filter((x): x is string => typeof x === "string" && x.trim().length > 0) : [];
+  return { summary, keyPoints: toStrings(obj.keyPoints), topics: toStrings(obj.topics) };
+}
+
+/**
+ * Summarize a transcript into study notes with the small (cheap) model. Returns
+ * null when the model output can't be parsed; the caller decides how to surface it.
+ */
+export async function summarizeTranscript(
+  transcript: YouTubeTranscript
+): Promise<VideoStudyNotes | null> {
+  const { text } = await generateText({
+    model: getSmallModel(),
+    system: SYSTEM_PROMPT,
+    prompt: `Transcript:\n${transcript.text.slice(0, MAX_TRANSCRIPT_CHARS)}`,
+    maxOutputTokens: 1200,
+  });
+  return parseStudyNotes(text);
+}


### PR DESCRIPTION
## What
On-click **study material** from a YouTube video — the value half of the feature.

- **Supadata transcript source** (`fetchYouTubeTranscript`) → `GET /v1/youtube/transcript?text=true`. A video with no caption track returns `no_transcript` (a normal outcome, not a circuit-breaker trip).
- **`summarizeTranscript`** → faithful study notes (summary + key points + topics) via the cheap small model; tolerant JSON parsing.
- **`POST /api/youtube/summary {videoId}`** → auth + rate-limit, then `cache.getOrCompute` keyed on `videoId` with a **30-day TTL**. Transcripts/summaries are immutable, so the first request pays the Supadata + LLM cost and every later request (any user) is a **cache hit**. Errors aren't cached (no captions → 422, unkeyed → 503).

This keeps the paid/fragile transcript layer strictly **on-click and pay-once** — the low-opex design.

## Verified live
Fetched the 42K-char Jennifer Doudna CRISPR lecture and produced accurate study notes (CRISPR as bacterial immune system, Cas9, Class 1 vs 2, anti-CRISPR proteins, ethics) — faithful to the transcript.

## Test
`study-notes.test.ts` — `parseStudyNotes` (bare/fenced/embedded JSON, filtering, null guards) + `summarizeTranscript` (mocked model). 6 green; tsc + eslint clean.

## Rollout
`SUPADATA_API_KEY` is already set in Vercel (prod + preview). Binds on next deploy.

## Next
3. Videos tab UI + transcript/summary panel (wires this endpoint to a click).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEgTUohzwMogXKPsWVdwJx