### PR TITLE
feat(explore): Videos tab + Transcript & Key Takeaways panel (study-material MVP, part 3)

### DIFF
--- a/src/app/api/youtube/summary/route.ts
+++ b/src/app/api/youtube/summary/route.ts
@@ -17,7 +17,7 @@ const VIDEO_ID_RE = /^[A-Za-z0-9_-]{6,20}$/;
 
 type SummaryPayload =
   | { error: "no_transcript" | "missing_config" | "summarize_failed" | "transcript_error"; message: string }
-  | { lang: string; summary: string; keyPoints: string[]; topics: string[] };
+  | { lang: string; transcript: string; summary: string; keyPoints: string[]; topics: string[] };
 
 export async function POST(req: NextRequest) {
   let userId: string;
@@ -58,9 +58,9 @@ export async function POST(req: NextRequest) {
         }
         const notes = await summarizeTranscript(t.transcript);
         if (!notes) {
-          return { error: "summarize_failed", message: "Could not produce study notes from the transcript" };
+          return { error: "summarize_failed", message: "Could not distill the transcript" };
         }
-        return { lang: t.transcript.lang, ...notes };
+        return { lang: t.transcript.lang, transcript: t.transcript.text, ...notes };
       },
       { ttlSeconds: SUMMARY_TTL_SECONDS, shouldCache: (v) => !("error" in v) }
     );

--- a/src/components/explore/ExplorePageClient.tsx
+++ b/src/components/explore/ExplorePageClient.tsx
@@ -42,6 +42,7 @@ const SEARCHABLE_TABS: SearchableExploreTab[] = [
   "web",
   "news",
   "discussions",
+  "videos",
 ];
 
 function createEmptyTabState(): TabState {
@@ -60,6 +61,7 @@ function buildInitialTabState(): Record<SearchableExploreTab, TabState> {
     web: createEmptyTabState(),
     news: createEmptyTabState(),
     discussions: createEmptyTabState(),
+    videos: createEmptyTabState(),
   };
 }
 
@@ -164,6 +166,7 @@ export function ExplorePageClient() {
     web: 0,
     news: 0,
     discussions: 0,
+    videos: 0,
     more: 0,
   });
   const [tabState, setTabState] = useState<Record<SearchableExploreTab, TabState>>(
@@ -230,6 +233,7 @@ export function ExplorePageClient() {
       web: 0,
       news: 0,
       discussions: 0,
+      videos: 0,
       more: 0,
     });
 
@@ -358,6 +362,7 @@ export function ExplorePageClient() {
           web: 0,
           news: 0,
           discussions: 0,
+          videos: 0,
           more: 0,
         });
         setIsSearching(true);
@@ -462,7 +467,7 @@ export function ExplorePageClient() {
       setHasSearched(true);
       setIsSearching(true);
       setError(null);
-      setCurrentPageByTab({ academic: 0, web: 0, news: 0, discussions: 0, more: 0 });
+      setCurrentPageByTab({ academic: 0, web: 0, news: 0, discussions: 0, videos: 0, more: 0 });
 
       const startedAt = performance.now();
       Promise.allSettled(
@@ -553,7 +558,7 @@ export function ExplorePageClient() {
       setHasSearched(true);
       setIsSearching(true);
       setError(null);
-      setCurrentPageByTab({ academic: 0, web: 0, news: 0, discussions: 0, more: 0 });
+      setCurrentPageByTab({ academic: 0, web: 0, news: 0, discussions: 0, videos: 0, more: 0 });
 
       const startedAt = performance.now();
       Promise.allSettled(

--- a/src/components/explore/ExploreTabs.tsx
+++ b/src/components/explore/ExploreTabs.tsx
@@ -2,13 +2,14 @@
 
 import { cn } from "@/lib/utils";
 
-export type ExploreTab = "academic" | "web" | "news" | "discussions" | "more";
+export type ExploreTab = "academic" | "web" | "news" | "discussions" | "videos" | "more";
 
 const TAB_LABELS: Record<ExploreTab, string> = {
   academic: "Academic",
   web: "Web",
   news: "News",
   discussions: "Discussions",
+  videos: "Videos",
   more: "More",
 };
 

--- a/src/components/explore/ResultCard.tsx
+++ b/src/components/explore/ResultCard.tsx
@@ -7,6 +7,7 @@ import type { UnifiedSearchResult } from "@/types/search";
 import type { ExploreTab } from "./ExploreTabs";
 import { ActionsMenu, type ActionsMenuCallbacks } from "./ActionsMenu";
 import { SourceInfoPanel } from "./SourceInfoPanel";
+import { VideoTakeaways } from "./VideoTakeaways";
 import type { DomainPreferenceLevel } from "@/lib/actions/domain-preferences";
 
 type SupportedTab = Exclude<ExploreTab, "more">;
@@ -336,6 +337,9 @@ export const ResultCard = memo(function ResultCard({
           {snippet}
         </p>
       ) : null}
+
+      {/* Videos tab: distill the lecture into transcript + key takeaways on demand */}
+      {tab === "videos" && <VideoTakeaways url={result.url} />}
 
       {/* Source Info Panel — inline expansion */}
       {showInfoPanel && (

--- a/src/components/explore/VideoTakeaways.tsx
+++ b/src/components/explore/VideoTakeaways.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useState } from "react";
+import { CircleNotch, FileText, CaretDown, CaretRight } from "@phosphor-icons/react";
+
+/** Pull the 11-char video id out of a youtube.com/watch?v= or youtu.be/ URL. */
+export function extractVideoId(url?: string): string | null {
+  if (!url) return null;
+  try {
+    const u = new URL(url);
+    if (u.hostname === "youtu.be") return u.pathname.slice(1) || null;
+    if (u.hostname.replace(/^www\./, "").endsWith("youtube.com")) return u.searchParams.get("v");
+  } catch {
+    /* not a parseable URL */
+  }
+  return null;
+}
+
+interface TakeawaysData {
+  lang: string;
+  transcript: string;
+  summary: string;
+  keyPoints: string[];
+  topics: string[];
+}
+
+type Status = "idle" | "loading" | "done" | "error";
+
+export function VideoTakeaways({ url }: { url?: string }) {
+  const videoId = extractVideoId(url);
+  const [status, setStatus] = useState<Status>("idle");
+  const [data, setData] = useState<TakeawaysData | null>(null);
+  const [errorMsg, setErrorMsg] = useState("");
+  const [showTranscript, setShowTranscript] = useState(false);
+
+  if (!videoId) return null;
+
+  const run = async () => {
+    setStatus("loading");
+    try {
+      const res = await fetch("/api/youtube/summary", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ videoId }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { message?: string };
+        setErrorMsg(
+          res.status === 422
+            ? "No transcript is available for this video."
+            : body.message || "Couldn't generate takeaways for this video."
+        );
+        setStatus("error");
+        return;
+      }
+      setData((await res.json()) as TakeawaysData);
+      setStatus("done");
+    } catch {
+      setErrorMsg("Couldn't generate takeaways for this video.");
+      setStatus("error");
+    }
+  };
+
+  if (status === "idle" || status === "error") {
+    return (
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        <button
+          className="inline-flex items-center gap-1.5 rounded-full border border-[var(--border)] px-3 py-1.5 text-[13px] font-medium text-ink transition-colors hover:border-brand hover:text-brand"
+          onClick={run}
+          type="button"
+        >
+          <FileText size={15} weight="regular" />
+          {status === "error" ? "Try again" : "Transcript & Key Takeaways"}
+        </button>
+        {status === "error" ? (
+          <span className="text-[12px] text-ink-muted">{errorMsg}</span>
+        ) : null}
+      </div>
+    );
+  }
+
+  if (status === "loading") {
+    return (
+      <div className="mt-3 flex items-center gap-2 text-[13px] text-ink-muted">
+        <CircleNotch className="animate-spin" size={15} weight="bold" />
+        Distilling the transcript…
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  return (
+    <div className="mt-3 rounded-xl border border-[var(--border)] bg-[var(--surface-raised)] p-4">
+      {data.keyPoints.length > 0 ? (
+        <section>
+          <h3 className="text-[12px] font-semibold uppercase tracking-wide text-ink-muted">Key takeaways</h3>
+          <ul className="mt-2 space-y-1.5">
+            {data.keyPoints.map((point, i) => (
+              <li className="flex gap-2 text-[14px] leading-[1.5] text-ink" key={i}>
+                <span className="mt-[7px] h-1.5 w-1.5 shrink-0 rounded-full bg-brand" />
+                <span>{point}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      {data.summary ? (
+        <section className="mt-4">
+          <h3 className="text-[12px] font-semibold uppercase tracking-wide text-ink-muted">Summary</h3>
+          <p className="mt-1.5 text-[14px] leading-[1.55] text-ink-muted">{data.summary}</p>
+        </section>
+      ) : null}
+
+      {data.topics.length > 0 ? (
+        <div className="mt-3 flex flex-wrap gap-1.5">
+          {data.topics.map((topic, i) => (
+            <span
+              className="rounded-full bg-black/[0.04] px-2.5 py-0.5 text-[12px] text-ink-muted dark:bg-white/[0.06]"
+              key={i}
+            >
+              {topic}
+            </span>
+          ))}
+        </div>
+      ) : null}
+
+      <button
+        className="mt-3 inline-flex items-center gap-1 text-[12px] font-medium text-ink-muted transition-colors hover:text-ink"
+        onClick={() => setShowTranscript((v) => !v)}
+        type="button"
+      >
+        {showTranscript ? <CaretDown size={13} weight="bold" /> : <CaretRight size={13} weight="bold" />}
+        {showTranscript ? "Hide transcript" : "View transcript"}
+      </button>
+      {showTranscript ? (
+        <p className="mt-2 max-h-72 overflow-y-auto whitespace-pre-wrap rounded-lg bg-black/[0.02] p-3 text-[13px] leading-[1.6] text-ink-muted dark:bg-white/[0.03]">
+          {data.transcript}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/explore/__tests__/ExplorePageClient.test.tsx
+++ b/src/components/explore/__tests__/ExplorePageClient.test.tsx
@@ -86,7 +86,8 @@ describe("ExplorePageClient", () => {
       await flushPromises();
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(4);
+    // One parallel fetch per searchable tab: academic, web, news, discussions, videos.
+    expect(fetchMock).toHaveBeenCalledTimes(5);
     expect(container.textContent).toContain("Academic");
     expect(container.textContent).toContain("academic result");
     expect(container.textContent).toContain("1 results in");

--- a/src/components/explore/__tests__/VideoTakeaways.test.ts
+++ b/src/components/explore/__tests__/VideoTakeaways.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { extractVideoId } from "../VideoTakeaways";
+
+describe("extractVideoId", () => {
+  it("extracts the id from a youtube.com/watch?v= URL", () => {
+    expect(extractVideoId("https://www.youtube.com/watch?v=47pkFey3CZ0")).toBe("47pkFey3CZ0");
+    expect(extractVideoId("https://youtube.com/watch?v=abc123&t=10s")).toBe("abc123");
+  });
+
+  it("extracts the id from a youtu.be short URL", () => {
+    expect(extractVideoId("https://youtu.be/47pkFey3CZ0")).toBe("47pkFey3CZ0");
+  });
+
+  it("returns null for non-YouTube or malformed URLs", () => {
+    expect(extractVideoId("https://vimeo.com/12345")).toBeNull();
+    expect(extractVideoId("https://www.youtube.com/results?search=x")).toBeNull();
+    expect(extractVideoId("not a url")).toBeNull();
+    expect(extractVideoId(undefined)).toBeNull();
+  });
+});


### PR DESCRIPTION
## What
Wires the YouTube backend (discovery + transcript + summary) into the explore UI — completing the integrated study-material feature.

- **New "Videos" tab** in `ExploreTabs`/`ExplorePageClient` (a 5th searchable tab; YouTube is single-source, so it pages through the same response pipeline as web/news/discussions).
- **`VideoTakeaways`** — a per-card **"Transcript & Key Takeaways"** CTA (named for a mature audience, not "study notes"). On click it calls `/api/youtube/summary` once and renders **Key takeaways → Summary → topic chips → a collapsible transcript**. Handles no-transcript (422) and error states. On-click + pay-once cached = low opex.
- `/api/youtube/summary` now also returns the **transcript text** (already fetched server-side; included in the immutable cached payload) so the panel can show it.

## Test
`VideoTakeaways.test.ts` — `extractVideoId` (watch / youtu.be / non-YouTube / malformed). `ExplorePageClient` updated for the 5th searchable tab. Explore + route suites (81) green; tsc + eslint clean.

## Rollout
`YOUTUBE_API_KEY` + `SUPADATA_API_KEY` already in Vercel (prod + preview). Binds on next deploy — then the Videos tab + Transcript & Key Takeaways are live end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEgTUohzwMogXKPsWVdwJx