### PR TITLE
fix(search): relevance-gate the quality ranker so off-topic mega-cited papers can't win

### DIFF
--- a/src/lib/search/__tests__/quality-ranker.test.ts
+++ b/src/lib/search/__tests__/quality-ranker.test.ts
@@ -17,19 +17,19 @@ function paper(over: Partial<UnifiedSearchResult>): UnifiedSearchResult {
   } as UnifiedSearchResult;
 }
 
-describe("quality-ranker — cross-encoder relevance is a bounded signal, not the ruler", () => {
-  it("does not let a low cross-encoder score bury a landmark RCT", () => {
-    // The primary trial report: the cross-encoder scored it low (it describes the
-    // intervention, not the trial acronym), but it is a high-evidence, highly cited
-    // RCT. The score arrives squashed to [0,1] (sigmoid(-7) ≈ 0.001) so it is one
-    // capped term; the clinical-quality priors must keep the primary on top.
+describe("quality-ranker — relevance gates the ranking; clinical priors order the relevant results", () => {
+  it("keeps a RELEVANT landmark RCT on top via its clinical priors", () => {
+    // An on-topic primary trial: the cross-encoder gives it a solid score, so it
+    // clears the relevance gate and its high evidence/citations/journal lift it above
+    // a less-relevant secondary. Realistic [0,1] scores — not the obsolete raw-logit
+    // 0.001 pathology, which the squashed reranker read-out no longer produces.
     const primary = paper({
       title: "Primary RCT",
       evidenceLevel: "I",
       citationCount: 5000,
       journalQuartile: "Q1",
       rrfScore: 0.9,
-      rerankScore: 0.001,
+      rerankScore: 0.55,
     });
     const secondary = paper({
       title: "Secondary sub-study",
@@ -37,11 +37,37 @@ describe("quality-ranker — cross-encoder relevance is a bounded signal, not th
       citationCount: 50,
       journalQuartile: "Q3",
       rrfScore: 0.3,
-      rerankScore: 0.88,
+      rerankScore: 0.5,
     });
 
     const ranked = qualityRank([secondary, primary], "primary rct");
     expect(ranked[0].title).toBe("Primary RCT");
+  });
+
+  it("relevance gate: an off-topic mega-cited paper cannot bury a relevant recent one", () => {
+    // The real-world failure this fixes: a generic methods paper (PRISMA) maxes every
+    // quality prior — Level I, Q1, 80k citations — but the cross-encoder correctly
+    // scores it near-zero for the actual clinical topic. The gate must crush it below
+    // a perfectly relevant, recent, zero-citation paper instead of crowning it.
+    const offTopic = paper({
+      title: "Off-topic mega-cited",
+      evidenceLevel: "I",
+      citationCount: 80000,
+      journalQuartile: "Q1",
+      rrfScore: 0.9,
+      rerankScore: 0.08,
+    });
+    const relevant = paper({
+      title: "Relevant recent paper",
+      evidenceLevel: "V",
+      citationCount: 0,
+      journalQuartile: null,
+      rrfScore: 0.4,
+      rerankScore: 0.92,
+    });
+
+    const ranked = qualityRank([offTopic, relevant], "the specific clinical topic");
+    expect(ranked[0].title).toBe("Relevant recent paper");
   });
 
   it("keeps the cross-encoder a meaningful but bounded signal (prefers the higher score, all else equal)", () => {

--- a/src/lib/search/quality-ranker.ts
+++ b/src/lib/search/quality-ranker.ts
@@ -37,13 +37,28 @@ export interface QualityRankingConfig {
  * source (measured: trial-acronym recall 0.72 → 0.85+ on the 87q harness).
  */
 const BALANCED_CONFIG: QualityRankingConfig = {
-  evidenceWeight: 0.25,
-  citationWeight: 0.10,
+  evidenceWeight: 0.16,
+  citationWeight: 0.07,
   velocityWeight: 0.0,
-  journalWeight: 0.10,
-  rrfWeight: 0.25,
-  relevanceWeight: 0.30,
+  journalWeight: 0.07,
+  rrfWeight: 0.20,
+  relevanceWeight: 0.50,
 };
+
+/**
+ * Relevance GATE. The weighted composite alone let off-topic mega-cited papers
+ * (e.g. PRISMA: Level I, Q1, 83k citations) out-score a perfectly relevant but
+ * recent, 0-citation paper, because the clinical priors maxed out while relevance
+ * was just one term. The gate makes relevance NECESSARY: the whole composite is
+ * multiplied by min(1, relevance / FLOOR), so a paper the cross-encoder scores
+ * below the floor is crushed no matter how prestigious it is, while everything at
+ * or above the floor is unpenalized and ordered by the quality priors as before.
+ */
+const RELEVANCE_GATE_FLOOR = 0.45;
+
+function relevanceGate(relevance: number): number {
+  return Math.min(1, relevance / RELEVANCE_GATE_FLOOR);
+}
 
 // ── Signal normalizers ──────────────────────────────────────────────
 
@@ -253,7 +268,7 @@ function scoreResult(r: UnifiedSearchResult, ctx: ScoringContext): ScoredResult 
   // or specific drug than the query specifies — drift the cross-encoder cannot
   // discriminate. The multiplier is recorded for the ranking trace.
   signals.entityDrift = ctx.rawQuery ? entityDriftPenalty(ctx.rawQuery, r) : 1;
-  const composite = weighted * signals.entityDrift;
+  const composite = weighted * signals.entityDrift * relevanceGate(signals.relevance);
   return { result: r, composite, signals };
 }
 


### PR DESCRIPTION
## The problem (live, in production)
"Recent advances in management of contrast-induced nephropathy" returned the **PRISMA statement (83k citations)**, a **dyslipidaemia guideline**, and an **intracerebral-haemorrhage imaging paper** at the top. None about CIN.

## Root cause
The quality composite weighted **relevance 0.30** vs **0.70** for clinical priors (evidence + rrf + citation + journal). A perfectly relevant but recent, zero-citation paper always lost to a generic paper that maxed every prior. The self-hosted **37M MedCPT dense lane returns the right papers** (verified: 12/12 on-topic CIN), but the ranker re-sorted them under PRISMA.

## Fix
- `relevanceWeight` **0.30 → 0.50**, priors cut to match.
- **Relevance gate**: composite × `min(1, relevance / 0.45)` — a paper the cross-encoder scores off-topic is crushed regardless of citations; anything at/above the floor is unpenalized and ordered by priors as before.

## Validation (evidence, not claims)
- **CIN query → 5/5 recent on-topic CIN papers; PRISMA gone.**
- **No regression:** DAPA-HF / EMPA-REG / SELECT lookups still return the primary trial at #1–3; GLP-1 and lecanemab queries clean.
- Corrected the test that encoded the bug (a 0.001-relevance paper ranking #1) + added a gate test. **285 search tests green**, tsc + eslint clean.

## Rollout (separate from this PR)
Wiring `MEDCPT_SEARCH_URL` + `MEDCPT_RERANK_URL` into Vercel so prod actually queries the dense index + reranker (they were never set — the index was dark in prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEgTUohzwMogXKPsWVdwJx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved search result ordering so relevance has a stronger role in ranking.

* **Bug Fixes**
  * Relevant results are now less likely to be pushed below off-topic items, even when those items have stronger quality signals.
  * Ranking behavior is more consistent for recent, relevant papers versus less relevant but highly cited content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->