### PR TITLE
fix(search): bump literature cache key to v2 (invalidate pre-fix results)

### DIFF
--- a/src/lib/search/run-search.ts
+++ b/src/lib/search/run-search.ts
@@ -359,7 +359,7 @@ async function searchPubMedPlanned(
 export async function runLiteratureSearch(
   params: RunLiteratureSearchParams
 ): Promise<LiteratureSearchResult> {
-  const key = buildCacheKey("litsearch:v1", {
+  const key = buildCacheKey("litsearch:v2", {
     query: params.query,
     pubmedQuery: params.pubmedQuery,
     sources: params.sources ? [...params.sources].sort() : undefined,


### PR DESCRIPTION
The Upstash result cache (~7h TTL, shared across deploys) re-serves literature rankings computed **before** the relevance-gate ranker fix — so a query stays bad on re-run even after the fix shipped. Bump `litsearch:v1 → v2` so every literature query recomputes with the corrected ranker.

Note: the deeper production issue is **Modal cold-start** — the dense lane + reranker idle down at low traffic, and a cold first-query drops the dense lane at the 6s fan-out deadline (the "34 results, no dense" symptom). Durable fix is `keep_warm=1` on the Modal functions; tracked separately.

tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEgTUohzwMogXKPsWVdwJx