### PR TITLE
fix(search): OpenRouter cohere/rerank-4-pro as primary academic reranker + signal-aware ranking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,7 +38,16 @@ ANTHROPIC_API_KEY=sk-ant-...
 # OpenAI (embeddings + deep research synthesis via GPT-5.2)
 OPENAI_API_KEY=sk-...
 
-# Optional: Cohere API key for search result reranking
+# Literature relevance reranker (academic path).
+# PRIMARY: OpenRouter cohere/rerank-4-pro — managed, always-warm (~1.2s, ~$0.0025/search).
+# Set OPENROUTER_API_KEY to enable it as the literature reranker. Override the model if needed:
+OPENROUTER_API_KEY=
+# ACADEMIC_RERANK_MODEL=cohere/rerank-4-pro
+# OPTIONAL self-hosted MedCPT cross-encoder (Modal A10G, scale-to-zero, ~20s cold) —
+# OFF the critical path unless explicitly opted in:
+# ACADEMIC_USE_MEDCPT_RERANK=1
+# MEDCPT_RERANK_URL=
+# TERTIARY fallback: Cohere-direct rerank-v3.5 (used if OPENROUTER/MedCPT are absent/down).
 COHERE_API_KEY=
 
 # Optional: SearXNG endpoint for Explore web/news/discussions search

--- a/.env.example
+++ b/.env.example
@@ -39,15 +39,19 @@ ANTHROPIC_API_KEY=sk-ant-...
 OPENAI_API_KEY=sk-...
 
 # Literature relevance reranker (academic path).
-# PRIMARY: OpenRouter cohere/rerank-4-pro — managed, always-warm (~1.2s, ~$0.0025/search).
-# Set OPENROUTER_API_KEY to enable it as the literature reranker. Override the model if needed:
+# REQUIRED for the academic reranker: OpenRouter cohere/rerank-4-pro is the PRIMARY,
+# always-warm reranker (managed, ~1.2s, ~$0.0025/search). Without OPENROUTER_API_KEY the
+# academic path has no live reranker and falls back to keyword-overlap relevance.
 OPENROUTER_API_KEY=
+# Override the OpenRouter rerank model if needed (default cohere/rerank-4-pro):
 # ACADEMIC_RERANK_MODEL=cohere/rerank-4-pro
-# OPTIONAL self-hosted MedCPT cross-encoder (Modal A10G, scale-to-zero, ~20s cold) —
-# OFF the critical path unless explicitly opted in:
+# OPTIONAL self-hosted MedCPT cross-encoder (Modal A10G, scale-to-zero, ~20s cold).
+# Retired from the live critical path (see docs/literature-search/RERANKER-DECISION.md);
+# the Modal A10G reranker stays scale-to-zero. MEDCPT_RERANK_URL is now OPTIONAL and is
+# only consulted when you explicitly opt in with ACADEMIC_USE_MEDCPT_RERANK=1:
 # ACADEMIC_USE_MEDCPT_RERANK=1
 # MEDCPT_RERANK_URL=
-# TERTIARY fallback: Cohere-direct rerank-v3.5 (used if OPENROUTER/MedCPT are absent/down).
+# TERTIARY fallback: Cohere-direct rerank-v3.5 (used only if OPENROUTER/MedCPT are absent/down).
 COHERE_API_KEY=
 
 # Optional: SearXNG endpoint for Explore web/news/discussions search

--- a/docs/literature-search/RERANKER-DECISION.md
+++ b/docs/literature-search/RERANKER-DECISION.md
@@ -1,0 +1,66 @@
+# Academic Reranker Decision — OpenRouter `cohere/rerank-4-pro`
+
+**Date:** 2026-06-29
+**Status:** Adopted (live)
+**Scope:** Literature/academic search reranking only. **Retrieval is unchanged.**
+
+## Decision
+
+The live academic (literature) reranker is **OpenRouter `cohere/rerank-4-pro`** —
+a managed, always-warm reranking endpoint reached with `OPENROUTER_API_KEY`.
+
+- **PRIMARY (on the critical path):** OpenRouter `cohere/rerank-4-pro`
+  (`OPENROUTER_API_KEY`, model overridable via `ACADEMIC_RERANK_MODEL`, default
+  `cohere/rerank-4-pro`). A real `rerankScore` is attached on every normal search.
+- **OPTIONAL / break-glass:** the self-hosted **MedCPT Cross-Encoder** on Modal
+  A10G (`MEDCPT_RERANK_URL`) is **retired from the live path** and only consulted
+  when explicitly opted in with `ACADEMIC_USE_MEDCPT_RERANK=1`.
+- **TERTIARY fallback:** Cohere-direct `rerank-v3.5` (`COHERE_API_KEY`), used only
+  if OpenRouter (and the opted-in MedCPT lane) are absent or failing.
+- **Floor:** with no reranker configured/reachable, search fails open to
+  keyword-overlap relevance — "no model, never fails."
+
+Backend order (literature path): **OpenRouter → [MedCPT if `ACADEMIC_USE_MEDCPT_RERANK=1`] → Cohere-direct.**
+
+Implementation: `src/lib/search/rerank.ts`.
+
+## Why
+
+Switching the live reranker to OpenRouter `cohere/rerank-4-pro` resolves three
+problems at once that the self-hosted MedCPT cross-encoder carried:
+
+1. **Cold start.** The self-hosted A10G cross-encoder scales to zero and takes
+   ~20s to warm. On the first reranked search after idle the lane failed open and
+   the user got pre-rerank order. OpenRouter is managed and always-warm (~1.2s).
+2. **Idle GPU cost.** Keeping the A10G cross-encoder warm 24/7 to avoid that cold
+   start would cost roughly **$540–800/mo of idle GPU**. The managed endpoint has
+   no idle cost — we pay only per search.
+3. **Cohere-key blocker.** Direct Cohere access was blocked on key provisioning;
+   routing Cohere's reranker through OpenRouter removed that dependency.
+
+## Cost
+
+- OpenRouter `cohere/rerank-4-pro`: **~$0.0025 per search** (managed, always-warm).
+- MedCPT A10G cross-encoder: **$0 idle** (scale-to-zero, retired from the live
+  path), avoiding the **~$540–800/mo** an always-warm reranker would have cost.
+
+## What did NOT change — retrieval
+
+This decision is about **reranking only**. The MedCPT **DENSE retrieval lane** is
+untouched and stays live:
+
+- CPU `QueryEncoder` (`MEDCPT_SEARCH_URL` / `MEDCPT_QUERY_ENCODER_URL`),
+  `min_containers=1` always-warm — see `infra/modal/medcpt_service.py` §1 and
+  `infra/modal/OPS.md`.
+- The `keep_warm` cron warms the Turbopuffer ANN namespace (dense lane) **only**;
+  it deliberately does **not** warm the reranker.
+
+## Operational notes
+
+- The Modal `CrossEncoder` (A10G) stays deployed but **scale-to-zero**. Do **not**
+  add `min_containers` / a keep-warm to it — that re-introduces the idle GPU cost
+  this decision eliminated.
+- `MEDCPT_RERANK_URL` is now **OPTIONAL**. Leave it unset for the normal config.
+  To opt the cross-encoder back onto the critical path (break-glass), set both
+  `MEDCPT_RERANK_URL` and `ACADEMIC_USE_MEDCPT_RERANK=1` (accepts ~20s cold start).
+- Env reference: `.env.example`. Ops runbook: `infra/modal/OPS.md`.

--- a/eval/literature-search/__tests__/precision-metric.test.ts
+++ b/eval/literature-search/__tests__/precision-metric.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect } from "vitest";
+import type { EvalResultItem } from "@/lib/search/eval/metrics";
+import {
+  classifyResult,
+  classifyResults,
+  computePrecisionMetrics,
+  matchedIntruder,
+  meanPrecision,
+  type PrecisionSpec,
+} from "../precision-metric";
+import { PRECISION_QUERIES } from "../precision-queries";
+
+const paper = (title: string, abstract?: string): EvalResultItem => ({ title, abstract });
+
+/** A small synthetic spec: on-topic = contrast nephropathy; PRISMA is an intruder. */
+const SPEC: PrecisionSpec = {
+  onTopic: ["contrast-induced nephropathy", "periprocedural hydration contrast"],
+  offTopic: [
+    { label: "PRISMA", phrases: ["prisma statement", "preferred reporting items"] },
+    { label: "diabetic nephropathy", phrases: ["diabetic nephropathy"] },
+  ],
+};
+
+describe("classifyResult", () => {
+  it("labels a genuinely on-topic paper on_topic", () => {
+    expect(classifyResult(paper("Contrast-induced nephropathy after PCI"), SPEC)).toBe("on_topic");
+  });
+
+  it("labels a paper matching no signal unknown (NOT credited as on-topic)", () => {
+    expect(classifyResult(paper("A history of cardiology"), SPEC)).toBe("unknown");
+  });
+
+  it("labels a known intruder off_topic", () => {
+    expect(classifyResult(paper("The PRISMA Statement for systematic reviews"), SPEC)).toBe(
+      "off_topic"
+    );
+  });
+
+  it("gives intruders PRECEDENCE over on-topic lexical overlap", () => {
+    // A diabetic-nephropathy paper that also name-drops the contrast topic in its
+    // abstract must still be an intrusion, not credited as on-topic.
+    const sneaky = paper(
+      "Diabetic nephropathy progression",
+      "we also discuss contrast-induced nephropathy in passing"
+    );
+    expect(classifyResult(sneaky, SPEC)).toBe("off_topic");
+    expect(matchedIntruder(sneaky, SPEC)?.label).toBe("diabetic nephropathy");
+  });
+
+  it("requires ALL tokens of a phrase to be present (AND within a phrase)", () => {
+    // "periprocedural hydration contrast" needs all three tokens.
+    expect(classifyResult(paper("periprocedural hydration strategies"), SPEC)).toBe("unknown");
+    expect(
+      classifyResult(paper("periprocedural hydration with contrast media"), SPEC)
+    ).toBe("on_topic");
+  });
+});
+
+describe("computePrecisionMetrics — the headline behaviors", () => {
+  it("an all-on-topic top-10 scores precision 1.0 and zero intrusion", () => {
+    const results = Array.from({ length: 10 }, (_, i) =>
+      paper(`Contrast-induced nephropathy study ${i}`)
+    );
+    const m = computePrecisionMetrics(results, SPEC);
+    expect(m.count).toBe(10);
+    expect(m.onTopic).toBe(10);
+    expect(m.precisionAtK).toBe(1.0);
+    expect(m.precisionAt3).toBe(1.0);
+    expect(m.offTopicIntrusionRate).toBe(0);
+    expect(m.labeledPrecision).toBe(1.0);
+    expect(m.firstIntruderRank).toBeNull();
+    expect(m.intruders).toEqual([]);
+  });
+
+  it("a PRISMA-style intruder is PENALIZED (precision drops, intrusion rises)", () => {
+    const results = [
+      paper("The PRISMA Statement: preferred reporting items"), // rank 1 intruder
+      ...Array.from({ length: 9 }, (_, i) => paper(`Contrast-induced nephropathy study ${i}`)),
+    ];
+    const m = computePrecisionMetrics(results, SPEC);
+    expect(m.offTopic).toBe(1);
+    expect(m.onTopic).toBe(9);
+    expect(m.precisionAtK).toBeCloseTo(0.9);
+    expect(m.offTopicIntrusionRate).toBeCloseTo(0.1);
+    // A rank-1 intrusion is the worst kind — it craters top-of-list precision.
+    expect(m.firstIntruderRank).toBe(1);
+    expect(m.precisionAt3).toBeCloseTo(2 / 3);
+    expect(m.intruders[0]).toEqual({
+      rank: 1,
+      title: "The PRISMA Statement: preferred reporting items",
+      label: "PRISMA",
+    });
+  });
+
+  it("treats unknown results as not-credited (precision counts them against)", () => {
+    const results = [
+      paper("Contrast-induced nephropathy review"),
+      paper("Unrelated bench study on zebrafish"), // unknown
+    ];
+    const m = computePrecisionMetrics(results, SPEC);
+    expect(m.onTopic).toBe(1);
+    expect(m.unknown).toBe(1);
+    expect(m.offTopic).toBe(0);
+    expect(m.precisionAtK).toBeCloseTo(0.5);
+    expect(m.offTopicIntrusionRate).toBe(0);
+    // labeledPrecision ignores `unknown`: purity among confidently-labeled = 1/1.
+    expect(m.labeledPrecision).toBe(1.0);
+  });
+
+  it("honors k (only the top-k are scored)", () => {
+    const results = [
+      paper("The PRISMA Statement"), // intruder at rank 1
+      paper("Contrast-induced nephropathy A"),
+      paper("Contrast-induced nephropathy B"),
+      paper("Contrast-induced nephropathy C"),
+    ];
+    const m = computePrecisionMetrics(results, SPEC, 3);
+    expect(m.count).toBe(3);
+    expect(m.offTopic).toBe(1);
+    expect(m.onTopic).toBe(2);
+  });
+
+  it("handles an empty list without throwing (all rates 0, nulls where undefined)", () => {
+    const m = computePrecisionMetrics([], SPEC);
+    expect(m.count).toBe(0);
+    expect(m.precisionAtK).toBe(0);
+    expect(m.precisionAt3).toBe(0);
+    expect(m.offTopicIntrusionRate).toBe(0);
+    expect(m.labeledPrecision).toBeNull();
+    expect(m.firstIntruderRank).toBeNull();
+  });
+
+  it("classifyResults returns rank-ordered labels with the matched intruder class", () => {
+    const labels = classifyResults(
+      [paper("Contrast-induced nephropathy"), paper("Diabetic nephropathy outcomes")],
+      SPEC
+    );
+    expect(labels).toEqual([
+      { rank: 1, title: "Contrast-induced nephropathy", label: "on_topic" },
+      {
+        rank: 2,
+        title: "Diabetic nephropathy outcomes",
+        label: "off_topic",
+        intruder: "diabetic nephropathy",
+      },
+    ]);
+  });
+});
+
+describe("meanPrecision", () => {
+  it("averages a numeric field and ignores nulls", () => {
+    const rows = [
+      computePrecisionMetrics([paper("Contrast-induced nephropathy")], SPEC), // labeled 1.0
+      computePrecisionMetrics([], SPEC), // labeledPrecision null → ignored
+    ];
+    expect(meanPrecision(rows, (m) => m.labeledPrecision)).toBe(1.0);
+    expect(meanPrecision(rows, (m) => m.precisionAtK)).toBeCloseTo(0.5); // (1 + 0) / 2
+  });
+
+  it("returns null when every row is null for the picked field", () => {
+    const rows = [computePrecisionMetrics([], SPEC)];
+    expect(meanPrecision(rows, (m) => m.labeledPrecision)).toBeNull();
+  });
+});
+
+describe("the curated NICHE/BROAD specs actually encode the failure class", () => {
+  const hfpef = PRECISION_QUERIES.find((q) => q.id === "prec-hfpef-management")!;
+
+  it("classifies a genuine HFpEF trial on_topic", () => {
+    expect(
+      classifyResult(
+        paper("Empagliflozin in Heart Failure with a Preserved Ejection Fraction"),
+        hfpef
+      )
+    ).toBe("on_topic");
+  });
+
+  it("classifies the famous HFrEF blockbuster as an off-topic intrusion", () => {
+    expect(
+      classifyResult(
+        paper("Dapagliflozin in Patients with Heart Failure and Reduced Ejection Fraction"),
+        hfpef
+      )
+    ).toBe("off_topic");
+  });
+
+  it("does NOT misclassify PARAGON-HF (a real HFpEF trial) as the HFrEF intruder", () => {
+    // The HFrEF marker is "enalapril"/"paradigm-hf"/"reduced ejection fraction" —
+    // deliberately NOT "sacubitril valsartan", which PARAGON-HF also carries.
+    expect(
+      classifyResult(
+        paper("Sacubitril–Valsartan in Heart Failure with Preserved Ejection Fraction"),
+        hfpef
+      )
+    ).toBe("on_topic");
+  });
+
+  it("classifies PRISMA as an intruder across every curated query", () => {
+    const prisma = paper("PRISMA 2020 statement: preferred reporting items for systematic reviews");
+    for (const q of PRECISION_QUERIES) {
+      expect(classifyResult(prisma, q)).toBe("off_topic");
+    }
+  });
+
+  it("every curated query carries at least one on-topic signal and one intruder class", () => {
+    for (const q of PRECISION_QUERIES) {
+      expect(q.onTopic.length).toBeGreaterThan(0);
+      expect(q.offTopic.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/eval/literature-search/capture-precision.ts
+++ b/eval/literature-search/capture-precision.ts
@@ -1,0 +1,233 @@
+/**
+ * LIVE-tab off-topic PRECISION capture for the NICHE/BROAD benchmark.
+ *
+ * WHAT IT MEASURES (and why it is different from every prior council)
+ * ------------------------------------------------------------------
+ * Prior evals scored landmark RECALL on FROZEN warm candidate pools — never the
+ * live tab, never top-of-list precision, never broad/niche "management of X"
+ * queries. This script closes all three gaps at once: it runs each
+ * `PRECISION_QUERIES` query through the SAME `runLiteratureSearch` the live
+ * search tab calls (`src/app/api/research/search/route.ts`), takes the final
+ * ranked top-10 the user would actually see, and scores it with the off-topic
+ * precision metric (precision@10, top-3 precision, off-topic-intrusion rate).
+ *
+ * It is the live, end-to-end complement to the unit-tested pure metric — so the
+ * "citation-dominant config that aces recall while pulling PRISMA / broad
+ * guidelines / wrong-subtype blockbusters to the top of a niche query" failure
+ * can no longer hide behind a green recall scorecard.
+ *
+ * SECRETS: this hits real PubMed / OpenAlex / rerank APIs, so it MUST be run via
+ * op-run so keys are injected from the Dev vault (never pasted, never on disk).
+ * It is intentionally NOT wired into CI and writes only to the git-ignored
+ * `runs/` directory.
+ *
+ * USAGE (run later, with real keys — NOT during the harness build):
+ *
+ *   op-run -- npm run eval:search:precision -- --label baseline
+ *   op-run -- npm run eval:search:precision -- --label citation-heavy --only prec-hfpef-management,prec-contrast-nephropathy-advances
+ *
+ * Writes eval/literature-search/runs/precision-<label>/summary.{json,md} plus
+ * per-query JSON (the ranked top-10 with each result's on/off-topic label).
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runLiteratureSearch } from "@/lib/search/run-search";
+import type { UnifiedSearchResult } from "@/types/search";
+import type { EvalResultItem } from "@/lib/search/eval/metrics";
+import { PRECISION_QUERIES, PRECISION_SPECIALTY_COUNTS, type PrecisionQuery } from "./precision-queries";
+import {
+  classifyResults,
+  computePrecisionMetrics,
+  meanPrecision,
+  type PrecisionMetrics,
+} from "./precision-metric";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const pct = (v: number | null) => (v === null ? "—" : `${Math.round(v * 100)}%`);
+
+function loadEnv(): void {
+  for (const f of [".env.local", ".env"]) {
+    try {
+      (process as unknown as { loadEnvFile: (p: string) => void }).loadEnvFile(
+        join(process.cwd(), f)
+      );
+    } catch {
+      /* env file absent — providers fall back to keyless/public access */
+    }
+  }
+}
+
+interface CliArgs {
+  label: string;
+  only?: string[];
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const out: CliArgs = { label: "baseline" };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--label") out.label = argv[++i];
+    else if (a === "--only") out.only = argv[++i].split(",").map((s) => s.trim());
+  }
+  return out;
+}
+
+function toEvalItems(results: UnifiedSearchResult[]): EvalResultItem[] {
+  return results.map((r) => ({
+    title: String(r.title ?? ""),
+    doi: r.doi || undefined,
+    pmid: r.pmid || undefined,
+    year: typeof r.year === "number" ? r.year : undefined,
+    journal: r.journal || undefined,
+    studyType: r.studyType || undefined,
+    abstract: r.abstract || undefined,
+  }));
+}
+
+interface PrecisionRun {
+  id: string;
+  query: string;
+  specialty: string;
+  latencyMs: number;
+  error?: string;
+  sourceCounts: Record<string, number>;
+  results: Array<EvalResultItem & { label: string; intruder?: string }>;
+  metrics: PrecisionMetrics;
+}
+
+async function runQuery(q: PrecisionQuery): Promise<PrecisionRun> {
+  const started = Date.now();
+  try {
+    // Same call the live tab makes (see api/research/search/route.ts) — the
+    // FINAL ranked `.results`, not the raw candidate pool.
+    const res = await runLiteratureSearch({ query: q.query, perPage: 10 });
+    const latencyMs = Date.now() - started;
+    const items = toEvalItems(res.results.slice(0, 10));
+    const labels = classifyResults(items, q, 10);
+    return {
+      id: q.id,
+      query: q.query,
+      specialty: q.specialty,
+      latencyMs,
+      sourceCounts: res.sourceCounts ?? {},
+      results: items.map((item, i) => ({
+        ...item,
+        label: labels[i].label,
+        ...(labels[i].intruder ? { intruder: labels[i].intruder } : {}),
+      })),
+      metrics: computePrecisionMetrics(items, q, 10),
+    };
+  } catch (err) {
+    return {
+      id: q.id,
+      query: q.query,
+      specialty: q.specialty,
+      latencyMs: Date.now() - started,
+      error: err instanceof Error ? err.message : String(err),
+      sourceCounts: {},
+      results: [],
+      metrics: computePrecisionMetrics([], q, 10),
+    };
+  }
+}
+
+function buildSummaryMd(label: string, runs: PrecisionRun[]): string {
+  const m = runs.map((r) => r.metrics);
+  const lines: string[] = [];
+  lines.push(`# Precision eval: \`${label}\``, "");
+  lines.push(`Niche/broad queries: ${runs.length} · specialties: ${Object.keys(PRECISION_SPECIALTY_COUNTS).length}`, "");
+  lines.push("## Aggregate (top-of-list precision — the recall-blind failure class)", "");
+  lines.push("| metric | value |", "|---|---|");
+  lines.push(`| precision@10 (on-topic share) | ${pct(meanPrecision(m, (x) => x.precisionAtK))} |`);
+  lines.push(`| precision@3 (top-of-list) | ${pct(meanPrecision(m, (x) => x.precisionAt3))} |`);
+  lines.push(`| off-topic intrusion rate | ${pct(meanPrecision(m, (x) => x.offTopicIntrusionRate))} |`);
+  lines.push(`| labeled precision (on / on+off) | ${pct(meanPrecision(m, (x) => x.labeledPrecision))} |`);
+  lines.push(
+    `| queries with a top-3 intrusion | ${runs.filter((r) => r.metrics.firstIntruderRank !== null && r.metrics.firstIntruderRank <= 3).length}/${runs.length} |`,
+    ""
+  );
+  lines.push("## Per-query", "");
+  lines.push("| id | specialty | n | P@10 | P@3 | intrusion | 1st-intruder-rank | top intruders |");
+  lines.push("|---|---|---|---|---|---|---|---|");
+  for (const r of runs) {
+    const x = r.metrics;
+    const intruders = x.intruders.map((i) => `#${i.rank} ${i.label}`).join("; ") || "—";
+    lines.push(
+      `| ${r.id} | ${r.specialty} | ${x.count} | ${pct(x.precisionAtK)} | ${pct(x.precisionAt3)} | ${pct(
+        x.offTopicIntrusionRate
+      )} | ${x.firstIntruderRank ?? "—"} | ${intruders} |${r.error ? ` ERR: ${r.error}` : ""}`
+    );
+  }
+  return lines.join("\n");
+}
+
+async function main() {
+  loadEnv();
+  const args = parseArgs(process.argv.slice(2));
+  const selected = args.only
+    ? PRECISION_QUERIES.filter((q) => args.only!.includes(q.id))
+    : PRECISION_QUERIES;
+  if (selected.length === 0) {
+    console.error("No queries selected. Check --only ids.");
+    process.exit(1);
+  }
+
+  const outDir = join(HERE, "runs", `precision-${args.label}`);
+  mkdirSync(join(outDir, "queries"), { recursive: true });
+  console.log(
+    `[precision] label=${args.label} queries=${selected.length} (LIVE runLiteratureSearch — real APIs)`
+  );
+  console.log(`[precision] specialties: ${JSON.stringify(PRECISION_SPECIALTY_COUNTS)}`);
+
+  const runs: PrecisionRun[] = [];
+  for (const q of selected) {
+    const run = await runQuery(q);
+    runs.push(run);
+    writeFileSync(join(outDir, "queries", `${q.id}.json`), JSON.stringify(run, null, 2));
+    const x = run.metrics;
+    console.log(
+      `  ${run.error ? "✗" : "✓"} ${q.id.padEnd(36)} n=${String(x.count).padStart(2)} ` +
+        `P@10=${pct(x.precisionAtK).padStart(4)} P@3=${pct(x.precisionAt3).padStart(4)} ` +
+        `intrusion=${pct(x.offTopicIntrusionRate).padStart(4)} 1st=${String(
+          x.firstIntruderRank ?? "—"
+        ).padStart(2)}` +
+        (run.error ? ` ERR: ${run.error}` : "")
+    );
+    // Pace between live queries so the shared OpenAlex/PubMed quota recovers
+    // (mirrors run.ts: a tight fan-out trips the OpenAlex circuit breaker).
+    await sleep(1500);
+  }
+
+  writeFileSync(
+    join(outDir, "summary.json"),
+    JSON.stringify(
+      {
+        label: args.label,
+        generatedAt: new Date().toISOString(),
+        queryCount: runs.length,
+        aggregate: {
+          precisionAt10: meanPrecision(runs.map((r) => r.metrics), (x) => x.precisionAtK),
+          precisionAt3: meanPrecision(runs.map((r) => r.metrics), (x) => x.precisionAt3),
+          offTopicIntrusionRate: meanPrecision(
+            runs.map((r) => r.metrics),
+            (x) => x.offTopicIntrusionRate
+          ),
+          labeledPrecision: meanPrecision(runs.map((r) => r.metrics), (x) => x.labeledPrecision),
+        },
+        runs,
+      },
+      null,
+      2
+    )
+  );
+  writeFileSync(join(outDir, "summary.md"), buildSummaryMd(args.label, runs));
+  console.log(`\n[precision] wrote ${outDir}/summary.{json,md}`);
+}
+
+main().catch((err) => {
+  console.error("[precision] fatal:", err);
+  process.exit(1);
+});

--- a/eval/literature-search/precision-metric.ts
+++ b/eval/literature-search/precision-metric.ts
@@ -1,0 +1,198 @@
+/**
+ * Off-topic PRECISION metric for the literature-search eval harness.
+ *
+ * WHY THIS EXISTS (the failure class it makes un-hideable)
+ * -------------------------------------------------------
+ * Prior councils measured set-based landmark RECALL on known-item queries —
+ * "did the famous high-citation paper appear in the top-10?". On those queries
+ * the blockbuster IS the answer, so a citation-dominant ranking scored great.
+ * But on NICHE / BROAD "management of X" queries the on-topic papers are NOT
+ * famous, and the generic mega-cited papers (PRISMA, broad ESC/KDIGO/ACC-AHA
+ * guidelines, methods papers, wrong-but-lexically-similar conditions) are
+ * tempting-but-WRONG. Recall can't see that failure; it only checks whether the
+ * known landmark is present, never whether the TOP of the list is on-topic or
+ * polluted by intruders.
+ *
+ * This module is the missing instrument: a PURE function (no I/O) that scores a
+ * ranked list against a query's on-topic / off-topic spec, producing
+ * precision@k and an off-topic-intrusion rate. It is deliberately DISTINCT from
+ * the recall metric in `@/lib/search/eval/metrics` (which it reuses only for
+ * text normalization), so the two measure orthogonal failure modes.
+ *
+ * Classification is heuristic and conservative:
+ *   - off_topic  — matches a CURATED intruder pattern (takes precedence: a
+ *                  generic paper that merely grazes the topic lexically is still
+ *                  an intrusion).
+ *   - on_topic   — does not match an intruder AND matches an on-topic signal.
+ *   - unknown    — matches neither (NOT credited as on-topic; it cannot inflate
+ *                  precision, and it is not counted as an intrusion either).
+ *
+ * The LLM council still supplies true semantic relevance; this metric supplies
+ * the cheap, deterministic, regression-proof signal that intruders are creeping
+ * to the top.
+ */
+
+import { normalizeTitle, type EvalResultItem } from "@/lib/search/eval/metrics";
+
+export type TopicLabel = "on_topic" | "off_topic" | "unknown";
+
+/** A named class of tempting-but-wrong intruder (e.g. "PRISMA reporting guideline"). */
+export interface OffTopicPattern {
+  /** Human-readable intruder class, surfaced in reports. */
+  label: string;
+  /**
+   * Phrases identifying this intruder. A phrase matches when ALL of its tokens
+   * appear in the result's title+abstract; the pattern matches if ANY phrase does.
+   */
+  phrases: string[];
+}
+
+/** The on-topic / off-topic acceptance spec for one query. */
+export interface PrecisionSpec {
+  /**
+   * Phrases identifying a genuinely on-topic paper. OR across phrases; AND across
+   * the tokens within a phrase (so `"empagliflozin preserved"` needs both words).
+   */
+  onTopic: string[];
+  /** Known intruder classes for this query (the tempting-but-wrong papers). */
+  offTopic: OffTopicPattern[];
+}
+
+const haystack = (item: EvalResultItem): string =>
+  `${normalizeTitle(item.title)} ${normalizeTitle(item.abstract ?? "")}`.trim();
+
+/**
+ * A phrase matches when every token (length >= 2 after normalization) appears as
+ * a substring of the haystack. Length-1 tokens are dropped so a stray initial
+ * (e.g. the "n" in "n-acetylcysteine") cannot match everything; a phrase with no
+ * surviving token never matches.
+ */
+function phraseMatches(hay: string, phrase: string): boolean {
+  const tokens = normalizeTitle(phrase)
+    .split(" ")
+    .filter((t) => t.length >= 2);
+  return tokens.length > 0 && tokens.every((t) => hay.includes(t));
+}
+
+const anyPhrase = (hay: string, phrases: string[]): boolean =>
+  phrases.some((p) => phraseMatches(hay, p));
+
+/** The first intruder pattern this result matches, or null. */
+export function matchedIntruder(
+  item: EvalResultItem,
+  spec: PrecisionSpec
+): OffTopicPattern | null {
+  const hay = haystack(item);
+  for (const pat of spec.offTopic) {
+    if (anyPhrase(hay, pat.phrases)) return pat;
+  }
+  return null;
+}
+
+/** Classify one result. Intruders take precedence over on-topic lexical overlap. */
+export function classifyResult(item: EvalResultItem, spec: PrecisionSpec): TopicLabel {
+  if (matchedIntruder(item, spec)) return "off_topic";
+  if (anyPhrase(haystack(item), spec.onTopic)) return "on_topic";
+  return "unknown";
+}
+
+export interface ClassifiedResult {
+  rank: number;
+  title: string;
+  label: TopicLabel;
+  /** Set only when label === "off_topic": which intruder class matched. */
+  intruder?: string;
+}
+
+/** Per-result labels for the top-k, in rank order. */
+export function classifyResults(
+  results: EvalResultItem[],
+  spec: PrecisionSpec,
+  k = 10
+): ClassifiedResult[] {
+  return results.slice(0, k).map((item, i) => {
+    const intruder = matchedIntruder(item, spec);
+    const label: TopicLabel = intruder
+      ? "off_topic"
+      : anyPhrase(haystack(item), spec.onTopic)
+        ? "on_topic"
+        : "unknown";
+    return {
+      rank: i + 1,
+      title: item.title,
+      label,
+      ...(intruder ? { intruder: intruder.label } : {}),
+    };
+  });
+}
+
+export interface PrecisionMetrics {
+  /** Results considered (min(k, list length)). */
+  count: number;
+  onTopic: number;
+  offTopic: number;
+  unknown: number;
+  /** on_topic / count. `unknown` counts against precision (conservative). */
+  precisionAtK: number;
+  /** on_topic / min(3, count) — the top-of-list precision the council can't fake. */
+  precisionAt3: number;
+  /** off_topic / count — the headline intrusion signal for this failure class. */
+  offTopicIntrusionRate: number;
+  /** on_topic / (on_topic + off_topic): purity among confidently-labeled results, or null. */
+  labeledPrecision: number | null;
+  /** 1-based rank of the first intruder, or null. A small rank = a top-of-list intrusion. */
+  firstIntruderRank: number | null;
+  /** The intruders that reached the top-k, with rank and matched class. */
+  intruders: Array<{ rank: number; title: string; label: string }>;
+}
+
+/**
+ * Score a ranked list against a query's on-topic / off-topic spec.
+ *
+ * Conventions for an empty list: every rate is 0 (no on-topic delivered, no
+ * intrusion) and `labeledPrecision` / `firstIntruderRank` are null. Callers that
+ * care about retrieval failure should read `count`.
+ */
+export function computePrecisionMetrics(
+  results: EvalResultItem[],
+  spec: PrecisionSpec,
+  k = 10
+): PrecisionMetrics {
+  const classified = classifyResults(results, spec, k);
+  const count = classified.length;
+  const onTopic = classified.filter((c) => c.label === "on_topic").length;
+  const offTopic = classified.filter((c) => c.label === "off_topic").length;
+  const unknown = classified.filter((c) => c.label === "unknown").length;
+
+  const top3 = classified.slice(0, 3);
+  const onTop3 = top3.filter((c) => c.label === "on_topic").length;
+
+  const firstIntruder = classified.find((c) => c.label === "off_topic");
+
+  return {
+    count,
+    onTopic,
+    offTopic,
+    unknown,
+    precisionAtK: count === 0 ? 0 : onTopic / count,
+    precisionAt3: top3.length === 0 ? 0 : onTop3 / top3.length,
+    offTopicIntrusionRate: count === 0 ? 0 : offTopic / count,
+    labeledPrecision: onTopic + offTopic === 0 ? null : onTopic / (onTopic + offTopic),
+    firstIntruderRank: firstIntruder ? firstIntruder.rank : null,
+    intruders: classified
+      .filter((c) => c.label === "off_topic")
+      .map((c) => ({ rank: c.rank, title: c.title, label: c.intruder ?? "intruder" })),
+  };
+}
+
+/** Mean of a numeric field across precision-metric rows, ignoring nulls. */
+export function meanPrecision(
+  rows: PrecisionMetrics[],
+  pick: (m: PrecisionMetrics) => number | null
+): number | null {
+  const vals = rows
+    .map(pick)
+    .filter((v): v is number => v !== null && v !== undefined && !Number.isNaN(v));
+  if (vals.length === 0) return null;
+  return vals.reduce((a, b) => a + b, 0) / vals.length;
+}

--- a/eval/literature-search/precision-queries.ts
+++ b/eval/literature-search/precision-queries.ts
@@ -1,0 +1,448 @@
+/**
+ * NICHE / BROAD precision benchmark for Manan OS literature search.
+ *
+ * THE GAP THIS CLOSES
+ * -------------------
+ * The recall benchmark (`./queries.ts`) is dominated by KNOWN-ITEM queries where
+ * the answer is a famous, high-citation landmark (PARTNER 3, DAPA-HF, KEYNOTE-189).
+ * On those, a citation-dominant ranking looks great. This set is the inverse: the
+ * on-topic papers are NOT blockbusters, and the generic mega-cited papers are
+ * exactly the wrong answer. Every query encodes:
+ *
+ *   - `onTopic`  — phrases that identify a genuinely on-topic paper.
+ *   - `offTopic` — CURATED intruder classes: the tempting-but-wrong papers a
+ *                  citation-greedy or lexically-naive ranker pulls to the top.
+ *
+ * The four recurring intruder archetypes (the failure class made concrete):
+ *   1. Reporting/methods papers — PRISMA, GRADE, Cochrane handbook. Astronomically
+ *      cited, topically empty.
+ *   2. Broad parent-field guidelines — a whole-disease ESC/KDIGO/ACC-AHA guideline
+ *      when the query asks about a narrow sub-entity.
+ *   3. Famous-but-wrong-subtype blockbusters — HFrEF trials for an HFpEF query,
+ *      checkpoint-inhibitor EFFICACY trials for an irAE-toxicity query.
+ *   4. Wrong-but-lexically-similar conditions — diabetic/IgA nephropathy for a
+ *      contrast-nephropathy query; GERD for eosinophilic esophagitis.
+ *
+ * Intruder phrases are written so they do NOT trip on the genuine niche papers
+ * (e.g. HFpEF uses "enalapril"/"paradigm-hf"/"reduced ejection fraction" as the
+ * HFrEF marker — never "sacubitril valsartan", which PARAGON-HF (a real HFpEF
+ * trial) also carries).
+ */
+
+import type { PrecisionSpec } from "./precision-metric";
+
+export interface PrecisionQuery extends PrecisionSpec {
+  /** Stable slug (used in artifact filenames). */
+  id: string;
+  /** The user query as typed into the live search tab. */
+  query: string;
+  specialty: string;
+  /** What an on-topic top-10 should actually contain. */
+  intent: string;
+  notes?: string;
+}
+
+/** The reporting/methods-paper intruder — cited everywhere, on-topic nowhere. */
+const METHODS_INTRUDER = {
+  label: "reporting/methods paper (PRISMA/GRADE/Cochrane)",
+  phrases: [
+    "prisma statement",
+    "preferred reporting items",
+    "prisma 2020",
+    "grade approach",
+    "grade guidelines",
+    "cochrane handbook",
+    "risk of bias tool",
+    "consort statement",
+  ],
+};
+
+export const PRECISION_QUERIES: PrecisionQuery[] = [
+  // ── Nephrology: contrast-induced nephropathy (REQUIRED) ─────────────────
+  {
+    id: "prec-contrast-nephropathy-advances",
+    query: "recent advances in management of contrast-induced nephropathy",
+    specialty: "nephrology",
+    intent:
+      "Contrast-specific prevention/management: peri-procedural hydration, the end of routine N-acetylcysteine (PRESERVE/AMACING), minimizing contrast volume. NOT the generic AKI guideline, NOT other nephropathies.",
+    onTopic: [
+      "contrast-induced nephropathy",
+      "contrast induced acute kidney injury",
+      "contrast-associated acute kidney injury",
+      "contrast nephropathy prevention",
+      "periprocedural hydration contrast",
+      "sodium bicarbonate contrast",
+      "acetylcysteine contrast",
+      "intravenous fluids angiography kidney",
+    ],
+    offTopic: [
+      METHODS_INTRUDER,
+      {
+        label: "broad KDIGO AKI guideline (not contrast-specific)",
+        phrases: ["kdigo clinical practice guideline acute kidney injury", "kdigo aki guideline"],
+      },
+      {
+        label: "wrong nephropathy (diabetic/IgA/membranous)",
+        phrases: ["diabetic nephropathy", "diabetic kidney disease", "iga nephropathy", "membranous nephropathy"],
+      },
+      {
+        label: "gadolinium / nephrogenic systemic fibrosis (different entity)",
+        phrases: ["gadolinium", "nephrogenic systemic fibrosis"],
+      },
+    ],
+  },
+
+  // ── Cardiology: HFpEF (REQUIRED) ────────────────────────────────────────
+  {
+    id: "prec-hfpef-management",
+    query: "management of HFpEF",
+    specialty: "cardiology",
+    intent:
+      "Heart failure with PRESERVED EF: SGLT2i (EMPEROR-Preserved, DELIVER), spironolactone (TOPCAT), sacubitril-valsartan (PARAGON-HF). The famous HFrEF blockbusters are the wrong subtype.",
+    onTopic: [
+      "heart failure with preserved ejection fraction",
+      "hfpef",
+      "preserved ejection fraction",
+      "empagliflozin preserved",
+      "dapagliflozin preserved",
+      "spironolactone preserved",
+    ],
+    offTopic: [
+      METHODS_INTRUDER,
+      {
+        label: "wrong subtype: HFrEF blockbuster",
+        phrases: [
+          "reduced ejection fraction",
+          "hfref",
+          "paradigm-hf",
+          "enalapril in heart failure",
+          "dapagliflozin in patients with heart failure and reduced",
+        ],
+      },
+      {
+        label: "acute decompensated / cardiogenic shock (wrong setting)",
+        phrases: ["cardiogenic shock", "acute decompensated heart failure inpatient"],
+      },
+    ],
+  },
+
+  // ── Onco-cardiology: ICI myocarditis ────────────────────────────────────
+  {
+    id: "prec-ici-myocarditis",
+    query: "management of immune checkpoint inhibitor associated myocarditis",
+    specialty: "onco-cardiology",
+    intent:
+      "ICI-induced myocarditis specifically: high-dose steroids, abatacept/ruxolitinib salvage. NOT the broad irAE guideline, NOT viral/giant-cell myocarditis, NOT checkpoint-inhibitor efficacy trials.",
+    onTopic: [
+      "checkpoint inhibitor myocarditis",
+      "immune-related myocarditis",
+      "immune checkpoint inhibitor associated myocarditis",
+      "ici myocarditis",
+      "fulminant myocarditis immune",
+    ],
+    offTopic: [
+      METHODS_INTRUDER,
+      {
+        label: "broad irAE management guideline (not myocarditis-specific)",
+        phrases: ["management of immune-related adverse events", "asco guideline immune-related adverse"],
+      },
+      {
+        label: "wrong etiology myocarditis (viral/giant-cell)",
+        phrases: ["viral myocarditis", "giant cell myocarditis"],
+      },
+      {
+        label: "checkpoint-inhibitor EFFICACY blockbuster",
+        phrases: ["keynote", "checkmate", "nivolumab versus", "pembrolizumab plus chemotherapy"],
+      },
+    ],
+  },
+
+  // ── Neurology: refractory status migrainosus ────────────────────────────
+  {
+    id: "prec-status-migrainosus",
+    query: "treatment of refractory status migrainosus",
+    specialty: "neurology",
+    intent:
+      "Inpatient/ED management of intractable migraine: IV DHE, magnesium, lidocaine, dexamethasone. NOT outpatient CGRP prophylaxis blockbusters, NOT cluster/tension headache, NOT the headache classification.",
+    onTopic: [
+      "status migrainosus",
+      "refractory migraine inpatient",
+      "intractable migraine emergency",
+      "dihydroergotamine status",
+      "lidocaine refractory migraine",
+    ],
+    offTopic: [
+      METHODS_INTRUDER,
+      {
+        label: "outpatient CGRP prophylaxis blockbuster (wrong setting)",
+        phrases: [
+          "erenumab",
+          "galcanezumab",
+          "fremanezumab for episodic migraine",
+          "cgrp monoclonal antibody prevention",
+        ],
+      },
+      {
+        label: "wrong headache type (cluster/tension)",
+        phrases: ["cluster headache", "tension-type headache"],
+      },
+      {
+        label: "headache classification reference",
+        phrases: ["international classification of headache disorders"],
+      },
+    ],
+  },
+
+  // ── Electrophysiology: CIED infection ───────────────────────────────────
+  {
+    id: "prec-cied-infection",
+    query: "management of cardiac implantable electronic device infection",
+    specialty: "electrophysiology",
+    intent:
+      "CIED/pacemaker pocket and lead infection: complete transvenous lead extraction, antibiotic envelope evidence. NOT native-valve endocarditis, NOT prosthetic-valve endocarditis, NOT dental prophylaxis.",
+    onTopic: [
+      "cardiac implantable electronic device infection",
+      "cied infection",
+      "pacemaker lead infection",
+      "transvenous lead extraction infection",
+      "device pocket infection",
+    ],
+    offTopic: [
+      METHODS_INTRUDER,
+      {
+        label: "native-valve infective endocarditis (lexically close, wrong entity)",
+        phrases: ["infective endocarditis", "duke criteria"],
+      },
+      {
+        label: "prosthetic valve endocarditis (wrong site)",
+        phrases: ["prosthetic valve endocarditis"],
+      },
+      {
+        label: "general dental antibiotic prophylaxis",
+        phrases: ["antibiotic prophylaxis dental procedures"],
+      },
+    ],
+  },
+
+  // ── Gastroenterology: eosinophilic esophagitis ──────────────────────────
+  {
+    id: "prec-eosinophilic-esophagitis",
+    query: "recent advances in management of eosinophilic esophagitis",
+    specialty: "gastroenterology",
+    intent:
+      "EoE-specific: dupilumab, swallowed topical (orodispersible budesonide), empiric elimination diet. NOT GERD/PPI, NOT eosinophilic ASTHMA biologics, NOT generic endoscopy-quality papers.",
+    onTopic: [
+      "eosinophilic esophagitis",
+      "dupilumab esophagitis",
+      "budesonide orodispersible esophagitis",
+      "swallowed topical corticosteroid esophagitis",
+      "elimination diet esophagitis",
+    ],
+    offTopic: [
+      METHODS_INTRUDER,
+      {
+        label: "GERD (lexically close, wrong diagnosis)",
+        phrases: ["gastroesophageal reflux disease", "proton pump inhibitor reflux"],
+      },
+      {
+        label: "eosinophilic ASTHMA biologic (wrong organ, shares 'eosinophilic')",
+        phrases: ["eosinophilic asthma", "severe asthma biologic"],
+      },
+      {
+        label: "generic endoscopy-quality paper",
+        phrases: ["adenoma detection rate", "bowel preparation colonoscopy"],
+      },
+    ],
+  },
+
+  // ── Heme-onc: tumor lysis syndrome ──────────────────────────────────────
+  {
+    id: "prec-tumor-lysis-syndrome",
+    query: "prevention and management of tumor lysis syndrome",
+    specialty: "hematology-oncology",
+    intent:
+      "TLS-specific: rasburicase vs allopurinol, risk stratification, hydration. NOT febrile neutropenia, NOT CAR-T cytokine release, NOT chronic-CKD potassium binders.",
+    onTopic: [
+      "tumor lysis syndrome",
+      "rasburicase",
+      "hyperuricemia tumor lysis",
+      "uric acid nephropathy malignancy",
+    ],
+    offTopic: [
+      METHODS_INTRUDER,
+      {
+        label: "febrile neutropenia (different onc emergency)",
+        phrases: ["febrile neutropenia", "neutropenic fever guideline"],
+      },
+      {
+        label: "chronic CKD hyperkalemia / potassium binders (wrong context)",
+        phrases: ["chronic kidney disease hyperkalemia", "patiromer", "sodium zirconium"],
+      },
+      {
+        label: "CAR-T cytokine release syndrome (different toxicity)",
+        phrases: ["cytokine release syndrome", "car t-cell therapy"],
+      },
+    ],
+  },
+
+  // ── ID / Orthopedics: prosthetic joint infection ────────────────────────
+  {
+    id: "prec-prosthetic-joint-infection",
+    query: "management of prosthetic joint infection",
+    specialty: "infectious-disease",
+    intent:
+      "PJI-specific: DAIR vs one-/two-stage revision, biofilm-active antibiotics, rifampin combinations. NOT native septic arthritis, NOT osteomyelitis, NOT generic surgical prophylaxis.",
+    onTopic: [
+      "prosthetic joint infection",
+      "periprosthetic joint infection",
+      "two-stage revision infection",
+      "debridement antibiotics implant retention",
+      "biofilm prosthetic",
+    ],
+    offTopic: [
+      METHODS_INTRUDER,
+      {
+        label: "native septic arthritis (lexically close, wrong entity)",
+        phrases: ["native joint septic arthritis", "septic arthritis native"],
+      },
+      {
+        label: "osteomyelitis (wrong infection)",
+        phrases: ["vertebral osteomyelitis", "diabetic foot osteomyelitis"],
+      },
+      {
+        label: "generic surgical antibiotic prophylaxis",
+        phrases: ["surgical antimicrobial prophylaxis guideline"],
+      },
+    ],
+  },
+
+  // ── Endocrinology: nonthyroidal illness syndrome ────────────────────────
+  {
+    id: "prec-nonthyroidal-illness",
+    query: "management of nonthyroidal illness syndrome in critically ill patients",
+    specialty: "endocrinology",
+    intent:
+      "Euthyroid-sick / low-T3 syndrome in the ICU: whether to treat, thyroid hormone trials in critical illness. NOT levothyroxine-for-hypothyroidism blockbusters, NOT Graves/hyperthyroidism, NOT thyroid nodules.",
+    onTopic: [
+      "nonthyroidal illness syndrome",
+      "euthyroid sick syndrome",
+      "low t3 syndrome critically ill",
+      "thyroid hormone critical illness",
+    ],
+    offTopic: [
+      METHODS_INTRUDER,
+      {
+        label: "primary hypothyroidism levothyroxine (famous, wrong context)",
+        phrases: ["levothyroxine hypothyroidism", "subclinical hypothyroidism treatment"],
+      },
+      {
+        label: "hyperthyroidism / Graves (wrong diagnosis)",
+        phrases: ["graves disease", "antithyroid drug hyperthyroidism"],
+      },
+      {
+        label: "thyroid nodule / cancer guideline",
+        phrases: ["thyroid nodule", "differentiated thyroid cancer"],
+      },
+    ],
+  },
+
+  // ── Rheum / Nephrology: lupus nephritis induction ───────────────────────
+  {
+    id: "prec-lupus-nephritis-induction",
+    query: "induction therapy for proliferative lupus nephritis",
+    specialty: "rheumatology",
+    intent:
+      "LN induction specifically: MMF, low-dose cyclophosphamide, belimumab (BLISS-LN), voclosporin (AURORA). NOT broad non-renal SLE management, NOT ANCA vasculitis, NOT other glomerulonephritides.",
+    onTopic: [
+      "lupus nephritis",
+      "proliferative lupus nephritis",
+      "voclosporin lupus",
+      "belimumab lupus nephritis",
+      "mycophenolate lupus induction",
+    ],
+    offTopic: [
+      METHODS_INTRUDER,
+      {
+        label: "broad non-renal SLE management/classification",
+        phrases: ["systemic lupus erythematosus classification criteria", "eular recommendations systemic lupus"],
+      },
+      {
+        label: "ANCA-associated vasculitis (wrong GN, lexically close)",
+        phrases: ["anca-associated vasculitis", "granulomatosis with polyangiitis"],
+      },
+      {
+        label: "wrong glomerulonephritis (IgA/diabetic)",
+        phrases: ["iga nephropathy", "diabetic nephropathy"],
+      },
+    ],
+  },
+
+  // ── Psychiatry: treatment-resistant schizophrenia ───────────────────────
+  {
+    id: "prec-clozapine-resistant-schizophrenia",
+    query: "management of treatment-resistant schizophrenia with clozapine",
+    specialty: "psychiatry",
+    intent:
+      "TRS / clozapine-specific: clozapine initiation, monitoring, augmentation strategies. NOT first-episode antipsychotic blockbusters, NOT generic antipsychotic network meta-analyses, NOT bipolar/MDD.",
+    onTopic: [
+      "treatment-resistant schizophrenia",
+      "clozapine",
+      "clozapine augmentation",
+      "refractory schizophrenia",
+    ],
+    offTopic: [
+      METHODS_INTRUDER,
+      {
+        label: "first-episode / first-line antipsychotic blockbuster",
+        phrases: ["first-episode psychosis", "antipsychotic in first-episode"],
+      },
+      {
+        label: "generic antipsychotic comparative meta-analysis",
+        phrases: ["comparative efficacy of antipsychotic", "network meta-analysis of antipsychotic"],
+      },
+      {
+        label: "wrong diagnosis (bipolar / major depression)",
+        phrases: ["bipolar disorder", "major depressive disorder"],
+      },
+    ],
+  },
+
+  // ── Rheum / Heme: VEXAS syndrome (recent, no blockbuster) ───────────────
+  {
+    id: "prec-vexas-syndrome",
+    query: "diagnosis and management of VEXAS syndrome",
+    specialty: "rheumatology",
+    intent:
+      "VEXAS-specific: UBA1 somatic mutation, treatment (JAK inhibitors, azacitidine, allo-HSCT) in VEXAS context. NOT generic MDS treatment, NOT large-vessel vasculitis, NOT other autoinflammatory syndromes.",
+    onTopic: [
+      "vexas syndrome",
+      "uba1 somatic",
+      "ubiquitin-activating enzyme uba1",
+      "vacuoles e1 enzyme",
+    ],
+    offTopic: [
+      METHODS_INTRUDER,
+      {
+        label: "generic myelodysplastic syndrome treatment (parent field)",
+        phrases: ["myelodysplastic syndrome treatment", "azacitidine in myelodysplastic"],
+      },
+      {
+        label: "large-vessel vasculitis / PMR (wrong rheum entity)",
+        phrases: ["giant cell arteritis", "polymyalgia rheumatica"],
+      },
+      {
+        label: "other autoinflammatory syndrome",
+        phrases: ["adult-onset still", "familial mediterranean fever"],
+      },
+    ],
+  },
+];
+
+/** Count of queries per specialty — sanity check for benchmark balance. */
+export const PRECISION_SPECIALTY_COUNTS: Record<string, number> = PRECISION_QUERIES.reduce(
+  (acc, q) => {
+    acc[q.specialty] = (acc[q.specialty] ?? 0) + 1;
+    return acc;
+  },
+  {} as Record<string, number>
+);

--- a/infra/modal/OPS.md
+++ b/infra/modal/OPS.md
@@ -68,16 +68,24 @@ Copy it.
   keep warm. Bulk *article* embedding still uses on-demand GPUs (`process_file`).
 - **`CrossEncoder.rerank`** — self-hosted `ncbi/MedCPT-Cross-Encoder` reranker on
   **scale-to-zero A10G** (`$0` idle; `scaledown_window` holds it warm across a
-  run). Reranks the top ~50 fused candidates post-fusion (~0.3–0.8s warm). Wired
-  via `MEDCPT_RERANK_URL`; throttle-proof replacement for Cohere (which stays as a
-  fail-open fallback). Cold start ~20s → the lane fails open (keeps pre-rerank
-  order) on the first query after idle.
+  run). **RETIRED from the live critical path** — the live academic reranker is now
+  OpenRouter `cohere/rerank-4-pro` (managed, always-warm, ~1.2s, ~$0.0025/search;
+  see `docs/literature-search/RERANKER-DECISION.md`). This A10G reranker stays
+  deployed but **scale-to-zero as an opt-in / break-glass fallback only**: it is
+  reached via `MEDCPT_RERANK_URL` **only when `ACADEMIC_USE_MEDCPT_RERANK=1`**.
+  **Do NOT add a `min_containers` / keep-warm to this reranker** — keeping it warm
+  24/7 is exactly the ~$540–800/mo of idle A10G the OpenRouter switch eliminated.
+  Cold start ~20s → if ever opted in it fails open (keeps pre-rerank order) on the
+  first query after idle. Retiring the reranker does **not** touch retrieval — the
+  MedCPT DENSE lane (`MEDCPT_SEARCH_URL`, below) is unchanged and stays live.
 - **`freshness`** — **weekly** cron (`FRESHNESS_CRON`, default `"0 6 * * 1"` =
   Mon 06:00 UTC). Pulls new daily updatefiles past the stored watermark.
-- **`keep_warm`** — **every-minute** cron that probes the Turbopuffer namespace so
-  its ANN cache never cools (warm ≈0.3s vs cold ≈3.5s ANN). Object-storage reads
-  only; the lane still fails open if the namespace is ever cold, so this is a
-  latency optimization, not a correctness dependency.
+- **`keep_warm`** — cron (`KEEP_WARM_CRON`, default `*/5 * * * *`) that probes the
+  Turbopuffer namespace so its ANN cache never cools (warm ≈0.3s vs cold ≈3.5s ANN).
+  **Scoped to the DENSE lane only — it does NOT warm the CrossEncoder reranker**
+  (that GPU is retired to scale-to-zero; see above). Object-storage reads only; the
+  lane still fails open if the namespace is ever cold, so this is a latency
+  optimization, not a correctness dependency.
 
 ---
 
@@ -118,9 +126,13 @@ code change** the moment they are present:
 # PREFERRED — one server-side round-trip (encode + Turbopuffer ANN on Modal).
 MEDCPT_SEARCH_URL=<the QueryEncoder.search URL from step 1>
 
-# Self-hosted reranker (throttle-proof MedCPT Cross-Encoder). When set, rerank.ts
-# uses it instead of Cohere; Cohere (COHERE_API_KEY) stays as a fail-open fallback.
-MEDCPT_RERANK_URL=<the CrossEncoder.rerank URL from step 1>
+# OPTIONAL self-hosted reranker (MedCPT Cross-Encoder), RETIRED from the live path.
+# The live academic reranker is OpenRouter cohere/rerank-4-pro (OPENROUTER_API_KEY) —
+# see docs/literature-search/RERANKER-DECISION.md. Leave MEDCPT_RERANK_URL UNSET for
+# the normal config. Only set it AND ACADEMIC_USE_MEDCPT_RERANK=1 to opt the scale-to-
+# zero A10G cross-encoder back onto the critical path (break-glass; accepts ~20s cold).
+# MEDCPT_RERANK_URL=<the CrossEncoder.rerank URL from step 1>
+# ACADEMIC_USE_MEDCPT_RERANK=1
 
 # Fallback two-hop (encode on Modal, ANN from the app). Used only when
 # MEDCPT_SEARCH_URL is unset. Both paths fail open.
@@ -211,6 +223,11 @@ which abstracts exceed).
 - Modal encoder: one always-warm **CPU** replica (`min_containers=1`) — a few
   $/mo, not GPU. Deterministic sub-second encode latency is the live lane's exit
   gate, which scale-to-zero could not meet (~20s cold start dropped the lane).
-- `keep_warm`: object-storage reads only — negligible.
+- `keep_warm`: object-storage reads only — negligible. (Dense lane only; it does
+  not warm the reranker.)
+- **Cross-Encoder reranker: $0 idle.** Retired from the live path (OpenRouter
+  cohere/rerank-4-pro is now the live academic reranker) and left **scale-to-zero**,
+  it avoids the ~$540–800/mo of idle A10G a 24/7 keep-warm would cost. The live
+  reranker cost moves to OpenRouter at ~$0.0025/search.
 - Freshness: a few GPU-minutes per week on the daily delta.
 - One-time: index load (egress/compute only) + the 2024–2026 backfill (~$3–15 GPU).

--- a/infra/modal/medcpt_service.py
+++ b/infra/modal/medcpt_service.py
@@ -404,15 +404,27 @@ class QueryEncoder:
 
 
 # ===========================================================================
-# 1b. Cross-Encoder reranker — self-hosted, throttle-proof replacement for the
-#     external (rate-limited) reranker. Scale-to-zero GPU: $0 idle, warms on use.
+# 1b. Cross-Encoder reranker — RETIRED from the live critical path.
 # ===========================================================================
-# Reranking runs POST-fusion over the top ~50 fused candidates — NOT inside the 5s
-# fan-out deadline — so a brief warm-up is acceptable. A10G batches all 50
-# (query, title+abstract) pairs in one forward pass (~0.3-0.8s warm). Scale-to-zero
-# keeps idle cost at $0; `scaledown_window` holds the replica warm across a run's
-# ~8s query gaps so it does not cold-start mid-eval. The lane FAILS OPEN: on cold
-# start, timeout, or error the caller keeps the pre-rerank order (see rerank.ts).
+# DEPRECATED FROM THE LIVE PATH: the live academic reranker is now OpenRouter
+# `cohere/rerank-4-pro` (managed, always-warm, ~1.2s, ~$0.0025/search; see
+# src/lib/search/rerank.ts and docs/literature-search/RERANKER-DECISION.md). That
+# solved the cold-start, idle-GPU cost, and Cohere-key blocker in one move, so this
+# self-hosted A10G cross-encoder no longer needs to be kept warm.
+#
+# It stays deployed but SCALE-TO-ZERO ($0 idle) as an opt-in / break-glass fallback:
+# rerank.ts only calls MEDCPT_RERANK_URL when ACADEMIC_USE_MEDCPT_RERANK=1. Do NOT add
+# a min_containers / keep-warm here — keeping this GPU warm 24/7 is exactly the
+# ~$540-800/mo of idle A10G the OpenRouter switch eliminated. NOTE: retiring the
+# reranker does NOT touch retrieval — the MedCPT DENSE lane (CPU QueryEncoder /
+# MEDCPT_SEARCH_URL, §1 below) stays live and unchanged.
+#
+# When opted in: reranking runs POST-fusion over the top ~50 fused candidates — NOT
+# inside the 5s fan-out deadline — so a brief warm-up is acceptable. A10G batches all
+# 50 (query, title+abstract) pairs in one forward pass (~0.3-0.8s warm). Scale-to-zero
+# keeps idle cost at $0; `scaledown_window` holds the replica warm across a run's ~8s
+# query gaps so it does not cold-start mid-eval. The lane FAILS OPEN: on cold start,
+# timeout, or error the caller keeps the pre-rerank order (see rerank.ts).
 @app.cls(
     image=image,
     gpu="A10G",
@@ -575,6 +587,11 @@ def freshness() -> dict:
 def keep_warm() -> int:
     """Keep the Turbopuffer namespace cache hot so the live dense lane's ANN
     latency is deterministic.
+
+    SCOPE: this warms the DENSE retrieval lane ONLY (Turbopuffer ANN namespace).
+    It deliberately does NOT warm the CrossEncoder reranker — that GPU is retired
+    from the live path and stays scale-to-zero (the live reranker is OpenRouter
+    cohere/rerank-4-pro; see §1b and docs/literature-search/RERANKER-DECISION.md).
 
     A warm namespace answers ANN in ~0.3s; a cold one (evicted to object storage
     after idle) takes ~3.5s, which — with query encoding — blows the live search's

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "ux:screenshot": "npx playwright test qa/ux-screenshot.ts",
     "eval:search": "tsx eval/literature-search/run.ts",
     "eval:search:cached": "tsx eval/literature-search/run-cached.ts",
+    "eval:search:precision": "tsx eval/literature-search/capture-precision.ts",
     "eval:web:exa": "npx tsx eval/web-search/capture-exa.ts",
     "eval:web:freeze": "npx tsx eval/web-search/capture-searxng.ts",
     "eval:web:run": "npx tsx eval/web-search/run.ts --label baseline",

--- a/src/lib/search/__tests__/guideline-boost.test.ts
+++ b/src/lib/search/__tests__/guideline-boost.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { planQuery } from "../query-planner";
 import { promoteGuidelines, rankAndAnnotate } from "../pipeline";
-import type { UnifiedSearchResult } from "@/types/search";
+import type { RankingTrace, UnifiedSearchResult } from "@/types/search";
 
 function paper(p: Partial<UnifiedSearchResult>): UnifiedSearchResult {
   return {
@@ -14,6 +14,21 @@ function paper(p: Partial<UnifiedSearchResult>): UnifiedSearchResult {
     isOpenAccess: false,
     sources: ["pubmed"],
     ...p,
+  };
+}
+
+function trace(over: Partial<RankingTrace>): RankingTrace {
+  return {
+    composite: 0,
+    evidence: 0,
+    citation: 0,
+    velocity: 0,
+    journal: 0,
+    rrf: 0,
+    relevance: 0,
+    entityDrift: 1,
+    strategy: "quality",
+    ...over,
   };
 }
 
@@ -69,6 +84,78 @@ describe("promoteGuidelines", () => {
       paper({ title: "B", studyType: "cohort" }),
     ];
     expect(promoteGuidelines(list).map((r) => r.title)).toEqual(["A", "B"]);
+  });
+
+  it("does NOT float an off-topic guideline that fails the relevance floor", () => {
+    const list = [
+      paper({
+        title: "On-topic RCT",
+        studyType: "rct",
+        citationCount: 100,
+        rankingTrace: trace({ relevance: 0.9, composite: 0.6 }),
+      }),
+      paper({
+        title: "Off-topic guideline",
+        studyType: "guideline",
+        year: 2024,
+        rankingTrace: trace({ relevance: 0.1, composite: 0.05 }),
+      }),
+    ];
+    const out = promoteGuidelines(list);
+    expect(out[0].title).toBe("On-topic RCT");
+    expect(out.map((r) => r.title)).toEqual(["On-topic RCT", "Off-topic guideline"]);
+  });
+
+  it("does NOT float a guideline flagged with off_topic_entity drift", () => {
+    const list = [
+      paper({ title: "On-topic RCT", studyType: "rct" }),
+      paper({
+        title: "Drifted guideline",
+        studyType: "guideline",
+        year: 2024,
+        flags: ["off_topic_entity"],
+      }),
+    ];
+    expect(promoteGuidelines(list)[0].title).toBe("On-topic RCT");
+  });
+
+  it("still floats an on-topic guideline that clears the relevance floor", () => {
+    const list = [
+      paper({
+        title: "Strong RCT",
+        studyType: "rct",
+        rankingTrace: trace({ relevance: 0.8, composite: 0.5 }),
+      }),
+      paper({
+        title: "On-topic guideline",
+        studyType: "guideline",
+        year: 2024,
+        rankingTrace: trace({ relevance: 0.7, composite: 0.4 }),
+      }),
+    ];
+    expect(promoteGuidelines(list)[0].title).toBe("On-topic guideline");
+  });
+
+  it("orders promoted guidelines by composite, newest year only as tie-breaker", () => {
+    const list = [
+      paper({
+        title: "2012 high-composite guideline",
+        studyType: "guideline",
+        year: 2012,
+        rankingTrace: trace({ relevance: 0.9, composite: 0.7 }),
+      }),
+      paper({
+        title: "2024 low-composite guideline",
+        studyType: "guideline",
+        year: 2024,
+        rankingTrace: trace({ relevance: 0.9, composite: 0.3 }),
+      }),
+    ];
+    // Higher composite wins even though it is older; year is only a tie-breaker.
+    expect(promoteGuidelines(list).map((r) => r.title)).toEqual([
+      "2012 high-composite guideline",
+      "2024 low-composite guideline",
+    ]);
   });
 });
 

--- a/src/lib/search/__tests__/quality-ranker.test.ts
+++ b/src/lib/search/__tests__/quality-ranker.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { UnifiedSearchResult } from "@/types/search";
-import { qualityRank } from "../quality-ranker";
+import { qualityRank, rankWithTrace } from "../quality-ranker";
 
 function paper(over: Partial<UnifiedSearchResult>): UnifiedSearchResult {
   return {
@@ -88,5 +88,63 @@ describe("quality-ranker — relevance gates the ranking; clinical priors order 
 
     const ranked = qualityRank([disliked, liked], "x");
     expect(ranked[0].title).toBe("Liked");
+  });
+});
+
+describe("quality-ranker — signal-aware gate: lexical fallback is not a cross-encoder probability", () => {
+  it("crushes a REAL-rerankScore off-topic mega-cited paper below a relevant one", () => {
+    // Defense-in-depth restated: with a calibrated cross-encoder score, the 0.45
+    // floor crushes the off-topic giant no matter how prestigious it is.
+    const offTopic = paper({
+      title: "Off-topic mega-cited methods paper",
+      evidenceLevel: "I",
+      citationCount: 95000,
+      journalQuartile: "Q1",
+      rrfScore: 0.95,
+      rerankScore: 0.07,
+    });
+    const relevant = paper({
+      title: "Tocilizumab for cytokine release syndrome",
+      evidenceLevel: "V",
+      citationCount: 3,
+      journalQuartile: null,
+      rrfScore: 0.3,
+      rerankScore: 0.9,
+    });
+    const ranked = qualityRank([offTopic, relevant], "tocilizumab cytokine release syndrome");
+    expect(ranked[0].title).toBe("Tocilizumab for cytokine release syndrome");
+  });
+
+  it("does NOT treat a generic filler-word overlap as relevance in the LEXICAL fallback", () => {
+    // No rerankScore → keyword fallback. The off-topic giant shares only the generic
+    // filler token "management" with the query; the distinctive disease/drug terms
+    // are absent. Its weighted overlap must stay below the gate floor so its maxed
+    // citation/journal priors cannot crown it, while the on-topic paper — which
+    // matches the distinctive terms — wins.
+    const offTopic = paper({
+      title: "Recent advances in the management of clinical patients",
+      evidenceLevel: "I",
+      citationCount: 90000,
+      journalQuartile: "Q1",
+      rrfScore: 0.95,
+    });
+    const onTopic = paper({
+      title: "Tocilizumab for cytokine release syndrome",
+      evidenceLevel: "V",
+      citationCount: 5,
+      journalQuartile: null,
+      rrfScore: 0.3,
+    });
+
+    const scored = rankWithTrace(
+      [offTopic, onTopic],
+      "tocilizumab cytokine release syndrome management"
+    );
+
+    expect(scored[0].result.title).toBe("Tocilizumab for cytokine release syndrome");
+    const off = scored.find((s) => s.result.title.startsWith("Recent advances"))!;
+    expect(off.signals.relevance).toBeLessThan(0.45);
+    const on = scored.find((s) => s.result.title.startsWith("Tocilizumab"))!;
+    expect(on.signals.relevance).toBeGreaterThan(0.7);
   });
 });

--- a/src/lib/search/__tests__/rerank.test.ts
+++ b/src/lib/search/__tests__/rerank.test.ts
@@ -8,11 +8,23 @@ vi.mock("@/lib/http/resilient-fetch", () => ({
   resilientFetch: mockResilientFetch,
 }));
 
+const OPENROUTER_KEY = "openrouter_test_key";
+const OPENROUTER_URL = "https://openrouter.ai/api/v1/rerank";
 const MEDCPT_URL = "https://example-medcpt-rerank.modal.run";
 const COHERE_KEY = "cohere_test_key";
+const COHERE_URL = "https://api.cohere.com/v2/rerank";
 
 function jsonResponse(body: unknown) {
   return { json: () => Promise.resolve(body) } as unknown as Response;
+}
+
+/** OpenRouter / Cohere v2 shape: results sorted by relevance, each pairing back to
+ * an input document via `index`. */
+function rerankResponse(pairs: [number, number][]) {
+  return jsonResponse({
+    results: pairs.map(([index, relevance_score]) => ({ index, relevance_score })),
+    usage: { search_units: 1, cost: 0.0025 },
+  });
 }
 
 function paper(title: string): UnifiedSearchResult {
@@ -40,11 +52,134 @@ afterEach(() => {
   vi.unstubAllEnvs();
 });
 
-describe("rerankResults — backend selection", () => {
-  it("uses the self-hosted MedCPT reranker when MEDCPT_RERANK_URL is set, sorting by score desc and squashing logits to [0,1]", async () => {
+describe("rerankResults — OpenRouter primary (literature)", () => {
+  it("maps relevance_score back to each input document by index and sorts desc", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", OPENROUTER_KEY);
+    // OpenRouter returns top_n results already sorted by relevance: B (idx 1) > C
+    // (idx 2) > A (idx 0). Each score is a [0,1] relevance probability used as-is.
+    mockResilientFetch.mockResolvedValueOnce(
+      rerankResponse([
+        [1, 0.91],
+        [2, 0.5],
+        [0, 0.12],
+      ])
+    );
+
+    const out = await rerankResults("q", RESULTS);
+
+    expect(out.map((r) => r.title)).toEqual([
+      "B relevance high",
+      "C relevance mid",
+      "A relevance low",
+    ]);
+    // relevance_score is carried through verbatim onto rerankScore (no squashing).
+    expect(out[0].rerankScore).toBe(0.91);
+    expect(out[1].rerankScore).toBe(0.5);
+    expect(out[2].rerankScore).toBe(0.12);
+
+    const [url, init] = mockResilientFetch.mock.calls[0];
+    expect(url).toBe(OPENROUTER_URL);
+    const body = JSON.parse(init.body as string);
+    expect(body).toMatchObject({
+      model: "cohere/rerank-4-pro",
+      query: "q",
+      documents: ["A relevance low. ", "B relevance high. ", "C relevance mid. "],
+      top_n: 3,
+    });
+    expect(init.headers.Authorization).toBe(`Bearer ${OPENROUTER_KEY}`);
+  });
+
+  it("ACADEMIC_RERANK_MODEL overrides the default model", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", OPENROUTER_KEY);
+    vi.stubEnv("ACADEMIC_RERANK_MODEL", "cohere/rerank-4-experimental");
+    mockResilientFetch.mockResolvedValueOnce(rerankResponse([[0, 0.4]]));
+
+    await rerankResults("q", RESULTS);
+
+    const body = JSON.parse(mockResilientFetch.mock.calls[0][1].body as string);
+    expect(body.model).toBe("cohere/rerank-4-experimental");
+  });
+
+  it("is PREFERRED over MedCPT and Cohere when all are configured", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", OPENROUTER_KEY);
     vi.stubEnv("MEDCPT_RERANK_URL", MEDCPT_URL);
-    // The endpoint returns raw LOGITS in INPUT order: A=-2, B=4, C=1 → sorted desc
-    // by sigmoid(logit) → B, C, A. The adapter squashes each to a [0,1] probability.
+    vi.stubEnv("ACADEMIC_USE_MEDCPT_RERANK", "1"); // even when MedCPT is explicitly enabled
+    vi.stubEnv("COHERE_API_KEY", COHERE_KEY);
+    mockResilientFetch.mockResolvedValueOnce(rerankResponse([[1, 0.9], [0, 0.1]]));
+
+    await rerankResults("q", RESULTS);
+
+    expect(mockResilientFetch).toHaveBeenCalledTimes(1);
+    expect(mockResilientFetch.mock.calls[0][0]).toBe(OPENROUTER_URL);
+  });
+
+  it("does NOT call MedCPT on the critical path unless ACADEMIC_USE_MEDCPT_RERANK=1", async () => {
+    // OpenRouter down, MedCPT URL present but NOT flagged → skip MedCPT, fall to Cohere.
+    vi.stubEnv("OPENROUTER_API_KEY", OPENROUTER_KEY);
+    vi.stubEnv("MEDCPT_RERANK_URL", MEDCPT_URL);
+    vi.stubEnv("COHERE_API_KEY", COHERE_KEY);
+    mockResilientFetch.mockRejectedValueOnce(new Error("[OpenRouter-Rerank] HTTP 503"));
+    mockResilientFetch.mockResolvedValueOnce(rerankResponse([[1, 0.9], [0, 0.1]]));
+
+    await rerankResults("q", RESULTS);
+
+    expect(mockResilientFetch).toHaveBeenCalledTimes(2);
+    expect(mockResilientFetch.mock.calls[0][0]).toBe(OPENROUTER_URL);
+    // second call skipped MedCPT entirely and went straight to Cohere
+    expect(mockResilientFetch.mock.calls[1][0]).toBe(COHERE_URL);
+  });
+
+  it("falls OpenRouter → MedCPT (when flagged) → Cohere", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", OPENROUTER_KEY);
+    vi.stubEnv("MEDCPT_RERANK_URL", MEDCPT_URL);
+    vi.stubEnv("ACADEMIC_USE_MEDCPT_RERANK", "1");
+    vi.stubEnv("COHERE_API_KEY", COHERE_KEY);
+    mockResilientFetch.mockRejectedValueOnce(new Error("[OpenRouter-Rerank] HTTP 503"));
+    mockResilientFetch.mockRejectedValueOnce(new Error("[MedCPT-Rerank] cold start timeout"));
+    mockResilientFetch.mockResolvedValueOnce(rerankResponse([[1, 0.9], [0, 0.1]]));
+
+    const out = await rerankResults("q", RESULTS);
+
+    expect(mockResilientFetch).toHaveBeenCalledTimes(3);
+    expect(mockResilientFetch.mock.calls[0][0]).toBe(OPENROUTER_URL);
+    expect(mockResilientFetch.mock.calls[1][0]).toBe(MEDCPT_URL);
+    expect(mockResilientFetch.mock.calls[2][0]).toBe(COHERE_URL);
+    expect(out.map((r) => r.title)).toEqual(["B relevance high", "A relevance low"]);
+  });
+
+  it("fails open (unchanged, no fetch) when no reranker is configured", async () => {
+    const out = await rerankResults("q", RESULTS);
+    expect(out).toBe(RESULTS);
+    expect(mockResilientFetch).not.toHaveBeenCalled();
+  });
+
+  it("fails open to the input order when OpenRouter is the only backend and it throws", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", OPENROUTER_KEY);
+    mockResilientFetch.mockRejectedValueOnce(new Error("[OpenRouter-Rerank] timed out"));
+
+    const out = await rerankResults("q", RESULTS);
+    expect(out).toBe(RESULTS);
+  });
+
+  it("advances to the next backend when OpenRouter yields no scores", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", OPENROUTER_KEY);
+    vi.stubEnv("COHERE_API_KEY", COHERE_KEY);
+    mockResilientFetch.mockResolvedValueOnce(jsonResponse({ results: [] }));
+    mockResilientFetch.mockResolvedValueOnce(rerankResponse([[1, 0.9], [0, 0.1]]));
+
+    const out = await rerankResults("q", RESULTS);
+
+    expect(mockResilientFetch).toHaveBeenCalledTimes(2);
+    expect(mockResilientFetch.mock.calls[1][0]).toBe(COHERE_URL);
+    expect(out.map((r) => r.title)).toEqual(["B relevance high", "A relevance low"]);
+  });
+});
+
+describe("rerankResults — MedCPT optional / Cohere tertiary", () => {
+  it("uses MedCPT (squashing logits to [0,1]) only when flagged and OpenRouter absent", async () => {
+    vi.stubEnv("MEDCPT_RERANK_URL", MEDCPT_URL);
+    vi.stubEnv("ACADEMIC_USE_MEDCPT_RERANK", "1");
+    // raw LOGITS in INPUT order: A=-2, B=4, C=1 → sorted desc by sigmoid → B, C, A.
     mockResilientFetch.mockResolvedValueOnce(jsonResponse({ scores: [-2, 4, 1] }));
 
     const out = await rerankResults("q", RESULTS);
@@ -54,85 +189,31 @@ describe("rerankResults — backend selection", () => {
       "C relevance mid",
       "A relevance low",
     ]);
-    // top score is sigmoid(4), not the raw logit; the negative logit becomes a
-    // bounded probability in (0, 0.5), never a negative value that could dominate
-    // a weighted sum of [0,1] quality signals.
     expect(out[0].rerankScore).toBeCloseTo(1 / (1 + Math.exp(-4)), 5);
-    expect(out[2].rerankScore).toBeCloseTo(1 / (1 + Math.exp(2)), 5);
     expect(out[2].rerankScore).toBeGreaterThan(0);
     expect(out[2].rerankScore).toBeLessThan(0.5);
-
-    const [url, init] = mockResilientFetch.mock.calls[0];
-    expect(url).toBe(MEDCPT_URL);
-    expect(JSON.parse(init.body as string)).toMatchObject({
-      query: "q",
-      documents: ["A relevance low. ", "B relevance high. ", "C relevance mid. "],
-    });
-  });
-
-  it("prefers MedCPT over Cohere when both are configured", async () => {
-    vi.stubEnv("MEDCPT_RERANK_URL", MEDCPT_URL);
-    vi.stubEnv("COHERE_API_KEY", COHERE_KEY);
-    mockResilientFetch.mockResolvedValueOnce(jsonResponse({ scores: [0.1, 0.9, 0.5] }));
-
-    await rerankResults("q", RESULTS);
-
-    expect(mockResilientFetch).toHaveBeenCalledTimes(1);
     expect(mockResilientFetch.mock.calls[0][0]).toBe(MEDCPT_URL);
   });
 
-  it("falls back to Cohere when only COHERE_API_KEY is set", async () => {
-    vi.stubEnv("COHERE_API_KEY", COHERE_KEY);
-    mockResilientFetch.mockResolvedValueOnce(
-      jsonResponse({ results: [{ index: 1, relevance_score: 0.9 }, { index: 0, relevance_score: 0.1 }] })
-    );
-
-    const out = await rerankResults("q", RESULTS);
-
-    expect(out.map((r) => r.title)).toEqual(["B relevance high", "A relevance low"]);
-    expect(mockResilientFetch.mock.calls[0][0]).toBe("https://api.cohere.com/v2/rerank");
-  });
-
-  it("fails open (unchanged, no fetch) when no reranker is configured", async () => {
+  it("ignores MEDCPT_RERANK_URL when the flag is not set, falling open with no other backend", async () => {
+    vi.stubEnv("MEDCPT_RERANK_URL", MEDCPT_URL); // present but NOT flagged
     const out = await rerankResults("q", RESULTS);
     expect(out).toBe(RESULTS);
     expect(mockResilientFetch).not.toHaveBeenCalled();
   });
 
-  it("fails open to the input order when the MedCPT call throws", async () => {
-    vi.stubEnv("MEDCPT_RERANK_URL", MEDCPT_URL);
-    mockResilientFetch.mockRejectedValueOnce(new Error("[MedCPT-Rerank] cold start timeout"));
-
-    const out = await rerankResults("q", RESULTS);
-    expect(out).toBe(RESULTS);
-  });
-
-  it("returns input unchanged when the reranker yields no scores", async () => {
-    vi.stubEnv("MEDCPT_RERANK_URL", MEDCPT_URL);
-    mockResilientFetch.mockResolvedValueOnce(jsonResponse({ scores: [] }));
-
-    const out = await rerankResults("q", RESULTS);
-    expect(out).toBe(RESULTS);
-  });
-
-  it("falls back from MedCPT to Cohere when the MedCPT call throws and Cohere is configured", async () => {
-    vi.stubEnv("MEDCPT_RERANK_URL", MEDCPT_URL);
+  it("uses Cohere-direct when only COHERE_API_KEY is set", async () => {
     vi.stubEnv("COHERE_API_KEY", COHERE_KEY);
-    mockResilientFetch.mockRejectedValueOnce(new Error("[MedCPT-Rerank] cold start timeout"));
-    mockResilientFetch.mockResolvedValueOnce(
-      jsonResponse({ results: [{ index: 1, relevance_score: 0.9 }, { index: 0, relevance_score: 0.1 }] })
-    );
+    mockResilientFetch.mockResolvedValueOnce(rerankResponse([[1, 0.9], [0, 0.1]]));
 
     const out = await rerankResults("q", RESULTS);
 
-    expect(mockResilientFetch).toHaveBeenCalledTimes(2);
-    expect(mockResilientFetch.mock.calls[0][0]).toBe(MEDCPT_URL);
-    expect(mockResilientFetch.mock.calls[1][0]).toBe("https://api.cohere.com/v2/rerank");
     expect(out.map((r) => r.title)).toEqual(["B relevance high", "A relevance low"]);
+    expect(mockResilientFetch.mock.calls[0][0]).toBe(COHERE_URL);
   });
 });
 
-describe("rerankResults — domain routing", () => {
+describe("rerankResults — domain routing (web path unchanged)", () => {
   const WEB_URL = "https://example-web-rerank.modal.run";
 
   it("web domain uses WEB_RERANK_URL, not the biomedical MedCPT reranker", async () => {
@@ -150,65 +231,61 @@ describe("rerankResults — domain routing", () => {
     ]);
   });
 
-  it("web domain does NOT borrow the literature MedCPT reranker (fails open when only MEDCPT is set)", async () => {
-    vi.stubEnv("MEDCPT_RERANK_URL", MEDCPT_URL); // literature lane only
-    const out = await rerankResults("q", RESULTS, undefined, { domain: "web" });
-    expect(mockResilientFetch).not.toHaveBeenCalled();
-    expect(out).toBe(RESULTS); // unchanged
-  });
-
-  it("literature (default) uses MedCPT and ignores WEB_RERANK_URL", async () => {
+  it("web domain does NOT borrow OpenRouter (literature primary) even when the key is set", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", OPENROUTER_KEY);
     vi.stubEnv("WEB_RERANK_URL", WEB_URL);
-    vi.stubEnv("MEDCPT_RERANK_URL", MEDCPT_URL);
     mockResilientFetch.mockResolvedValueOnce(jsonResponse({ scores: [1, 2, 3] }));
 
-    await rerankResults("q", RESULTS);
+    await rerankResults("q", RESULTS, undefined, { domain: "web" });
 
-    expect(mockResilientFetch.mock.calls[0][0]).toBe(MEDCPT_URL);
+    expect(mockResilientFetch.mock.calls[0][0]).toBe(WEB_URL);
   });
 
   it("web domain falls back to Cohere when WEB_RERANK_URL is unset", async () => {
     vi.stubEnv("COHERE_API_KEY", COHERE_KEY);
-    mockResilientFetch.mockResolvedValueOnce(
-      jsonResponse({
-        results: [
-          { index: 1, relevance_score: 0.9 },
-          { index: 0, relevance_score: 0.2 },
-        ],
-      })
-    );
+    mockResilientFetch.mockResolvedValueOnce(rerankResponse([[1, 0.9], [0, 0.2]]));
     const out = await rerankResults("q", RESULTS, undefined, { domain: "web" });
-    expect(mockResilientFetch.mock.calls[0][0]).toBe("https://api.cohere.com/v2/rerank");
+    expect(mockResilientFetch.mock.calls[0][0]).toBe(COHERE_URL);
     expect(out[0].title).toBe("B relevance high");
   });
 });
 
 describe("hasReranker / attachRerankScores", () => {
-  it("hasReranker reflects any configured backend", () => {
+  it("hasReranker is true when OPENROUTER_API_KEY is present", () => {
     expect(hasReranker()).toBe(false);
+    vi.stubEnv("OPENROUTER_API_KEY", OPENROUTER_KEY);
+    expect(hasReranker()).toBe(true);
+  });
+
+  it("hasReranker reflects MEDCPT_RERANK_URL and COHERE_API_KEY too", () => {
+    expect(hasReranker()).toBe(false);
+    vi.stubEnv("MEDCPT_RERANK_URL", MEDCPT_URL);
+    expect(hasReranker()).toBe(true);
+    vi.unstubAllEnvs();
     vi.stubEnv("COHERE_API_KEY", COHERE_KEY);
     expect(hasReranker()).toBe(true);
   });
 
-  it("hasReranker reflects MEDCPT_RERANK_URL", () => {
-    expect(hasReranker()).toBe(false);
-    vi.stubEnv("MEDCPT_RERANK_URL", MEDCPT_URL);
-    expect(hasReranker()).toBe(true);
-  });
-
-  it("attachRerankScores activates via MEDCPT_RERANK_URL (no Cohere key) and sets scores without reordering", async () => {
-    vi.stubEnv("MEDCPT_RERANK_URL", MEDCPT_URL);
-    mockResilientFetch.mockResolvedValueOnce(jsonResponse({ scores: [0.1, 0.9, 0.5] }));
+  it("attachRerankScores activates via OPENROUTER_API_KEY and sets scores without reordering", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", OPENROUTER_KEY);
+    mockResilientFetch.mockResolvedValueOnce(
+      rerankResponse([
+        [1, 0.9],
+        [2, 0.5],
+        [0, 0.1],
+      ])
+    );
 
     const input = [paper("A relevance low"), paper("B relevance high"), paper("C relevance mid")];
     const out = await attachRerankScores("q", input, 50);
 
-    // same order (no reordering), scores attached by identity, squashed to [0,1]
+    // same order (no reordering), scores attached by identity
     expect(out.map((r) => r.title)).toEqual([
       "A relevance low",
       "B relevance high",
       "C relevance mid",
     ]);
-    expect(out[1].rerankScore).toBeCloseTo(1 / (1 + Math.exp(-0.9)), 5);
+    expect(out[1].rerankScore).toBe(0.9);
+    expect(out[0].rerankScore).toBe(0.1);
   });
 });

--- a/src/lib/search/pipeline.ts
+++ b/src/lib/search/pipeline.ts
@@ -11,7 +11,12 @@
  */
 
 import type { RankingTrace, UnifiedSearchResult } from "@/types/search";
-import { rankWithTrace, enrichJournalQuality, type ScoredResult } from "./quality-ranker";
+import {
+  rankWithTrace,
+  enrichJournalQuality,
+  RELEVANCE_GATE_FLOOR,
+  type ScoredResult,
+} from "./quality-ranker";
 import { enrichStudyTypes } from "./study-type-detector";
 import { getEvidenceLevel } from "./evidence-level";
 import { demoteSecondaryTrialResults } from "./trial-ranking";
@@ -294,25 +299,58 @@ export function rankAndAnnotate(
 }
 
 /**
- * Float clinical-practice-guideline documents to the top, newest version first.
- * Only RAISES guidelines (they move ahead of non-guideline results); the relative
- * order of every non-guideline result is preserved. A no-op when the pool has no
- * guideline-typed results. Gated by `isGuidelineLookup` in rankAndAnnotate so
- * ordinary clinical queries are untouched.
+ * A guideline is only floated to the top if it actually answers the query. An
+ * "ESC heart-failure guideline" must not surface for a kidney-transplant search
+ * just because it is typed as a guideline. Promotion is RELEVANCE-AWARE: a
+ * guideline is eligible only when it is not demonstrably off-topic, i.e. it carries
+ * no off_topic_entity drift flag AND (its lexical/model relevance is unknown, or it
+ * clears the relevance floor). An off-topic guideline is left in place and ordered
+ * by its quality composite like any other result — never raised.
+ */
+function isPromotableGuideline(r: UnifiedSearchResult): boolean {
+  if (r.studyType !== "guideline") return false;
+  if (r.flags?.includes("off_topic_entity")) return false;
+  const relevance = r.rankingTrace?.relevance;
+  if (typeof relevance === "number" && relevance < RELEVANCE_GATE_FLOOR) return false;
+  return true;
+}
+
+/**
+ * Composite-descending comparator with year as a TIE-BREAKER only. The input is
+ * already composite-sorted, so this preserves the quality order among guidelines
+ * and only uses the newer version to break an otherwise-equal ranking (so the 2024
+ * edition floats above the 2012 one when their composites are equal).
+ */
+function byCompositeThenYear(
+  a: UnifiedSearchResult,
+  b: UnifiedSearchResult
+): number {
+  const ca = a.rankingTrace?.composite ?? a.rrfScore ?? 0;
+  const cb = b.rankingTrace?.composite ?? b.rrfScore ?? 0;
+  if (cb !== ca) return cb - ca;
+  return (b.year || 0) - (a.year || 0);
+}
+
+/**
+ * Float clinical-practice-guideline documents to the top, ordered by quality
+ * composite with the newest version as a tie-breaker. Only RAISES guidelines that
+ * are relevant (see {@link isPromotableGuideline}); off-topic guidelines and every
+ * non-guideline result keep their relative order. A no-op when the pool has no
+ * promotable guideline. Gated by `isGuidelineLookup` in rankAndAnnotate so ordinary
+ * clinical queries are untouched.
  */
 export function promoteGuidelines(
   results: UnifiedSearchResult[]
 ): UnifiedSearchResult[] {
-  const guidelines: UnifiedSearchResult[] = [];
+  const promotable: UnifiedSearchResult[] = [];
   const rest: UnifiedSearchResult[] = [];
   for (const r of results) {
-    if (r.studyType === "guideline") guidelines.push(r);
+    if (isPromotableGuideline(r)) promotable.push(r);
     else rest.push(r);
   }
-  if (guidelines.length === 0) return results;
-  // Prefer the latest version among guidelines; stable for equal years.
-  const latestFirst = [...guidelines].sort((a, b) => (b.year || 0) - (a.year || 0));
-  return [...latestFirst, ...rest];
+  if (promotable.length === 0) return results;
+  const ordered = [...promotable].sort(byCompositeThenYear);
+  return [...ordered, ...rest];
 }
 
 function demoteRetracted(results: UnifiedSearchResult[]): UnifiedSearchResult[] {

--- a/src/lib/search/quality-ranker.ts
+++ b/src/lib/search/quality-ranker.ts
@@ -54,10 +54,32 @@ const BALANCED_CONFIG: QualityRankingConfig = {
  * below the floor is crushed no matter how prestigious it is, while everything at
  * or above the floor is unpenalized and ordered by the quality priors as before.
  */
-const RELEVANCE_GATE_FLOOR = 0.45;
+export const RELEVANCE_GATE_FLOOR = 0.45;
 
-function relevanceGate(relevance: number): number {
-  return Math.min(1, relevance / RELEVANCE_GATE_FLOOR);
+/**
+ * Stricter gate floor for the LEXICAL fallback. A real cross-encoder rerankScore is
+ * a calibrated topical-relevance probability, so the 0.45 floor is meaningful for it.
+ * A keyword-overlap score is NOT a probability — a generic paper that shares a couple
+ * of filler words ("management", "treatment") can post a deceptively high overlap. So
+ * when relevance is lexical we demand a higher overlap before treating the paper as
+ * "relevant", as defense-in-depth: an off-topic high-citation paper cannot ride a few
+ * shared generic words past the gate even if the reranker signal is ever missing.
+ */
+export const LEXICAL_RELEVANCE_GATE_FLOOR = 0.6;
+
+/**
+ * Where the relevance signal came from:
+ *  - "model"   — a real cross-encoder rerankScore (calibrated [0,1] probability)
+ *  - "lexical" — keyword-overlap fallback (NOT a probability; gated more strictly)
+ *  - "neutral" — no query keywords to score against (gate is a no-op)
+ */
+export type RelevanceSource = "model" | "lexical" | "neutral";
+
+function relevanceGate(relevance: number, source: RelevanceSource): number {
+  if (source === "neutral") return 1; // nothing to gate on — leave the composite intact
+  const floor =
+    source === "lexical" ? LEXICAL_RELEVANCE_GATE_FLOOR : RELEVANCE_GATE_FLOOR;
+  return Math.min(1, relevance / floor);
 }
 
 // ── Signal normalizers ──────────────────────────────────────────────
@@ -138,8 +160,41 @@ function extractQueryKeywords(query: string): string[] {
 }
 
 /**
- * Compute keyword overlap between a paper and the query.
- * Returns 0-1 ratio: (matched keywords) / (total query keywords).
+ * Generic clinical "filler" tokens. They survive stopword removal (they are not
+ * grammatical glue) yet carry almost no discriminative power for WHICH paper is on
+ * topic — every clinical corpus is saturated with them. Matching one of these is
+ * weak evidence of relevance, so they are heavily down-weighted in the lexical
+ * overlap score. Listed in both singular and plural so exact-token matching is
+ * enough (no fragile stemming that would also catch "advanced", "patient-reported").
+ */
+const GENERIC_FILLER_TOKENS = new Set([
+  "recent", "advance", "advances", "management", "treatment", "treatments",
+  "guideline", "guidelines", "recommendation", "recommendations", "role", "roles",
+  "update", "updates", "overview", "overviews", "clinical", "patient", "patients",
+]);
+
+const GENERIC_TOKEN_WEIGHT = 0.25;
+const DISTINCTIVE_TOKEN_WEIGHT = 1.5;
+const BASELINE_TOKEN_WEIGHT = 1.0;
+
+/**
+ * Relevance weight of a single query token. Generic filler is nearly discounted;
+ * long tokens (≥8 chars — drug names, conditions, mechanisms like "tocilizumab",
+ * "empagliflozin", "ferroptosis") are treated as rare/distinctive and up-weighted,
+ * so matching one of them is strong evidence of on-topic relevance.
+ */
+function keywordWeight(kw: string): number {
+  if (GENERIC_FILLER_TOKENS.has(kw)) return GENERIC_TOKEN_WEIGHT;
+  return kw.length >= 8 ? DISTINCTIVE_TOKEN_WEIGHT : BASELINE_TOKEN_WEIGHT;
+}
+
+/**
+ * Weighted keyword overlap between a paper and the query, in [0,1]. Unlike a plain
+ * matched/total ratio, each token contributes its discriminative weight: a paper
+ * that matches only generic filler ("management", "treatment") scores near zero,
+ * while one that matches the distinctive disease/drug terms scores near one. This
+ * is the LEXICAL fallback used only when no cross-encoder rerankScore is available;
+ * it must never let a few shared generic words masquerade as semantic relevance.
  */
 function computeRelevance(
   result: UnifiedSearchResult,
@@ -154,8 +209,14 @@ function computeRelevance(
     .join(" ")
     .toLowerCase();
 
-  const matchCount = queryKeywords.filter((kw) => text.includes(kw)).length;
-  return matchCount / queryKeywords.length;
+  let matchedWeight = 0;
+  let totalWeight = 0;
+  for (const kw of queryKeywords) {
+    const w = keywordWeight(kw);
+    totalWeight += w;
+    if (text.includes(kw)) matchedWeight += w;
+  }
+  return totalWeight > 0 ? matchedWeight / totalWeight : 0;
 }
 
 // ── Journal quality enrichment ──────────────────────────────────────
@@ -234,7 +295,28 @@ function buildScoringContext(
   };
 }
 
+/**
+ * Resolve the relevance signal AND where it came from. A real cross-encoder
+ * rerankScore (already squashed to [0,1] by the reranker adapter) is the calibrated
+ * "model" signal; absent it we fall back to the weighted keyword overlap ("lexical"),
+ * which the gate treats far more conservatively. With no query keywords there is
+ * nothing to gate on ("neutral").
+ */
+function resolveRelevance(
+  r: UnifiedSearchResult,
+  ctx: ScoringContext
+): { value: number; source: RelevanceSource } {
+  if (typeof r.rerankScore === "number") {
+    return { value: r.rerankScore, source: "model" };
+  }
+  if (ctx.queryKeywords.length > 0) {
+    return { value: computeRelevance(r, ctx.queryKeywords), source: "lexical" };
+  }
+  return { value: 0.5, source: "neutral" };
+}
+
 function scoreResult(r: UnifiedSearchResult, ctx: ScoringContext): ScoredResult {
+  const relevance = resolveRelevance(r, ctx);
   const signals: QualitySignals = {
     evidence: normalizeEvidence(r.evidenceLevel),
     citation: normalizeCitations(r.citationCount || 0, ctx.citationCap),
@@ -244,16 +326,7 @@ function scoreResult(r: UnifiedSearchResult, ctx: ScoringContext): ScoredResult 
     ),
     journal: normalizeJournalQuartile(r.journalQuartile),
     rrf: normalizeRrf(r.rrfScore, ctx.maxRrf),
-    // Prefer the cross-encoder rerank score as the relevance signal — it arrives
-    // already squashed to [0,1] by the reranker adapter, so it is one capped signal
-    // weighted alongside the quality priors, never a raw logit that dominates. Fall
-    // back to keyword overlap when no reranker ran.
-    relevance:
-      typeof r.rerankScore === "number"
-        ? r.rerankScore
-        : ctx.queryKeywords.length > 0
-          ? computeRelevance(r, ctx.queryKeywords)
-          : 0.5,
+    relevance: relevance.value,
     entityDrift: 1,
   };
   const c = ctx.config;
@@ -268,7 +341,11 @@ function scoreResult(r: UnifiedSearchResult, ctx: ScoringContext): ScoredResult 
   // or specific drug than the query specifies — drift the cross-encoder cannot
   // discriminate. The multiplier is recorded for the ranking trace.
   signals.entityDrift = ctx.rawQuery ? entityDriftPenalty(ctx.rawQuery, r) : 1;
-  const composite = weighted * signals.entityDrift * relevanceGate(signals.relevance);
+  // The gate is SIGNAL-AWARE: a model rerankScore is gated at the calibrated 0.45
+  // floor; a lexical overlap is gated more strictly so generic word matches cannot
+  // pass as cross-encoder-grade relevance.
+  const composite =
+    weighted * signals.entityDrift * relevanceGate(signals.relevance, relevance.source);
   return { result: r, composite, signals };
 }
 

--- a/src/lib/search/rerank.ts
+++ b/src/lib/search/rerank.ts
@@ -8,12 +8,46 @@ interface CohereRerankResponse {
   }[];
 }
 
+/** OpenRouter's rerank endpoint mirrors Cohere's v2 shape: a `results` array that
+ * pairs each input document back to a [0,1] `relevance_score` by its input `index`
+ * (the `document` echo is optional and ignored — we map by index, never by text). */
+interface OpenRouterRerankResponse {
+  results: {
+    index: number;
+    relevance_score: number;
+    document?: { text: string };
+  }[];
+  usage?: { search_units?: number; cost?: number };
+}
+
 /** A relevance score paired to a candidate's index in the input list. The score
- * is ALWAYS a [0,1] relevance probability regardless of backend — Cohere returns
- * that natively; the MedCPT cross-encoder returns a raw logit which we squash here
- * (see {@link logitToProbability}) so downstream ranking treats every backend the
- * same and never sees an unbounded value. */
+ * is ALWAYS a [0,1] relevance probability regardless of backend — OpenRouter and
+ * Cohere return that natively; the MedCPT cross-encoder returns a raw logit which we
+ * squash here (see {@link logitToProbability}) so downstream ranking treats every
+ * backend the same and never sees an unbounded value. */
 type RerankScore = { index: number; relevance_score: number };
+
+/** The OpenRouter rerank model for the academic literature path. Env-overridable
+ * via ACADEMIC_RERANK_MODEL; cohere/rerank-4-pro returns a [0,1] relevance score
+ * already commensurate with the quality-ranker's relevance signal. Read lazily (not
+ * a module-load constant) so tests/deploys can override it via the environment. */
+function academicRerankModel(): string {
+  return process.env.ACADEMIC_RERANK_MODEL || "cohere/rerank-4-pro";
+}
+
+/** Cap each document sent to a reranker. Title + abstract past a few thousand chars
+ * adds cost/latency without sharpening the relevance signal (the model truncates
+ * internally anyway), so we bound it before the wire. */
+const RERANK_DOC_MAX_CHARS = 2000;
+
+/** Title + abstract (or TLDR), trimmed to {@link RERANK_DOC_MAX_CHARS}, as the unit
+ * of text every reranker scores against the query. */
+function buildRerankDocument(result: UnifiedSearchResult): string {
+  const doc = `${result.title}. ${result.abstract || result.tldr || ""}`;
+  return doc.length > RERANK_DOC_MAX_CHARS
+    ? doc.slice(0, RERANK_DOC_MAX_CHARS)
+    : doc;
+}
 
 /** Squash a cross-encoder relevance logit (MedCPT range ≈ −16…+10) into the [0,1]
  * probability that `relevance_score` is contracted to carry. Sigmoid is the standard
@@ -24,9 +58,15 @@ function logitToProbability(logit: number): number {
   return 1 / (1 + Math.exp(-logit));
 }
 
-/** True when SOME reranker is configured (self-hosted MedCPT or Cohere). */
+/** True when SOME reranker is configured. OpenRouter is the PRIMARY literature
+ * backend (managed, always-warm); the self-hosted MedCPT cross-encoder and
+ * Cohere-direct remain optional fallbacks. */
 export function hasReranker(): boolean {
-  return Boolean(process.env.MEDCPT_RERANK_URL || process.env.COHERE_API_KEY);
+  return Boolean(
+    process.env.OPENROUTER_API_KEY ||
+      process.env.MEDCPT_RERANK_URL ||
+      process.env.COHERE_API_KEY
+  );
 }
 
 /**
@@ -64,6 +104,48 @@ async function rerankSelfHosted(
     .slice(0, topN);
 }
 
+/**
+ * OpenRouter rerank — the PRIMARY, managed/always-warm literature reranker
+ * (model {@link academicRerankModel}, default cohere/rerank-4-pro). POSTs the
+ * candidate documents and reads back a [0,1] `relevance_score` per document, paired
+ * to its input position by the response `index`. Warm latency ≈ 1.2s, ~$0.0025 per
+ * search. Fail-open: a non-200 or timeout throws (resilientFetch) so the caller
+ * advances to the next backend instead of returning empty results.
+ */
+async function rerankOpenRouter(
+  apiKey: string,
+  query: string,
+  documents: string[],
+  topN: number
+): Promise<RerankScore[]> {
+  const response = await resilientFetch(
+    "https://openrouter.ai/api/v1/rerank",
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: academicRerankModel(),
+        query,
+        documents,
+        top_n: topN,
+      }),
+    },
+    { service: "OpenRouter-Rerank", timeout: 4000, maxRetries: 1 }
+  );
+  const data: OpenRouterRerankResponse = await response.json();
+  const results = Array.isArray(data?.results) ? data.results : [];
+  return results
+    .filter(
+      (r) =>
+        typeof r?.index === "number" &&
+        typeof r?.relevance_score === "number"
+    )
+    .map((r) => ({ index: r.index, relevance_score: r.relevance_score }));
+}
+
 /** External Cohere reranker (fallback). Returns its already-sorted top-N. */
 async function rerankCohere(
   apiKey: string,
@@ -94,16 +176,25 @@ async function rerankCohere(
 }
 
 /**
- * Rerank by query↔document relevance through a fail-open backend CHAIN. The leading
- * self-hosted backend is DOMAIN-ROUTED: the web path (`domain: "web"`) uses the
- * general cross-encoder (`WEB_RERANK_URL`); the literature path (default) uses the
- * biomedical MedCPT cross-encoder (`MEDCPT_RERANK_URL`) — a query is never reranked
- * by the wrong-domain model. Each domain uses its own circuit-breaker label so an
- * outage in one lane can't trip the other. Cohere (`COHERE_API_KEY`) is the warm
- * fallback for either during the scale-to-zero cold window. A backend is tried only
- * if configured; if it errors or yields no scores, the next is attempted. With none
- * configured — or all failing — the input is returned unchanged and the quality
- * ranker falls back to keyword-overlap relevance: the "no model, never fails" floor.
+ * Rerank by query↔document relevance through a fail-open backend CHAIN.
+ *
+ * LITERATURE path (default domain): OpenRouter `cohere/rerank-4-pro`
+ * (`OPENROUTER_API_KEY`) is the PRIMARY, always-warm reranker (~1.2s, ~$0.0025) — it
+ * is on the critical path so a real `rerankScore` is attached on every normal search.
+ * The self-hosted MedCPT cross-encoder (`MEDCPT_RERANK_URL`, Modal A10G scale-to-zero,
+ * ~20s cold) is DROPPED off the critical path: it is only attempted when explicitly
+ * opted in via `ACADEMIC_USE_MEDCPT_RERANK=1`. Cohere-direct (`COHERE_API_KEY`)
+ * remains a tertiary fallback. Order: OpenRouter → [MedCPT if flagged] → Cohere.
+ *
+ * WEB path (`domain: "web"`): unchanged — the general cross-encoder (`WEB_RERANK_URL`)
+ * leads, Cohere-direct backs it up. A query is never reranked by the wrong-domain
+ * model and each domain uses its own circuit-breaker label so an outage in one lane
+ * can't trip the other.
+ *
+ * A backend is tried only if configured/enabled; if it errors or yields no scores,
+ * the next is attempted. With none configured — or all failing — the input is
+ * returned unchanged and the quality ranker falls back to keyword-overlap relevance:
+ * the "no model, never fails" floor.
  */
 export async function rerankResults(
   query: string,
@@ -112,21 +203,43 @@ export async function rerankResults(
   opts?: { domain?: "web" | "literature" }
 ): Promise<UnifiedSearchResult[]> {
   const isWeb = opts?.domain === "web";
+  const openRouterKey = process.env.OPENROUTER_API_KEY;
   const selfHostedUrl = isWeb
     ? process.env.WEB_RERANK_URL
     : process.env.MEDCPT_RERANK_URL;
   const cohereKey = process.env.COHERE_API_KEY;
-  if (results.length === 0 || (!selfHostedUrl && !cohereKey)) {
+
+  // OpenRouter is the literature primary; the web path keeps its own reranker chain.
+  const openRouterEnabled = !isWeb && Boolean(openRouterKey);
+  // The self-hosted MedCPT cross-encoder is DROPPED to scale-to-zero — for the
+  // literature path it is on the critical path ONLY when explicitly opted in. The web
+  // reranker (its own scale-to-zero GPU) stays its domain's primary as before.
+  const selfHostedEnabled = isWeb
+    ? Boolean(selfHostedUrl)
+    : Boolean(selfHostedUrl) && process.env.ACADEMIC_USE_MEDCPT_RERANK === "1";
+
+  if (
+    results.length === 0 ||
+    (!openRouterEnabled && !selfHostedEnabled && !cohereKey)
+  ) {
     return results;
   }
 
   const limit = topN || Math.min(results.length, 50);
-  const documents = results.map(
-    (r) => `${r.title}. ${r.abstract || r.tldr || ""}`
-  );
+  const documents = results.map(buildRerankDocument);
 
   const backends: { name: string; run: () => Promise<RerankScore[]> }[] = [];
-  if (selfHostedUrl)
+
+  // 1. OpenRouter (primary, literature) — managed, always-warm, ~1.2s.
+  if (openRouterEnabled && openRouterKey)
+    backends.push({
+      name: "OpenRouter",
+      run: () => rerankOpenRouter(openRouterKey, query, documents, limit),
+    });
+
+  // 2. Self-hosted cross-encoder — web: WEB_RERANK_URL (primary); literature: MedCPT
+  //    only when ACADEMIC_USE_MEDCPT_RERANK=1.
+  if (selfHostedEnabled && selfHostedUrl)
     backends.push({
       name: isWeb ? "WebReranker" : "MedCPT",
       run: () =>
@@ -136,18 +249,18 @@ export async function rerankResults(
           documents,
           limit,
           isWeb ? "Web-Rerank" : "MedCPT-Rerank",
-          // The web reranker is GPU scale-to-zero; keeping it warm 24/7 isn't worth
-          // it at this scale. Fail-open-fast: a short ceiling + no retry means a
-          // cold start degrades to un-reranked results instantly instead of making
-          // the user wait ~30s. A warm rerank returns in well under a second. The
-          // ceiling is env-tunable (WEB_RERANK_TIMEOUT_MS) so an offline/batch context
-          // — or a future always-warm deploy — can absorb the cold start; production
-          // leaves it unset and keeps the 4s fast-fail.
+          // Both self-hosted rerankers are GPU scale-to-zero; keeping them warm 24/7
+          // isn't worth it at this scale. The web lane fail-open-fasts (short ceiling,
+          // no retry) so a cold start degrades to un-reranked results instantly. The
+          // literature MedCPT lane is opt-in (ACADEMIC_USE_MEDCPT_RERANK) and, when
+          // on, absorbs the cold start with a longer ceiling + one retry. Warm: <1s.
           isWeb
             ? { timeout: Number(process.env.WEB_RERANK_TIMEOUT_MS) || 4000, maxRetries: 0 }
             : { timeout: 15000, maxRetries: 1 }
         ),
     });
+
+  // 3. Cohere-direct — tertiary fallback for either domain.
   if (cohereKey)
     backends.push({
       name: "Cohere",
@@ -158,6 +271,7 @@ export async function rerankResults(
     try {
       const scored = await backend.run();
       if (scored.length === 0) continue;
+      console.info(`[Rerank] scored by ${backend.name} (${scored.length} docs)`);
       return scored.map((r) => ({
         ...results[r.index],
         rerankScore: r.relevance_score,

--- a/src/lib/search/run-search.ts
+++ b/src/lib/search/run-search.ts
@@ -705,7 +705,8 @@ async function runLiteratureSearchUncached(
   // post-fusion critical path ~30-45% and shrinks the window where lane timeouts
   // accumulate. Both fail-open.
   //  - enrich: OpenAlex citation/PMID/DOI backfill — the S2-independent landmark signal.
-  //  - rerank: Cohere cross-encoder relevance score (dominant relevance signal).
+  //  - rerank: OpenRouter cohere/rerank-4-pro relevance score (managed, always-warm,
+  //    ~1.2s; the dominant relevance signal). MedCPT is off the critical path now.
   //
   // Both are bounded to the top `POST_FUSION_POOL` candidates by RRF score, in
   // place (slice shares object refs, so the originals in `fused` still get the


### PR DESCRIPTION
## Why
The live academic search returned citation-dominated, off-topic results (e.g. "management of contrast-induced nephropathy" surfaced PRISMA 83k-cites, KDIGO-diabetes, valvular-disease guidelines). Root cause: the cross-encoder reranker (MedCPT, Modal A10G scale-to-zero, ~20s cold) was dropped at a 4s deadline on cold start, so no relevance score reached the quality-ranker, which fell back to weak keyword-overlap — letting citation/journal priors crown off-topic mega-cited papers.

## What changed
- **OpenRouter `cohere/rerank-4-pro` is now the PRIMARY academic reranker** (`rerank.ts`) — managed, always-warm (~1.2s), ~$0.0025/search, via the existing `OPENROUTER_API_KEY`. The MedCPT A10G cross-encoder is dropped off the critical path (opt-in via `ACADEMIC_USE_MEDCPT_RERANK=1`), saving ~$540–800/mo of idle GPU. MedCPT **dense retrieval** lane is untouched.
- **Signal-aware relevance gate** (`quality-ranker.ts`) — the hard 0.45 gate applies to a real cross-encoder score; the keyword-overlap fallback uses a stricter floor and down-weights generic clinical filler so it can't masquerade as relevance.
- **Relevance-aware `promoteGuidelines`** (`pipeline.ts`) — guidelines only float when on-topic.
- **Off-topic precision eval instrument** (`eval/literature-search/`) — niche "management of X" queries + a precision@k / off-topic-intrusion metric + a live-tab capture script, so this failure class is measurable going forward.

## Proof (live precision eval on this branch)
| Query | Before (prod) | After |
|---|---|---|
| Contrast-induced nephropathy | PRISMA / KDIGO-diabetes / valvular guidelines | **10/10 CIN papers** — SGLT2 / hydration / temperature prevention on top |
| HFpEF | valvular / congenital / PE guidelines | **10/10 HFpEF papers** incl. STEP-HFpEF semaglutide |

`OPENROUTER_API_KEY` is set in Vercel prod + preview; activates on this deploy.

## Tests
tsc clean · eslint clean · **512 tests, 0 failures**.

## Follow-ups (not blocking)
- Precision metric over-flags same-condition papers (CIN-biomarker/epidemiology) as intruders — tighten intruder rules so aggregate numbers reflect the (already-good) top-10.
- Rare cold-first-query `n=0` transient when both lexical lanes hiccup — harden transient-empty recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEgTUohzwMogXKPsWVdwJx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new literature-search precision benchmark, with a command to run it and generate per-query plus summary reports.
  * Introduced a new primary reranking option for academic/literature search, with clearer configuration and fallback behavior.

* **Bug Fixes**
  * Improved ranking behavior so relevant guidelines are promoted more reliably, while off-topic results are less likely to surface.
  * Refined relevance scoring to better ignore generic matches and prioritize stronger signals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->