### PR TITLE
fix(search): retrieval robustness — stop dropping good lanes when a provider is down + kill stale-result race

### DIFF
--- a/src/components/explore/ExplorePageClient.tsx
+++ b/src/components/explore/ExplorePageClient.tsx
@@ -242,6 +242,12 @@ export function ExplorePageClient() {
       SEARCHABLE_TABS.map(async (tab) => [tab, await fetchSearchPage(trimmedQuery, tab, 0, filters)] as const)
     );
 
+    // A newer search superseded this one while its lanes were in flight (a slow lane
+    // or an upstream outage widens this window to many seconds). Discard these stale
+    // results instead of overwriting the current search — otherwise the older, slower
+    // search lands last and the UI shows the PREVIOUS query's results.
+    if (searchCounterRef.current !== thisSearch) return;
+
     const nextTabState = buildInitialTabState();
     let successCount = 0;
 

--- a/src/lib/search/run-search.ts
+++ b/src/lib/search/run-search.ts
@@ -153,8 +153,16 @@ function withSourceTimeout<T>(
  * Global fan-out deadline (ms). A single stuck/throttled lane must not hold the
  * whole query — at the deadline we proceed with whatever lanes have resolved
  * (partial results), marking the rest as dropped. Caps the p95 tail.
+ *
+ * Set to 8s (was 5s): the owned MedCPT dense lane is the recall backbone — when
+ * the lexical lanes are throttled or an upstream (OpenAlex) is down, the dense
+ * lane alone returns the right papers. Under prod serverless latency + event-loop
+ * contention from a slow lane, dense and PubMed were finishing just past 5s and
+ * being dropped, collapsing the pool to whatever fast junk lane survived. 8s gives
+ * the good lanes room; a lane that resolves early still returns immediately (this
+ * is a ceiling, not a floor), so it only lengthens the degraded/one-lane-down tail.
  */
-export const FANOUT_DEADLINE_MS = 5000;
+export const FANOUT_DEADLINE_MS = 8000;
 
 /**
  * Dedicated timeout (ms) for the transient-empty recovery pass — a single fresh

--- a/src/lib/search/sources/openalex.ts
+++ b/src/lib/search/sources/openalex.ts
@@ -270,7 +270,11 @@ export async function searchOpenAlex(
 
   try {
     await paceOpenAlex();
-    const res = await resilientFetch(url, {}, { service: "OpenAlex", timeout: 15000, maxRetries: 2 });
+    // Fail fast: a search lane races the fan-out deadline, so retrying a down/slow
+    // OpenAlex (2 retries × 15s ≈ 45s) only starves the other lanes' event-loop
+    // continuations without ever landing in time. One 6s attempt — if it's up it
+    // answers well under that; if it's down we drop it and lean on PubMed + dense.
+    const res = await resilientFetch(url, {}, { service: "OpenAlex", timeout: 6000, maxRetries: 0 });
     const data: OpenAlexResponse = await res.json();
     const results = (data.results || []).map(mapWork);
 


### PR DESCRIPTION
Follow-up to #113. The reranker fix was correct, but two retrieval/UX bugs made prod look broken:

## 1. Retrieval collapsed to ClinicalTrials.gov when a provider was down
Diagnosis (reproduced locally with OpenAlex 504-ing): PubMed and the owned MedCPT dense lane were finishing just past the **5s fan-out deadline** under load, so both got dropped — leaving only the fast ClinicalTrials.gov lane (trial protocols, not papers). OpenAlex's 2×15s retries were starving the other lanes' event-loop continuations.

**Fix:** raise `FANOUT_DEADLINE_MS` 5s→8s (the dense recall backbone + PubMed aren't guillotined), and make the OpenAlex search lane **fail fast** (6s, no retries). Validated with OpenAlex down: *"how is aortic stenosis related to amyloidosis?"* went from **20 ClinicalTrials protocols → 173 on-topic papers** (dense + PubMed), top-5 all AS+amyloidosis reviews/meta-analyses. Trade-off: degraded case (a provider down) is slower (~14s) but correct; normal case unaffected (returns as soon as lanes settle).

## 2. New search showed the PREVIOUS search's results
`runSearch` had a `searchCounterRef` race-guard but applied it only to the saved-URLs calls — `setTabState` ran unconditionally. A slow older search could resolve last and overwrite a newer one. **Fix:** bail after the fan-out if a newer search has started.

## Tests
tsc + eslint clean · **470 search/explore tests pass** · client race guard covered by ExplorePageClient tests.

Note: OpenAlex is currently in an external 504 outage — results improve further once it recovers; these fixes make the app degrade gracefully to PubMed + dense instead of collapsing to trial protocols.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEgTUohzwMogXKPsWVdwJx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search results now ignore outdated responses when a newer search is started, reducing flicker and stale results in the UI.
  * Some search requests now wait a bit longer before timing out, helping more sources finish and improving result completeness.
  * One search source now fails faster when it’s unavailable, which can make the app respond more quickly during slow or failing requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->