### PR TITLE
fix(search): route live academic tab through runLiteratureSearch; drop OpenAlex/S2/ClinicalTrials/arXiv; add Europe PMC + dense floor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,6 +73,18 @@ OPENALEX_API_KEY=
 # OPTIONAL — the engine works fully without it; never a hard dependency).
 SEMANTIC_SCHOLAR_API_KEY=
 
+# Elsevier / Scopus — OPTIONAL literature source. The Scopus lane is ENV-GATED:
+# with no key it stays inert (returns empty/"disabled", never throws) and is NOT
+# in the default fan-out. Set a key to enable it. Either variable name works;
+# ELSEVIER_API_KEY takes precedence. Get one at https://dev.elsevier.com/ .
+ELSEVIER_API_KEY=
+# SCOPUS_API_KEY=
+
+# Springer Nature — OPTIONAL literature source (Meta v2 API). ENV-GATED: with no
+# key the Springer lane stays inert (returns empty/"disabled", never throws) and
+# is NOT in the default fan-out. Get a free key at https://dev.springernature.com/ .
+SPRINGER_API_KEY=
+
 # PDF Storage (local dev — will be GCS in production)
 PDF_STORAGE_PATH=
 

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ cloud-sql-proxy
 .worktrees/
 qa/artifacts/
 node_modules
+.vercel
+.env*.local

--- a/docs/literature-search/PARITY-SPRINT-STATUS.md
+++ b/docs/literature-search/PARITY-SPRINT-STATUS.md
@@ -193,3 +193,22 @@ backfill → ≥90%, guideline/recency lanes → decisive win share, transient-e
 recovery → empty-set count) is **not yet re-measured** — it needs a clean,
 non-throttled 87q harness run + a fresh blinded council. That run is the next step
 to confirm the gates close and to start the 3-consecutive-cycle Stop count.
+
+## Live-resilience verification (2026-06-29)
+After wiring the owned MedCPT endpoints into `dev.env` (`MEDCPT_SEARCH_URL`,
+`MEDCPT_RERANK_URL` — non-secret public Modal URLs), an 8-query smoke through the
+**real app pipeline** (`searchPapers`) happened to land during a **total OpenAlex
+outage** (HTTP 504 on every call, all retries exhausted). Result — the engine held:
+
+- **0 empties** — 8/8 queries returned a full n=10 despite `openalex:0` across the board.
+- The **owned dense lane carried it**: `medcpt_dense:25` on 6/8 queries; the recency
+  query fired `medcpt_dense_recent:25` (cycle-3 lane activating as designed); the two
+  dense-miss queries were backfilled by the `web` lane + PubMed to n=10.
+- **PMID fill 91%** (≥90% gate held) and DOI 89% even with OpenAlex — the richest
+  metadata source — fully dark; cycle-15 NCBI PMID backfill is what kept PMID above gate.
+- recall@10 75% / best-in-top-3 75% under this worst case (vs 85%/78% with OpenAlex up).
+
+**Takeaway:** the throttle-proof owned dense lane + transient-empty recovery (cycle 11)
++ PMID backfill (cycle 15) make the engine degrade *gracefully* through a full upstream
+outage rather than cascade-to-empty. The wired owned stack is confirmed engaged in the
+real code path, not just reachable.

--- a/eval/literature-search/run.ts
+++ b/eval/literature-search/run.ts
@@ -18,6 +18,7 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { BENCHMARK_QUERIES, CATEGORY_COUNTS, type BenchmarkQuery } from "./queries";
 import { searchPapers } from "@/lib/mcp/tools";
+import type { SearchSourceId } from "@/lib/search/run-search";
 import { computeQueryMetrics, type EvalResultItem } from "@/lib/search/eval/metrics";
 import { buildSummaryMd, buildSummaryJson, type QueryRun } from "./report";
 
@@ -39,7 +40,7 @@ interface CliArgs {
   label: string;
   only?: string[];
   max: number;
-  sources?: ("pubmed" | "semantic_scholar" | "openalex")[];
+  sources?: SearchSourceId[];
 }
 
 function parseArgs(argv: string[]): CliArgs {

--- a/src/app/api/search/unified/__tests__/route.test.ts
+++ b/src/app/api/search/unified/__tests__/route.test.ts
@@ -5,18 +5,11 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // ---------------------------------------------------------------------------
 const mockGetCurrentUserId = vi.hoisted(() => vi.fn());
 const mockCheckRateLimit = vi.hoisted(() => vi.fn());
-const mockSearchPubMed = vi.hoisted(() => vi.fn());
-const mockSearchSemanticScholar = vi.hoisted(() => vi.fn());
-const mockSearchOpenAlex = vi.hoisted(() => vi.fn());
-const mockSearchClinicalTrials = vi.hoisted(() => vi.fn());
+const mockRunLiteratureSearch = vi.hoisted(() => vi.fn());
 const mockSearchSearXNG = vi.hoisted(() => vi.fn());
 const mockFederateNonAcademic = vi.hoisted(() => vi.fn());
-const mockReciprocalRankFusion = vi.hoisted(() => vi.fn());
 const mockRerankResults = vi.hoisted(() => vi.fn());
 const mockAugmentQuery = vi.hoisted(() => vi.fn());
-const mockEnrichStudyTypes = vi.hoisted(() => vi.fn());
-const mockQualityRank = vi.hoisted(() => vi.fn());
-const mockExpandQueryForDomain = vi.hoisted(() => vi.fn());
 const mockGetDomainPreferences = vi.hoisted(() => vi.fn());
 const mockGetUserScopes = vi.hoisted(() => vi.fn());
 
@@ -48,20 +41,11 @@ vi.mock("@/lib/logger", () => ({
   },
 }));
 
-vi.mock("@/lib/search/sources/pubmed", () => ({
-  searchPubMed: mockSearchPubMed,
-}));
-
-vi.mock("@/lib/search/sources/semantic-scholar", () => ({
-  searchSemanticScholar: mockSearchSemanticScholar,
-}));
-
-vi.mock("@/lib/search/sources/openalex", () => ({
-  searchOpenAlex: mockSearchOpenAlex,
-}));
-
-vi.mock("@/lib/search/sources/clinical-trials", () => ({
-  searchClinicalTrials: mockSearchClinicalTrials,
+// The academic tab delegates ALL retrieval/fusion/rerank/quality-rank to the
+// shared literature pipeline (the "good pipeline"). The route only augments the
+// query for display and layers trust/scope/sort on top.
+vi.mock("@/lib/search/run-search", () => ({
+  runLiteratureSearch: mockRunLiteratureSearch,
 }));
 
 vi.mock("@/lib/search/sources/searxng", () => ({
@@ -72,36 +56,12 @@ vi.mock("@/lib/search/web/federate", () => ({
   federateNonAcademic: mockFederateNonAcademic,
 }));
 
-vi.mock("@/lib/search/rank-fusion", () => ({
-  reciprocalRankFusion: mockReciprocalRankFusion,
-}));
-
 vi.mock("@/lib/search/rerank", () => ({
   rerankResults: mockRerankResults,
 }));
 
-vi.mock("@/lib/search/evidence-level", () => ({
-  getEvidenceLevel: vi.fn().mockReturnValue({ level: "II" }),
-}));
-
 vi.mock("@/lib/ai/query-augment", () => ({
   augmentQuery: mockAugmentQuery,
-}));
-
-vi.mock("@/lib/search/journal-quality", () => ({
-  lookupJournalQuality: vi.fn().mockReturnValue(null),
-}));
-
-vi.mock("@/lib/search/study-type-detector", () => ({
-  enrichStudyTypes: mockEnrichStudyTypes,
-}));
-
-vi.mock("@/lib/search/quality-ranker", () => ({
-  qualityRank: mockQualityRank,
-}));
-
-vi.mock("@/lib/search/query-expander", () => ({
-  expandQueryForDomain: mockExpandQueryForDomain,
 }));
 
 vi.mock("@/lib/actions/domain-preferences", () => ({
@@ -130,16 +90,37 @@ const sampleResult = {
   source: "pubmed",
 };
 
+function literatureResult(overrides: Record<string, unknown> = {}) {
+  return {
+    results: [sampleResult],
+    total: 1,
+    page: 0,
+    perPage: 20,
+    hasMore: false,
+    sourceCounts: { pubmed: 1, europepmc: 0 },
+    sourceStatuses: {
+      pubmed: { status: "ok" },
+      europepmc: { status: "ok" },
+    },
+    confidence: "high",
+    plan: {
+      pubmedQuery: "augmented pubmed",
+      recency: false,
+      trialAcronyms: [],
+      wantsTrials: false,
+    },
+    ...overrides,
+  };
+}
+
 describe("GET /api/search/unified", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetCurrentUserId.mockResolvedValue("dev_user_001");
     mockCheckRateLimit.mockResolvedValue(null);
 
-    mockSearchPubMed.mockResolvedValue({ results: [sampleResult], total: 1 });
-    mockSearchSemanticScholar.mockResolvedValue({ results: [], total: 0 });
-    mockSearchOpenAlex.mockResolvedValue({ results: [], total: 0 });
-    mockSearchClinicalTrials.mockResolvedValue({ results: [], total: 0 });
+    mockRunLiteratureSearch.mockResolvedValue(literatureResult());
+
     mockSearchSearXNG.mockResolvedValue({
       results: [
         {
@@ -179,7 +160,6 @@ describe("GET /api/search/unified", () => {
       degraded: false,
     });
 
-    mockReciprocalRankFusion.mockReturnValue([sampleResult]);
     mockRerankResults.mockImplementation((_q: string, r: unknown[]) => r);
     mockAugmentQuery.mockResolvedValue({
       pubmedQuery: "augmented pubmed",
@@ -187,16 +167,6 @@ describe("GET /api/search/unified", () => {
       openAlexQuery: "augmented oa",
     });
 
-    // New module defaults
-    mockEnrichStudyTypes.mockReturnValue(0);
-    mockQualityRank.mockImplementation(
-      (results: unknown[]) => results,
-    );
-    mockExpandQueryForDomain.mockReturnValue({
-      original: "test",
-      supplementary: null,
-      expansions: [],
-    });
     mockGetDomainPreferences.mockResolvedValue([]);
     mockGetUserScopes.mockResolvedValue([]);
   });
@@ -237,13 +207,173 @@ describe("GET /api/search/unified", () => {
     expect(res.status).toBe(401);
   });
 
-  it("keeps academic search as the default tab", async () => {
+  // ── Academic tab → the shared literature pipeline ────────────────
+
+  it("keeps academic search as the default tab and routes it through runLiteratureSearch", async () => {
     const res = await GET(makeRequest({ q: "diabetes treatment review" }));
 
     expect(res.status).toBe(200);
     expect(mockSearchSearXNG).not.toHaveBeenCalled();
-    expect(mockSearchPubMed).toHaveBeenCalled();
+    expect(mockFederateNonAcademic).not.toHaveBeenCalled();
+    expect(mockRunLiteratureSearch).toHaveBeenCalledTimes(1);
   });
+
+  it("maps academic search params onto the runLiteratureSearch call", async () => {
+    const res = await GET(
+      makeRequest({
+        q: "SGLT2 inhibitors heart failure outcomes",
+        yearStart: "2018",
+        yearEnd: "2024",
+        studyTypes: "rct,meta_analysis",
+        openAccessOnly: "true",
+        page: "0",
+        perPage: "20",
+      })
+    );
+
+    expect(res.status).toBe(200);
+    // The augmented PubMed query (display + planner override) is threaded in as
+    // pubmedQuery; year/study-type/full-text/paging map straight through.
+    expect(mockRunLiteratureSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: "SGLT2 inhibitors heart failure outcomes",
+        pubmedQuery: "augmented pubmed",
+        yearFrom: 2018,
+        yearTo: 2024,
+        studyTypes: ["rct", "meta_analysis"],
+        fullTextOnly: true,
+        page: 0,
+        perPage: 20,
+      })
+    );
+  });
+
+  it("maps the pipeline result into the academic search response", async () => {
+    mockRunLiteratureSearch.mockResolvedValueOnce(
+      literatureResult({
+        results: [
+          { title: "Paper A", sources: ["pubmed"], year: 2023 },
+          { title: "Paper B", sources: ["europepmc"], year: 2022 },
+        ],
+        total: 42,
+        hasMore: true,
+        sourceCounts: { pubmed: 30, europepmc: 12 },
+        sourceStatuses: {
+          pubmed: { status: "ok" },
+          europepmc: { status: "rate_limited", message: "throttled" },
+        },
+      })
+    );
+
+    const res = await GET(makeRequest({ q: "heart failure outcomes trial" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.results.map((r: { title: string }) => r.title)).toEqual([
+      "Paper A",
+      "Paper B",
+    ]);
+    expect(body.total).toBe(42);
+    expect(body.sourceCounts).toEqual({ pubmed: 30, europepmc: 12 });
+    expect(body.sourceStatuses.europepmc.status).toBe("rate_limited");
+    expect(body.searxngUnavailable).toBe(false);
+    // hasMore is recomputed from total vs (page + 1) * perPage: 42 > 20 → true.
+    expect(body.hasMore).toBe(true);
+    // Augmentation is still surfaced for the "we searched for…" display chips.
+    expect(body.augmentedQueries.pubmed).toBe("augmented pubmed");
+  });
+
+  it("passes the pipeline's per-source health through unchanged", async () => {
+    mockRunLiteratureSearch.mockResolvedValueOnce(
+      literatureResult({
+        sourceStatuses: {
+          pubmed: { status: "ok" },
+          europepmc: { status: "timeout", message: "dropped: fan-out exceeded" },
+        },
+      })
+    );
+
+    const res = await GET(makeRequest({ q: "diabetes treatment review" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.sourceStatuses.pubmed).toEqual({ status: "ok" });
+    expect(body.sourceStatuses.europepmc.status).toBe("timeout");
+  });
+
+  it("applies scope domain filter on academic results", async () => {
+    mockGetUserScopes.mockResolvedValueOnce([
+      {
+        id: 42,
+        name: "Gov Only",
+        includedDomains: ["nih.gov"],
+        excludedDomains: [],
+        includedKeywords: [],
+        excludedKeywords: [],
+        dateFrom: null,
+        dateTo: null,
+        region: null,
+        isActive: true,
+        sortOrder: 0,
+        createdAt: null,
+        updatedAt: null,
+      },
+    ]);
+
+    mockRunLiteratureSearch.mockResolvedValueOnce(
+      literatureResult({
+        results: [
+          { title: "NIH paper", domain: "nih.gov", sources: ["pubmed"] },
+          { title: "Harvard paper", domain: "harvard.edu", sources: ["europepmc"] },
+        ],
+        total: 2,
+        sourceCounts: { pubmed: 1, europepmc: 1 },
+      })
+    );
+
+    const res = await GET(makeRequest({ q: "heart disease", scopeId: "42" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // Only the NIH result should survive the scope filter.
+    expect(body.results).toHaveLength(1);
+    expect(body.results[0].title).toBe("NIH paper");
+  });
+
+  it("sorts by trust tier when sort=trust", async () => {
+    mockRunLiteratureSearch.mockResolvedValueOnce(
+      literatureResult({
+        results: [
+          { title: "Community post", domain: "reddit.com", trustTier: "community", sources: ["europepmc"] },
+          { title: "Government report", domain: "nih.gov", trustTier: "government", sources: ["pubmed"] },
+          { title: "News article", domain: "reuters.com", trustTier: "major_journalism", sources: ["europepmc"] },
+        ],
+        total: 3,
+      })
+    );
+
+    const res = await GET(makeRequest({ q: "climate change", sort: "trust" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.results[0].title).toBe("Government report");
+    expect(body.results[1].title).toBe("News article");
+    expect(body.results[2].title).toBe("Community post");
+  });
+
+  it("serves the academic tab even when augmentation is disabled (no pubmedQuery override)", async () => {
+    const res = await GET(
+      makeRequest({ q: "diabetes treatment review", augment: "false" })
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockAugmentQuery).not.toHaveBeenCalled();
+    expect(mockRunLiteratureSearch).toHaveBeenCalledWith(
+      expect.objectContaining({ pubmedQuery: undefined })
+    );
+    const body = await res.json();
+    expect(body.augmentedQueries).toBeUndefined();
+  });
+
+  // ── Non-academic tabs (federation) ───────────────────────────────
 
   it("routes the web tab through the multi-source federation, not SearXNG directly", async () => {
     const res = await GET(makeRequest({ q: "climate change", tab: "web" }));
@@ -256,7 +386,8 @@ describe("GET /api/search/unified", () => {
       expect.objectContaining({ limit: 100 })
     );
     expect(mockSearchSearXNG).not.toHaveBeenCalled();
-    expect(mockSearchPubMed).not.toHaveBeenCalled();
+    // The web tab must never fall into the academic literature pipeline.
+    expect(mockRunLiteratureSearch).not.toHaveBeenCalled();
     expect(body.results).toHaveLength(1);
     expect(body.sourceCounts).toEqual({ web: 1 });
     expect(body.searxngUnavailable).toBe(false);
@@ -552,93 +683,7 @@ describe("GET /api/search/unified", () => {
     expect(body.hasMore).toBe(true);
   });
 
-  // ── Slice 1: enrichStudyTypes() ──────────────────────────────────
-
-  it("calls enrichStudyTypes on fused results before evidence assignment", async () => {
-    const res = await GET(makeRequest({ q: "diabetes treatment review" }));
-    expect(res.status).toBe(200);
-    expect(mockEnrichStudyTypes).toHaveBeenCalledTimes(1);
-    // Should be called with the fused results array
-    expect(mockEnrichStudyTypes).toHaveBeenCalledWith(expect.any(Array));
-  });
-
-  it("degrades gracefully when enrichStudyTypes throws", async () => {
-    mockEnrichStudyTypes.mockImplementation(() => {
-      throw new Error("detector crash");
-    });
-    const res = await GET(makeRequest({ q: "diabetes treatment review" }));
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.results).toBeDefined();
-  });
-
-  // ── Slice 2: qualityRank() ───────────────────────────────────────
-
-  it("calls qualityRank with fused results and query string", async () => {
-    const query = "diabetes treatment review";
-    const res = await GET(makeRequest({ q: query }));
-    expect(res.status).toBe(200);
-    expect(mockQualityRank).toHaveBeenCalledTimes(1);
-    expect(mockQualityRank).toHaveBeenCalledWith(expect.any(Array), query);
-  });
-
-  it("degrades gracefully when qualityRank throws", async () => {
-    mockQualityRank.mockImplementation(() => {
-      throw new Error("ranker crash");
-    });
-    const res = await GET(makeRequest({ q: "diabetes treatment review" }));
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.results).toBeDefined();
-  });
-
-  // ── Slice 3: expandQueryForDomain() ──────────────────────────────
-
-  it("calls expandQueryForDomain with query and domain config", async () => {
-    const res = await GET(makeRequest({ q: "SGLT2 inhibitors heart failure" }));
-    expect(res.status).toBe(200);
-    expect(mockExpandQueryForDomain).toHaveBeenCalledTimes(1);
-    expect(mockExpandQueryForDomain).toHaveBeenCalledWith(
-      "SGLT2 inhibitors heart failure",
-      expect.objectContaining({ sources: expect.any(Array) }),
-    );
-  });
-
-  it("fires supplementary PubMed search when expansion returns supplementary query", async () => {
-    mockExpandQueryForDomain.mockReturnValue({
-      original: "SGLT2 inhibitors heart failure",
-      supplementary: "(empagliflozin OR dapagliflozin) AND (sglt2 heart failure)",
-      expansions: [{ term: "SGLT2 inhibitors", synonyms: ["empagliflozin", "dapagliflozin"] }],
-    });
-    const res = await GET(makeRequest({ q: "SGLT2 inhibitors heart failure" }));
-    expect(res.status).toBe(200);
-    // PubMed should have been called twice: once for original, once for supplementary
-    expect(mockSearchPubMed).toHaveBeenCalledTimes(2);
-  });
-
-  it("does not fire supplementary search when expansion returns null", async () => {
-    mockExpandQueryForDomain.mockReturnValue({
-      original: "test query",
-      supplementary: null,
-      expansions: [],
-    });
-    const res = await GET(makeRequest({ q: "some generic query without drugs" }));
-    expect(res.status).toBe(200);
-    // PubMed should only be called once (original query)
-    expect(mockSearchPubMed).toHaveBeenCalledTimes(1);
-  });
-
-  it("degrades gracefully when expandQueryForDomain throws", async () => {
-    mockExpandQueryForDomain.mockImplementation(() => {
-      throw new Error("expander crash");
-    });
-    const res = await GET(makeRequest({ q: "diabetes treatment review" }));
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.results).toBeDefined();
-  });
-
-  // ── Phase 4: Filter pills + Scope constraints ────────────────────
+  // ── Filter pills + Scope constraints ─────────────────────────────
 
   it("passes timeRange to the federation for non-academic tabs", async () => {
     const res = await GET(
@@ -676,57 +721,6 @@ describe("GET /api/search/unified", () => {
     expect(mockGetDomainPreferences).not.toHaveBeenCalled();
   });
 
-  it("applies scope domain filter on academic results", async () => {
-    mockGetUserScopes.mockResolvedValueOnce([
-      {
-        id: 42,
-        name: "Gov Only",
-        includedDomains: ["nih.gov"],
-        excludedDomains: [],
-        includedKeywords: [],
-        excludedKeywords: [],
-        dateFrom: null,
-        dateTo: null,
-        region: null,
-        isActive: true,
-        sortOrder: 0,
-        createdAt: null,
-        updatedAt: null,
-      },
-    ]);
-
-    mockReciprocalRankFusion.mockReturnValueOnce([
-      { title: "NIH paper", domain: "nih.gov", sources: ["pubmed"] },
-      { title: "Harvard paper", domain: "harvard.edu", sources: ["openalex"] },
-    ]);
-
-    const res = await GET(
-      makeRequest({ q: "heart disease", scopeId: "42" })
-    );
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    // Only the NIH result should survive the scope filter
-    expect(body.results).toHaveLength(1);
-    expect(body.results[0].title).toBe("NIH paper");
-  });
-
-  it("sorts by trust tier when sort=trust", async () => {
-    mockReciprocalRankFusion.mockReturnValueOnce([
-      { title: "Community post", domain: "reddit.com", trustTier: "community", sources: ["openalex"] },
-      { title: "Government report", domain: "nih.gov", trustTier: "government", sources: ["pubmed"] },
-      { title: "News article", domain: "reuters.com", trustTier: "major_journalism", sources: ["openalex"] },
-    ]);
-
-    const res = await GET(
-      makeRequest({ q: "climate change", sort: "trust" })
-    );
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.results[0].title).toBe("Government report");
-    expect(body.results[1].title).toBe("News article");
-    expect(body.results[2].title).toBe("Community post");
-  });
-
   it("rejects invalid timeRange values", async () => {
     const res = await GET(
       makeRequest({ q: "test", tab: "web", timeRange: "invalid" })
@@ -734,79 +728,6 @@ describe("GET /api/search/unified", () => {
     expect(res.status).toBe(400);
     const body = await res.json();
     expect(body.error).toMatch(/timeRange/i);
-  });
-
-  // ── Source status surfacing ──────────────────────────────────────
-
-  it("reports a source that returns results as ok", async () => {
-    const res = await GET(makeRequest({ q: "diabetes treatment review" }));
-    const body = await res.json();
-    expect(res.status).toBe(200);
-    expect(body.sourceStatuses.pubmed).toEqual({ status: "ok" });
-  });
-
-  it("surfaces a rejected (timed-out) source as degraded, not a normal zero", async () => {
-    mockSearchOpenAlex.mockRejectedValueOnce(
-      new Error("OpenAlex timed out after 12000ms")
-    );
-    const res = await GET(makeRequest({ q: "diabetes treatment review" }));
-    const body = await res.json();
-    expect(res.status).toBe(200);
-    expect(body.sourceCounts.openalex).toBe(0);
-    expect(body.sourceStatuses.openalex.status).toBe("timeout");
-  });
-
-  it("surfaces an adapter-reported rate limit instead of zero results", async () => {
-    mockSearchSemanticScholar.mockResolvedValueOnce({
-      results: [],
-      total: 0,
-      status: { status: "rate_limited", message: "Rate limited" },
-    });
-    const res = await GET(makeRequest({ q: "diabetes treatment review" }));
-    const body = await res.json();
-    expect(res.status).toBe(200);
-    expect(body.sourceStatuses.semantic_scholar.status).toBe("rate_limited");
-  });
-
-  it("marks a genuine empty source as ok (true zero)", async () => {
-    mockSearchSemanticScholar.mockResolvedValueOnce({
-      results: [],
-      total: 0,
-      status: { status: "ok" },
-    });
-    const res = await GET(makeRequest({ q: "diabetes treatment review" }));
-    const body = await res.json();
-    expect(body.sourceStatuses.semantic_scholar).toEqual({ status: "ok" });
-  });
-
-  it("retries PubMed with the raw query when the augmented query returns zero", async () => {
-    mockAugmentQuery.mockResolvedValueOnce({
-      pubmedQuery: "over-constrained MeSH query",
-      semanticScholarQuery: "s2",
-      openAlexQuery: "oa",
-    });
-    // First PubMed call (augmented) returns empty; raw fallback returns a hit.
-    mockSearchPubMed
-      .mockResolvedValueOnce({ results: [], total: 0, status: { status: "ok" } })
-      .mockResolvedValueOnce({
-        results: [sampleResult],
-        total: 1,
-        status: { status: "ok" },
-      });
-    mockReciprocalRankFusion.mockReturnValueOnce([sampleResult]);
-
-    const res = await GET(
-      makeRequest({ q: "transcatheter aortic valve six year outcomes" })
-    );
-    const body = await res.json();
-    expect(res.status).toBe(200);
-    // augmented call + raw fallback call
-    expect(mockSearchPubMed).toHaveBeenCalledWith(
-      "transcatheter aortic valve six year outcomes",
-      expect.objectContaining({ page: 0 })
-    );
-    expect(body.sourceCounts.pubmed).toBe(1);
-    expect(body.sourceStatuses.pubmed.status).toBe("ok");
   });
 
   it("strips double quotes from query when exactMatch is true", async () => {

--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -1,57 +1,28 @@
 import { NextResponse } from "next/server";
 import type { SearchResponse } from "@/types/search";
-import { searchPubMed } from "@/lib/search/sources/pubmed";
-import { searchSemanticScholar } from "@/lib/search/sources/semantic-scholar";
-import { searchOpenAlex } from "@/lib/search/sources/openalex";
-import { searchClinicalTrials } from "@/lib/search/sources/clinical-trials";
-import { searchArxiv } from "@/lib/search/sources/arxiv";
+import { runLiteratureSearch } from "@/lib/search/run-search";
 import { federateNonAcademic } from "@/lib/search/web/federate";
 import { searchYouTube } from "@/lib/search/sources/youtube";
-import { reciprocalRankFusion } from "@/lib/search/rank-fusion";
 import { rerankResults } from "@/lib/search/rerank";
 import { diversifyForTab } from "@/lib/search/diversity";
-import { getDomainEvidenceLevel } from "@/lib/search/evidence-level";
 import { getDomainConfig } from "@/lib/search/domains";
 import { augmentQuery } from "@/lib/ai/query-augment";
 import { getCurrentUserId } from "@/lib/auth";
 import { checkRateLimit, RATE_LIMITS } from "@/lib/rate-limit";
 import { logger } from "@/lib/logger";
-import { lookupJournalQuality } from "@/lib/search/journal-quality";
 import { getDevelopmentFallbackResults } from "@/lib/search/dev-fallback";
 import { getCurrentUserDomainConfig } from "@/lib/search/domains/user-domain";
-import { enrichStudyTypes } from "@/lib/search/study-type-detector";
-import { qualityRank } from "@/lib/search/quality-ranker";
-import { expandQueryForDomain } from "@/lib/search/query-expander";
 import { getDomainPreferences } from "@/lib/actions/domain-preferences";
 import { getUserScopes, type ScopeRecord } from "@/lib/actions/scopes";
 import { getTrustTier } from "@/lib/search/trust-tier";
 import { normalizeDomain } from "@/lib/search/domain-utils";
-import type { SourceId } from "@/lib/search/domains";
 import type { UnifiedSearchResult } from "@/types/search";
-import {
-  classifyRejectionReason,
-  moreSevereStatus,
-  okStatus,
-  type SourceStatus,
-} from "@/lib/search/source-status";
-
-type SourceSearchResponse = {
-  results: UnifiedSearchResult[];
-  total: number;
-  status?: SourceStatus;
-};
 
 type ResultDomainPreferenceLevel = NonNullable<
   UnifiedSearchResult["domainPreferenceLevel"]
 >;
 
 type SearchTab = "academic" | "web" | "news" | "discussions" | "videos";
-
-type SourceDefinition = {
-  sourceId: SourceId;
-  label: string;
-  run: () => Promise<SourceSearchResponse>;
-};
 
 const DOMAIN_PREFERENCE_WEIGHT: Record<ResultDomainPreferenceLevel, number> = {
   mute: -99,
@@ -62,16 +33,6 @@ const DOMAIN_PREFERENCE_WEIGHT: Record<ResultDomainPreferenceLevel, number> = {
 };
 const MAX_NON_ACADEMIC_RESULTS = 100;
 
-/**
- * Per-source ceiling for the academic fan-out. Each source is fetched in
- * parallel, so this is the worst-case wall-clock the slowest source can add.
- * Measured round-trips: PubMed runs two sequential calls (esearch + efetch)
- * that routinely total ~5s, and OpenAlex ~3.5s. The previous 4500ms cap
- * silently killed PubMed before efetch returned, surfacing healthy sources as
- * zero-result. 12s gives real upstreams headroom while still bounding latency.
- */
-const SOURCE_TIMEOUT_MS = 12000;
-
 function isSearchTab(tab: string): tab is SearchTab {
   return (
     tab === "academic" ||
@@ -80,27 +41,6 @@ function isSearchTab(tab: string): tab is SearchTab {
     tab === "discussions" ||
     tab === "videos"
   );
-}
-
-async function withSourceTimeout<T>(
-  label: string,
-  promise: Promise<T>,
-  timeoutMs = SOURCE_TIMEOUT_MS
-): Promise<T> {
-  let timeoutId: ReturnType<typeof setTimeout> | null = null;
-
-  try {
-    return await Promise.race([
-      promise,
-      new Promise<T>((_, reject) => {
-        timeoutId = setTimeout(() => {
-          reject(new Error(`${label} timed out after ${timeoutMs}ms`));
-        }, timeoutMs);
-      }),
-    ]);
-  } finally {
-    if (timeoutId) clearTimeout(timeoutId);
-  }
 }
 
 function addTrustTier(result: UnifiedSearchResult): UnifiedSearchResult {
@@ -415,334 +355,88 @@ export async function GET(req: Request) {
       ? getDomainConfig(requestedDomainId)
       : await getCurrentUserDomainConfig(userId);
 
-    // Step 1: Query augmentation (if enabled and query is long enough)
-    let pubmedQuery = q;
-    let s2Query = q;
-    let oaQuery = q;
+    // Step 1: Query augmentation (if enabled and query is long enough). Retained
+    // for display (the "we searched for…" chips) and to hand the shared pipeline
+    // an optimized PubMed query; the pipeline owns retrieval, fusion, and ranking.
     let augmentedQueries: SearchResponse["augmentedQueries"] | undefined;
 
     if (augment && q.length > 20) {
       try {
         const augmented = await augmentQuery(q, domain);
-        pubmedQuery = augmented.pubmedQuery;
-        s2Query = augmented.semanticScholarQuery;
-        oaQuery = augmented.openAlexQuery;
         augmentedQueries = {
-          pubmed: pubmedQuery,
-          semanticScholar: s2Query,
-          openAlex: oaQuery,
+          pubmed: augmented.pubmedQuery,
+          semanticScholar: augmented.semanticScholarQuery,
+          openAlex: augmented.openAlexQuery,
         };
       } catch {
         // Fall back to raw query if augmentation fails
       }
     }
 
-    // Step 1b: Regex-based synonym expansion (supplementary PubMed search)
-    let supplementaryPubmedQuery: string | null = null;
-    try {
-      const expansion = expandQueryForDomain(q, domain);
-      supplementaryPubmedQuery = expansion.supplementary;
-    } catch {
-      log.warn("Query expansion failed, continuing without synonyms");
-    }
-
-    // Step 2: Fan out to all sources in parallel
-    // Fetch enough results from each source to fill the requested page.
-    // We need (page+1)*perPage results after fusion to serve the slice,
-    // so ask each source for that many (capped at 100 for API limits).
-    const neededPerSource = Math.min((page + 1) * perPage, 100);
-    const sourceDefinitions: SourceDefinition[] = [];
-
-    if (domain.sources.includes("pubmed")) {
-      sourceDefinitions.push({
-        sourceId: "pubmed",
-        label: "PubMed",
-        run: () =>
-          searchPubMed(pubmedQuery, {
-            maxResults: neededPerSource,
-            page: 0,
-            yearStart,
-            yearEnd,
-          }),
-      });
-    }
-
-    if (supplementaryPubmedQuery && domain.sources.includes("pubmed")) {
-      const expandedQuery = supplementaryPubmedQuery;
-      sourceDefinitions.push({
-        sourceId: "pubmed" as SourceId,
-        label: "PubMed (expanded)",
-        run: () =>
-          searchPubMed(expandedQuery, {
-            maxResults: neededPerSource,
-            page: 0,
-            yearStart,
-            yearEnd,
-          }),
-      });
-    }
-
-    if (domain.sources.includes("semantic_scholar")) {
-      sourceDefinitions.push({
-        sourceId: "semantic_scholar",
-        label: "Semantic Scholar",
-        run: () =>
-          searchSemanticScholar(s2Query, {
-            limit: neededPerSource,
-            offset: 0,
-            yearStart,
-            yearEnd,
-          }),
-      });
-    }
-
-    if (domain.sources.includes("openalex")) {
-      sourceDefinitions.push({
-        sourceId: "openalex",
-        label: "OpenAlex",
-        run: () =>
-          searchOpenAlex(oaQuery, {
-            limit: neededPerSource,
-            page: 1,
-            yearStart,
-            yearEnd,
-            onlyOpenAccess: openAccessOnly,
-          }),
-      });
-    }
-
-    if (
-      domain.features.clinicalTrialsSearch &&
-      domain.sources.includes("clinical_trials")
-    ) {
-      sourceDefinitions.push({
-        sourceId: "clinical_trials",
-        label: "ClinicalTrials.gov",
-        run: () =>
-          searchClinicalTrials(q, {
-            limit: perPage,
-            yearStart,
-            yearEnd,
-          }),
-      });
-    }
-
-    if (domain.sources.includes("arxiv")) {
-      sourceDefinitions.push({
-        sourceId: "arxiv",
-        label: "arXiv",
-        run: () =>
-          searchArxiv(q, {
-            maxResults: neededPerSource,
-            start: 0,
-            yearStart,
-            yearEnd,
-          }),
-      });
-    }
-
-    const sourceResults = await Promise.allSettled(
-      sourceDefinitions.map((source) =>
-        withSourceTimeout(source.label, source.run())
-      )
-    );
-
-    const resultsBySource: Partial<Record<SourceId, UnifiedSearchResult[]>> = {};
-    const perDefinitionStatus: Array<{ sourceId: SourceId; status: SourceStatus }> = [];
-
-    sourceDefinitions.forEach((source, index) => {
-      const result = sourceResults[index];
-      if (result.status === "fulfilled") {
-        resultsBySource[source.sourceId] = result.value.results;
-        perDefinitionStatus.push({
-          sourceId: source.sourceId,
-          status: result.value.status ?? okStatus(),
-        });
-        return;
-      }
-
-      resultsBySource[source.sourceId] = [];
-      perDefinitionStatus.push({
-        sourceId: source.sourceId,
-        status: classifyRejectionReason(result.reason),
-      });
-      log.warn(`${source.label} search degraded`, {
-        query: q,
-        error: String(result.reason),
-      });
+    // Step 2: Delegate to the shared literature pipeline — the single source of
+    // truth for academic search. It fans out to the owned MedCPT dense lane plus
+    // PubMed and Europe PMC, RRF-fuses, cross-encoder reranks, enriches study
+    // types / evidence / journal quality, and quality-ranks internally, then
+    // applies the study-type and full-text filters. This replaces the route's
+    // former manual fan-out to PubMed/S2/OpenAlex/ClinicalTrials/arXiv.
+    const literature = await runLiteratureSearch({
+      query: q,
+      pubmedQuery: augmentedQueries?.pubmed,
+      yearFrom: yearStart,
+      yearTo: yearEnd,
+      studyTypes,
+      fullTextOnly: openAccessOnly,
+      page,
+      perPage,
     });
 
-    // PubMed raw-query fallback: when augmentation rewrote the PubMed query and
-    // that rewrite returned a *genuine* zero (status ok, not a timeout/error),
-    // retry once with the user's raw query. An over-constrained MeSH rewrite is
-    // the most common cause of an empty PubMed set even though the plain query
-    // matches papers.
-    const pubmedRewritten =
-      !!augmentedQueries?.pubmed && augmentedQueries.pubmed !== q;
-    const pubmedReturnedEmpty = (resultsBySource["pubmed"] ?? []).length === 0;
-    const pubmedHealthy = perDefinitionStatus
-      .filter((entry) => entry.sourceId === "pubmed")
-      .every((entry) => entry.status.status === "ok");
-    if (
-      domain.sources.includes("pubmed") &&
-      pubmedRewritten &&
-      pubmedReturnedEmpty &&
-      pubmedHealthy
-    ) {
-      try {
-        const rawPubmed = await withSourceTimeout(
-          "PubMed (raw fallback)",
-          searchPubMed(q, {
-            maxResults: neededPerSource,
-            page: 0,
-            yearStart,
-            yearEnd,
-          })
-        );
-        if (rawPubmed.results.length > 0) {
-          resultsBySource["pubmed"] = rawPubmed.results;
-          perDefinitionStatus.push({
-            sourceId: "pubmed",
-            status: rawPubmed.status ?? okStatus(),
-          });
-          log.info("PubMed raw-query fallback recovered results", { query: q });
-        }
-      } catch (error) {
-        log.warn("PubMed raw fallback failed", { error: String(error) });
-      }
-    }
+    let pool: UnifiedSearchResult[] = literature.results;
+    let sourceCounts: Record<string, number> = literature.sourceCounts;
+    let total = literature.total;
 
-    if (
-      sourceDefinitions.length > 0 &&
-      sourceDefinitions.every(
-        (source) => (resultsBySource[source.sourceId] ?? []).length === 0
-      )
-    ) {
-      const fallback = await getDevelopmentFallbackResults(q, neededPerSource);
+    // Dev-only safety net: when every live upstream is unreachable (local dev
+    // without network), serve cached fixtures so the UI still renders results.
+    if (pool.length === 0) {
+      const fallback = await getDevelopmentFallbackResults(q, perPage);
       if (fallback) {
-        const fallbackBySource: Partial<Record<SourceId, UnifiedSearchResult[]>> = {
-          pubmed: fallback.pubmedResults,
-          semantic_scholar: fallback.semanticScholarResults,
-          openalex: fallback.openAlexResults,
-          clinical_trials: fallback.clinicalTrialsResults,
+        pool = [
+          ...fallback.pubmedResults,
+          ...fallback.semanticScholarResults,
+          ...fallback.openAlexResults,
+          ...fallback.clinicalTrialsResults,
+        ];
+        sourceCounts = {
+          pubmed: fallback.pubmedResults.length,
+          semantic_scholar: fallback.semanticScholarResults.length,
+          openalex: fallback.openAlexResults.length,
+          clinical_trials: fallback.clinicalTrialsResults.length,
         };
-
-        sourceDefinitions.forEach((source) => {
-          if (fallbackBySource[source.sourceId]) {
-            resultsBySource[source.sourceId] = fallbackBySource[source.sourceId];
-          }
-        });
-
+        total = pool.length;
         log.info("Unified search served development fallback results", {
           query: q,
         });
       }
     }
 
-    const sourceCounts = Object.fromEntries(
-      sourceDefinitions.map((source) => [
-        source.sourceId,
-        (resultsBySource[source.sourceId] ?? []).length,
-      ])
-    );
+    // Post-steps: the pipeline already filtered by study type / full text and
+    // returned the requested page ranked by quality. The route only layers its
+    // own concerns on top — trust tiers, scope constraints, and explicit sort.
+    let results = pool.map(addTrustTier);
 
-    // Per-source status: a source with results is "ok"; a source with zero
-    // results inherits the most severe status across its runs, so a timeout or
-    // rate-limit is never reported as a normal zero-result source.
-    const uniqueSourceIds = [
-      ...new Set(sourceDefinitions.map((source) => source.sourceId)),
-    ];
-    const sourceStatuses: Record<string, SourceStatus> = Object.fromEntries(
-      uniqueSourceIds.map((sourceId) => {
-        if ((resultsBySource[sourceId] ?? []).length > 0) {
-          return [sourceId, okStatus()];
-        }
-        const merged = perDefinitionStatus
-          .filter((entry) => entry.sourceId === sourceId)
-          .reduce<SourceStatus>(
-            (acc, entry) => moreSevereStatus(acc, entry.status),
-            okStatus()
-          );
-        return [sourceId, merged];
-      })
-    );
-
-    // Step 3: RRF fusion
-    let fused = reciprocalRankFusion(
-      sourceDefinitions.map((source) => ({
-        source: source.sourceId,
-        results: resultsBySource[source.sourceId] ?? [],
-      }))
-    );
-
-    // Step 4: Rerank (if Cohere key available)
-    fused = await rerankResults(q, fused);
-
-    // Step 4b: Detect study types from title/abstract text
-    try {
-      enrichStudyTypes(fused);
-    } catch {
-      log.warn("Study type enrichment failed, continuing");
-    }
-
-    // Step 5: Apply evidence levels
-    fused = fused.map((result) => {
-      if (result.studyType && !result.evidenceLevel) {
-        const evidence = getDomainEvidenceLevel(result.studyType, domain);
-        return { ...result, evidenceLevel: evidence.level };
-      }
-      return result;
-    });
-
-    // Step 5b: Enrich with journal quality indicators
-    fused = fused.map((result) => {
-      if (result.journal) {
-        const quality = lookupJournalQuality(result.journal);
-        if (quality) {
-          return {
-            ...result,
-            journalQuartile: quality.quartile,
-            journalImpactProxy: quality.citesPerDoc2y,
-          };
-        }
-      }
-      return result;
-    });
-
-    // Step 5c: Quality-weighted composite ranking
-    try {
-      fused = qualityRank(fused, q);
-    } catch {
-      log.warn("Quality ranking failed, continuing with rerank order");
-    }
-
-    // Step 6: Apply study type filter
-    let filtered = fused;
-    if (studyTypes && studyTypes.length > 0) {
-      filtered = filtered.filter(
-        (r) => r.studyType && studyTypes.includes(r.studyType)
-      );
-    }
-
-    // Step 7: Apply open access filter (if not already applied at source level)
-    if (openAccessOnly) {
-      filtered = filtered.filter((r) => r.isOpenAccess);
-    }
-
-    // Step 7b: Apply scope constraints
+    // Scope constraints (custom included/excluded domains + keywords).
     if (scopeId && scopeId > 0) {
       const allScopes = await getUserScopes();
       const scope = allScopes.find((s) => s.id === scopeId);
       if (scope) {
-        filtered = applyScopeFilter(filtered, scope);
+        results = applyScopeFilter(results, scope);
       }
     }
 
-    // Step 8: Sort
+    // Sort. "relevance" keeps the pipeline's quality-ranked order (default).
     if (sort === "citations") {
-      filtered.sort((a, b) => (b.citationCount || 0) - (a.citationCount || 0));
+      results.sort((a, b) => (b.citationCount || 0) - (a.citationCount || 0));
     } else if (sort === "year") {
-      filtered.sort((a, b) => (b.year || 0) - (a.year || 0));
+      results.sort((a, b) => (b.year || 0) - (a.year || 0));
     } else if (sort === "evidence") {
       const levelOrder: Record<string, number> = {
         I: 1,
@@ -751,15 +445,14 @@ export async function GET(req: Request) {
         IV: 4,
         V: 5,
       };
-      filtered.sort(
+      results.sort(
         (a, b) =>
           (levelOrder[a.evidenceLevel || "V"] || 5) -
           (levelOrder[b.evidenceLevel || "V"] || 5)
       );
     } else if (sort === "impact") {
-      filtered.sort(
-        (a, b) =>
-          (b.journalImpactProxy ?? -1) - (a.journalImpactProxy ?? -1),
+      results.sort(
+        (a, b) => (b.journalImpactProxy ?? -1) - (a.journalImpactProxy ?? -1),
       );
     } else if (sort === "trust") {
       const trustOrder: Record<string, number> = {
@@ -768,28 +461,24 @@ export async function GET(req: Request) {
         community: 2,
         other: 3,
       };
-      filtered.sort(
+      results.sort(
         (a, b) =>
           (trustOrder[a.trustTier ?? "other"] ?? 3) -
           (trustOrder[b.trustTier ?? "other"] ?? 3)
       );
     }
-    // "relevance" keeps RRF/rerank order (default)
 
-    // Step 9: Pagination
-    const total = filtered.length;
-    const start = page * perPage;
-    const paged = filtered.slice(start, start + perPage);
-    const hasMore = start + perPage < total;
+    const hasMore = total > (page + 1) * perPage;
 
     const response: SearchResponse = {
-      results: paged.map(addTrustTier),
+      results,
       total,
       page,
       perPage,
       hasMore,
       sourceCounts,
-      sourceStatuses,
+      sourceStatuses: literature.sourceStatuses,
+      searxngUnavailable: false,
       augmentedQueries,
     };
 

--- a/src/components/research/FilterPanel.tsx
+++ b/src/components/research/FilterPanel.tsx
@@ -24,6 +24,7 @@ const DEFAULT_SOURCES: ResearchSearchFilters["sources"] = ["pubmed", "semantic_s
 
 const SOURCE_LABELS: Record<string, string> = {
   pubmed: "PubMed",
+  europepmc: "Europe PMC",
   semantic_scholar: "Semantic Scholar",
   openalex: "OpenAlex",
   clinical_trials: "ClinicalTrials.gov",

--- a/src/lib/mcp/__tests__/tools.test.ts
+++ b/src/lib/mcp/__tests__/tools.test.ts
@@ -59,8 +59,8 @@ describe("search_papers tool", () => {
       page: 0,
       perPage: 10,
       hasMore: false,
-      sourceCounts: { pubmed: 1, openalex: 1 },
-      sourceStatuses: { pubmed: { status: "ok" }, openalex: { status: "ok" } },
+      sourceCounts: { pubmed: 1, europepmc: 1 },
+      sourceStatuses: { pubmed: { status: "ok" }, europepmc: { status: "ok" } },
       confidence: "ok",
       plan: { pubmedQuery: "TAVR low risk", recency: false, trialAcronyms: [], wantsTrials: false },
     });
@@ -100,12 +100,12 @@ describe("search_papers tool", () => {
   it("forwards sources and year filters to the search backend", async () => {
     await searchPapers({
       query: "x",
-      sources: ["openalex"],
+      sources: ["europepmc"],
       yearFrom: 2020,
       yearTo: 2026,
     });
     expect(mockedRun).toHaveBeenCalledWith(
-      expect.objectContaining({ sources: ["openalex"], yearFrom: 2020, yearTo: 2026 })
+      expect.objectContaining({ sources: ["europepmc"], yearFrom: 2020, yearTo: 2026 })
     );
   });
 });
@@ -161,17 +161,15 @@ describe("get_search_capabilities tool", () => {
     const caps = getSearchCapabilities();
     expect(caps.sources.map((s) => s.id)).toEqual([
       "pubmed",
-      "semantic_scholar",
-      "openalex",
+      "europepmc",
     ]);
     expect(caps.limits.maxResults).toBe(50);
     expect(caps.outputFields).toContain("doi");
     expect(caps.outputFields).toContain("evidenceLevel");
     expect(caps.outputFields).toContain("whyRelevant");
-    // Default sources are PubMed + OpenAlex — Semantic Scholar is opt-in only
-    // (the system must work without it).
+    // Both active literature sources (PubMed + Europe PMC) are on by default.
     const defaults = caps.sources.filter((s) => s.default).map((s) => s.id);
-    expect(defaults).toEqual(["pubmed", "openalex"]);
+    expect(defaults).toEqual(["pubmed", "europepmc"]);
   });
 });
 

--- a/src/lib/mcp/tools.ts
+++ b/src/lib/mcp/tools.ts
@@ -230,6 +230,6 @@ export function getSearchCapabilities(): {
 
 const SOURCE_DESCRIPTIONS: Record<SearchSourceId, string> = {
   pubmed: "PubMed / MEDLINE — biomedical literature with MeSH and evidence levels",
-  semantic_scholar: "Semantic Scholar — cross-disciplinary papers with citation metrics and TLDRs",
-  openalex: "OpenAlex — open catalog of scholarly works across all disciplines",
+  europepmc:
+    "Europe PMC — biomedical literature and preprints with native citation counts and open-access links",
 };

--- a/src/lib/search/__tests__/domain-pipeline.test.ts
+++ b/src/lib/search/__tests__/domain-pipeline.test.ts
@@ -112,14 +112,10 @@ describe("FilterPanel domain data", () => {
   });
 
   it("medicine config provides correct source list", () => {
-    expect(medicineDomain.sources).toEqual([
-      "pubmed", "semantic_scholar", "openalex", "clinical_trials",
-    ]);
+    expect(medicineDomain.sources).toEqual(["pubmed", "europepmc"]);
   });
 
   it("multidisciplinary config provides correct source list", () => {
-    expect(multidisciplinaryDomain.sources).toEqual([
-      "pubmed", "semantic_scholar", "openalex", "clinical_trials",
-    ]);
+    expect(multidisciplinaryDomain.sources).toEqual(["pubmed", "europepmc"]);
   });
 });

--- a/src/lib/search/__tests__/feature-flags.test.ts
+++ b/src/lib/search/__tests__/feature-flags.test.ts
@@ -12,8 +12,10 @@ describe("domain feature flags", () => {
     expect(getDomainConfig("multidisciplinary").features.picoExtraction).toBe(false);
   });
 
-  it("disables clinical trials search for multidisciplinary", () => {
-    expect(getDomainConfig("medicine").sources).toContain("clinical_trials");
+  it("keeps clinical trials search enabled for medicine but off for multidisciplinary", () => {
+    // Clinical trials moved off the academic fan-out to the dedicated
+    // /api/search/clinical-trials route; the capability flag still gates it.
+    expect(getDomainConfig("medicine").features.clinicalTrialsSearch).toBe(true);
     expect(getDomainConfig("multidisciplinary").features.clinicalTrialsSearch).toBe(false);
   });
 

--- a/src/lib/search/__tests__/scopus.test.ts
+++ b/src/lib/search/__tests__/scopus.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  searchScopus,
+  mapScopusEntry,
+  extractScopusAuthors,
+  getScopusApiKey,
+  type ScopusEntry,
+} from "../sources/scopus";
+
+const SAMPLE_ENTRY: ScopusEntry = {
+  "dc:title": "SGLT2 inhibitors in heart failure",
+  "dc:creator": "Smith A.",
+  "dc:description": "A randomised trial of SGLT2 inhibition.",
+  "prism:publicationName": "New England Journal of Medicine",
+  "prism:coverDate": "2021-08-15",
+  "prism:doi": "10.1056/nejmoa2107038",
+  "citedby-count": "1234",
+  openaccessFlag: true,
+  author: [
+    { authname: "Smith A.", surname: "Smith", "given-name": "A." },
+    { authname: "Jones B.", surname: "Jones", "given-name": "B." },
+  ],
+};
+
+function mockFetchOnce(body: unknown) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => body,
+    }))
+  );
+}
+
+describe("extractScopusAuthors", () => {
+  it("prefers the full author[] list via authname", () => {
+    expect(extractScopusAuthors(SAMPLE_ENTRY)).toEqual(["Smith A.", "Jones B."]);
+  });
+
+  it("falls back to ce:indexed-name when authname is absent", () => {
+    expect(
+      extractScopusAuthors({ author: [{ "ce:indexed-name": "Doe C." }] })
+    ).toEqual(["Doe C."]);
+  });
+
+  it("falls back to dc:creator (first author) when author[] is missing", () => {
+    expect(extractScopusAuthors({ "dc:creator": "Only A." })).toEqual(["Only A."]);
+  });
+
+  it("returns an empty array when no author data is present", () => {
+    expect(extractScopusAuthors({})).toEqual([]);
+  });
+});
+
+describe("mapScopusEntry", () => {
+  it("maps every field from a Scopus entry", () => {
+    const mapped = mapScopusEntry(SAMPLE_ENTRY);
+    expect(mapped).toMatchObject({
+      title: "SGLT2 inhibitors in heart failure",
+      authors: ["Smith A.", "Jones B."],
+      journal: "New England Journal of Medicine",
+      year: 2021,
+      doi: "10.1056/nejmoa2107038",
+      abstract: "A randomised trial of SGLT2 inhibition.",
+      citationCount: 1234,
+      isOpenAccess: true,
+      sources: ["scopus"],
+    });
+  });
+
+  it("treats openaccess string '1' as open access", () => {
+    expect(mapScopusEntry({ "dc:title": "x", openaccess: "1" })?.isOpenAccess).toBe(true);
+    expect(mapScopusEntry({ "dc:title": "x", openaccess: "0" })?.isOpenAccess).toBe(false);
+  });
+
+  it("returns null for an untitled entry", () => {
+    expect(mapScopusEntry({ "dc:creator": "Nobody" })).toBeNull();
+  });
+
+  it("defaults citationCount to 0 when citedby-count is absent", () => {
+    expect(mapScopusEntry({ "dc:title": "x" })?.citationCount).toBe(0);
+  });
+});
+
+describe("getScopusApiKey", () => {
+  const original = { ...process.env };
+  afterEach(() => {
+    process.env = { ...original };
+  });
+
+  it("accepts ELSEVIER_API_KEY", () => {
+    delete process.env.SCOPUS_API_KEY;
+    process.env.ELSEVIER_API_KEY = "els-key";
+    expect(getScopusApiKey()).toBe("els-key");
+  });
+
+  it("accepts SCOPUS_API_KEY as an alias", () => {
+    delete process.env.ELSEVIER_API_KEY;
+    process.env.SCOPUS_API_KEY = "scopus-key";
+    expect(getScopusApiKey()).toBe("scopus-key");
+  });
+});
+
+describe("searchScopus", () => {
+  const original = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.ELSEVIER_API_KEY;
+    delete process.env.SCOPUS_API_KEY;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    process.env = { ...original };
+  });
+
+  it("is inert (disabled, never throws, never fetches) when no key is set", async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const out = await searchScopus("heart failure");
+
+    expect(out.results).toEqual([]);
+    expect(out.total).toBe(0);
+    expect(out.status.status).toBe("missing_config");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("maps results through fetch when a key is configured", async () => {
+    process.env.ELSEVIER_API_KEY = "els-key";
+    mockFetchOnce({
+      "search-results": {
+        "opensearch:totalResults": "2",
+        entry: [SAMPLE_ENTRY],
+      },
+    });
+
+    const out = await searchScopus("heart failure");
+
+    expect(out.status.status).toBe("ok");
+    expect(out.total).toBe(2);
+    expect(out.results).toHaveLength(1);
+    expect(out.results[0].title).toBe("SGLT2 inhibitors in heart failure");
+    expect(out.results[0].sources).toEqual(["scopus"]);
+  });
+
+  it("returns an empty ok result for a zero-result query (synthetic error entry)", async () => {
+    process.env.SCOPUS_API_KEY = "scopus-key";
+    mockFetchOnce({
+      "search-results": {
+        "opensearch:totalResults": "0",
+        entry: [{ error: "Result set was empty" }],
+      },
+    });
+
+    const out = await searchScopus("asdfqwerty no results");
+
+    expect(out.status.status).toBe("ok");
+    expect(out.results).toEqual([]);
+  });
+});

--- a/src/lib/search/__tests__/springer.test.ts
+++ b/src/lib/search/__tests__/springer.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  searchSpringer,
+  mapSpringerRecord,
+  extractSpringerAuthors,
+  extractSpringerPdfUrl,
+  getSpringerApiKey,
+  type SpringerRecord,
+} from "../sources/springer";
+
+const SAMPLE_RECORD: SpringerRecord = {
+  title: "Deep learning for protein folding",
+  creators: [{ creator: "Doe, Jane" }, { creator: "Roe, Richard" }],
+  publicationName: "Nature Methods",
+  publicationDate: "2020-03-01",
+  doi: "10.1038/s41592-020-0772-5",
+  abstract: "We present a deep-learning approach to protein structure prediction.",
+  openaccess: "true",
+  url: [
+    { platform: "web", format: "html", value: "http://link.springer.com/article/abc" },
+    { platform: "web", format: "pdf", value: "http://link.springer.com/pdf/abc.pdf" },
+  ],
+};
+
+function mockFetchOnce(body: unknown) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => body,
+    }))
+  );
+}
+
+describe("extractSpringerAuthors", () => {
+  it("reverses 'Last, First' into natural 'First Last' order", () => {
+    expect(extractSpringerAuthors(SAMPLE_RECORD)).toEqual([
+      "Jane Doe",
+      "Richard Roe",
+    ]);
+  });
+
+  it("passes through names without a comma", () => {
+    expect(
+      extractSpringerAuthors({ creators: [{ creator: "Aristotle" }] })
+    ).toEqual(["Aristotle"]);
+  });
+
+  it("returns an empty array when creators is missing", () => {
+    expect(extractSpringerAuthors({})).toEqual([]);
+  });
+});
+
+describe("extractSpringerPdfUrl", () => {
+  it("prefers the web PDF link and upgrades http to https", () => {
+    expect(extractSpringerPdfUrl(SAMPLE_RECORD)).toBe(
+      "https://link.springer.com/pdf/abc.pdf"
+    );
+  });
+
+  it("falls back to the web HTML link when no PDF is present", () => {
+    expect(
+      extractSpringerPdfUrl({
+        url: [{ platform: "web", format: "html", value: "https://link.springer.com/x" }],
+      })
+    ).toBe("https://link.springer.com/x");
+  });
+
+  it("returns null when there is no web link", () => {
+    expect(extractSpringerPdfUrl({})).toBeNull();
+  });
+});
+
+describe("mapSpringerRecord", () => {
+  it("maps every field from a Springer record", () => {
+    const mapped = mapSpringerRecord(SAMPLE_RECORD);
+    expect(mapped).toMatchObject({
+      title: "Deep learning for protein folding",
+      authors: ["Jane Doe", "Richard Roe"],
+      journal: "Nature Methods",
+      year: 2020,
+      doi: "10.1038/s41592-020-0772-5",
+      abstract: "We present a deep-learning approach to protein structure prediction.",
+      isOpenAccess: true,
+      openAccessPdfUrl: "https://link.springer.com/pdf/abc.pdf",
+      sources: ["springer"],
+    });
+  });
+
+  it("treats openaccess 'false' as closed and omits the PDF url", () => {
+    const mapped = mapSpringerRecord({ ...SAMPLE_RECORD, openaccess: "false" });
+    expect(mapped?.isOpenAccess).toBe(false);
+    expect(mapped?.openAccessPdfUrl).toBeNull();
+  });
+
+  it("returns null for an untitled record", () => {
+    expect(mapSpringerRecord({ doi: "10.1/x" })).toBeNull();
+  });
+});
+
+describe("getSpringerApiKey", () => {
+  const original = { ...process.env };
+  afterEach(() => {
+    process.env = { ...original };
+  });
+
+  it("reads SPRINGER_API_KEY", () => {
+    process.env.SPRINGER_API_KEY = "springer-key";
+    expect(getSpringerApiKey()).toBe("springer-key");
+  });
+
+  it("returns undefined when unset", () => {
+    delete process.env.SPRINGER_API_KEY;
+    expect(getSpringerApiKey()).toBeUndefined();
+  });
+});
+
+describe("searchSpringer", () => {
+  const original = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.SPRINGER_API_KEY;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    process.env = { ...original };
+  });
+
+  it("is inert (disabled, never throws, never fetches) when no key is set", async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const out = await searchSpringer("protein folding");
+
+    expect(out.results).toEqual([]);
+    expect(out.total).toBe(0);
+    expect(out.status.status).toBe("missing_config");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("maps results through fetch when a key is configured", async () => {
+    process.env.SPRINGER_API_KEY = "springer-key";
+    mockFetchOnce({
+      result: [{ total: "42" }],
+      records: [SAMPLE_RECORD],
+    });
+
+    const out = await searchSpringer("protein folding");
+
+    expect(out.status.status).toBe("ok");
+    expect(out.total).toBe(42);
+    expect(out.results).toHaveLength(1);
+    expect(out.results[0].title).toBe("Deep learning for protein folding");
+    expect(out.results[0].sources).toEqual(["springer"]);
+  });
+
+  it("returns an empty ok result when records is absent", async () => {
+    process.env.SPRINGER_API_KEY = "springer-key";
+    mockFetchOnce({ result: [{ total: "0" }] });
+
+    const out = await searchSpringer("no matches here");
+
+    expect(out.status.status).toBe("ok");
+    expect(out.results).toEqual([]);
+  });
+});

--- a/src/lib/search/domains/__tests__/registry.test.ts
+++ b/src/lib/search/domains/__tests__/registry.test.ts
@@ -42,12 +42,14 @@ describe("getDomainConfig", () => {
     expect(config.features).toBeDefined();
   });
 
-  it("medicine config sources include all 4 expected sources", () => {
+  it("medicine config routes through the good pipeline sources (PubMed + Europe PMC)", () => {
     const config = getDomainConfig("medicine");
     expect(config.sources).toContain("pubmed");
-    expect(config.sources).toContain("semantic_scholar");
-    expect(config.sources).toContain("openalex");
-    expect(config.sources).toContain("clinical_trials");
+    expect(config.sources).toContain("europepmc");
+    // The deprecated fan-out sources are no longer part of the academic pipeline.
+    expect(config.sources).not.toContain("semantic_scholar");
+    expect(config.sources).not.toContain("openalex");
+    expect(config.sources).not.toContain("clinical_trials");
   });
 
   it("medicine evidence hierarchy has exactly 5 levels", () => {

--- a/src/lib/search/domains/biology.ts
+++ b/src/lib/search/domains/biology.ts
@@ -5,7 +5,7 @@ export const biologyDomain: DomainConfig = {
   label: "Biology & Life Sciences",
   description: "Molecular biology, cell biology, genetics, evolution, ecology, and systems biology",
 
-  sources: ["pubmed", "semantic_scholar", "openalex"],
+  sources: ["pubmed", "europepmc"],
 
   personas: {
     librarian: "You are a biology research librarian. Translate the user's question into database-ready searches for molecular, cellular, organismal, and ecological biology.\n\nFor PubMed: use MeSH where appropriate, title/abstract fields, organism names, and assay terms.\nFor Semantic Scholar: use descriptive natural language with pathway, phenotype, and method terms.\nFor OpenAlex: use concept keywords, taxonomic terms, and important synonyms.",

--- a/src/lib/search/domains/chemistry.ts
+++ b/src/lib/search/domains/chemistry.ts
@@ -5,7 +5,7 @@ export const chemistryDomain: DomainConfig = {
   label: "Chemistry",
   description: "Organic, inorganic, physical, analytical, materials, and chemical biology research",
 
-  sources: ["semantic_scholar", "openalex"],
+  sources: ["europepmc"],
 
   personas: {
     librarian: "You are a chemistry research librarian. Convert the user's question into precise database-ready searches using compound names, reaction classes, catalyst terms, spectroscopy methods, and material names.\n\nFor Semantic Scholar: use descriptive chemistry phrases, named reactions, and property terms.\nFor OpenAlex: use concept-based keywords with synonyms and common abbreviations.",

--- a/src/lib/search/domains/computer-science.ts
+++ b/src/lib/search/domains/computer-science.ts
@@ -5,7 +5,7 @@ export const computerScienceDomain: DomainConfig = {
   label: "Computer Science",
   description: "Artificial intelligence, systems, security, theory, HCI, and software engineering",
 
-  sources: ["arxiv", "semantic_scholar", "openalex"],
+  sources: ["arxiv"],
 
   personas: {
     librarian: "You are a computer science research librarian. Convert the user's research question into venue-aware academic search queries.\n\nFor arXiv: use cs.* or stat.ML categories, title and abstract field prefixes when needed.\nFor Semantic Scholar: use natural language with method, benchmark, and task terms.\nFor OpenAlex: use concept keywords, abbreviations, and relevant subfield synonyms.",

--- a/src/lib/search/domains/economics.ts
+++ b/src/lib/search/domains/economics.ts
@@ -5,7 +5,7 @@ export const economicsDomain: DomainConfig = {
   label: "Economics & Finance",
   description: "Microeconomics, macroeconomics, econometrics, development, public finance, and financial economics",
 
-  sources: ["arxiv", "semantic_scholar", "openalex"],
+  sources: ["arxiv"],
 
   personas: {
     librarian: "You are an economics research librarian. Convert the user's question into literature search queries using model names, identification strategies, sectors, and policy variables.\n\nFor arXiv: use q-fin and econ-related categories where relevant, plus title and abstract search.\nFor Semantic Scholar: use natural language with topic, outcome, and empirical strategy terms.\nFor OpenAlex: use concept keywords, standard abbreviations, and policy/economic synonyms.",

--- a/src/lib/search/domains/education.ts
+++ b/src/lib/search/domains/education.ts
@@ -5,7 +5,7 @@ export const educationDomain: DomainConfig = {
   label: "Education",
   description: "Teaching, learning sciences, curriculum, teacher development, educational policy, and assessment",
 
-  sources: ["semantic_scholar", "openalex"],
+  sources: ["europepmc"],
 
   personas: {
     librarian: "You are an education research librarian. Convert the user's question into search queries using learner groups, instructional interventions, settings, outcomes, and methodology terms.\n\nFor Semantic Scholar: use natural language with pedagogy, assessment, and implementation terms.\nFor OpenAlex: use concept keywords, educational levels, and common instructional synonyms.",

--- a/src/lib/search/domains/engineering.ts
+++ b/src/lib/search/domains/engineering.ts
@@ -5,7 +5,7 @@ export const engineeringDomain: DomainConfig = {
   label: "Engineering",
   description: "Electrical, mechanical, civil, materials, robotics, and applied systems engineering",
 
-  sources: ["arxiv", "semantic_scholar", "openalex"],
+  sources: ["arxiv"],
 
   personas: {
     librarian: "You are an engineering research librarian. Convert the user's question into technical search queries using device names, materials, standards, performance metrics, and application contexts.\n\nFor arXiv: use category codes when relevant, especially for robotics, controls, or systems.\nFor Semantic Scholar: use natural language with component, process, and performance terms.\nFor OpenAlex: use concept keywords, abbreviations, and application-specific synonyms.",

--- a/src/lib/search/domains/environmental.ts
+++ b/src/lib/search/domains/environmental.ts
@@ -5,7 +5,7 @@ export const environmentalDomain: DomainConfig = {
   label: "Environmental Science",
   description: "Climate science, sustainability, ecology, environmental engineering, and earth system impacts",
 
-  sources: ["semantic_scholar", "openalex"],
+  sources: ["europepmc"],
 
   personas: {
     librarian: "You are an environmental science research librarian. Convert the user's question into search queries using pollutant, ecosystem, climate variable, geography, and method terms.\n\nFor Semantic Scholar: use natural language with system, exposure, scale, and method terms.\nFor OpenAlex: use concept keywords, environmental synonyms, and region-specific descriptors.",

--- a/src/lib/search/domains/humanities.ts
+++ b/src/lib/search/domains/humanities.ts
@@ -5,7 +5,7 @@ export const humanitiesDomain: DomainConfig = {
   label: "Humanities",
   description: "Literature, history, philosophy, cultural studies, and interpretive humanities scholarship",
 
-  sources: ["semantic_scholar", "openalex"],
+  sources: ["europepmc"],
 
   personas: {
     librarian: "You are a humanities research librarian. Convert the user's question into scholarly search queries using periodization, primary texts, authors, movements, archives, and interpretive frameworks.\n\nFor Semantic Scholar: use natural language with texts, themes, and method terms.\nFor OpenAlex: use concept keywords, alternate spellings, and historical or cultural descriptors.",

--- a/src/lib/search/domains/law.ts
+++ b/src/lib/search/domains/law.ts
@@ -5,7 +5,7 @@ export const lawDomain: DomainConfig = {
   label: "Law & Legal Studies",
   description: "Constitutional law, public law, private law, comparative law, and legal theory",
 
-  sources: ["semantic_scholar", "openalex"],
+  sources: ["europepmc"],
 
   personas: {
     librarian: "You are a legal research librarian. Convert the user's question into literature search queries using doctrines, jurisdictions, statutes, cases, and policy terms.\n\nFor Semantic Scholar: use natural language with doctrine names, jurisdictions, and issue framing.\nFor OpenAlex: use concept keywords, legal synonyms, and comparative-law terminology.",

--- a/src/lib/search/domains/mathematics.ts
+++ b/src/lib/search/domains/mathematics.ts
@@ -5,7 +5,7 @@ export const mathematicsDomain: DomainConfig = {
   label: "Mathematics",
   description: "Pure mathematics, applied mathematics, statistics, and mathematical modeling",
 
-  sources: ["arxiv", "semantic_scholar", "openalex"],
+  sources: ["arxiv"],
 
   personas: {
     librarian: "You are a mathematics research librarian. Convert the user's question into precise searches using theorem names, problem classes, notation words, and subfield labels.\n\nFor arXiv: use math.* categories and ti: or abs: for exact concepts.\nFor Semantic Scholar: use descriptive mathematical language.\nFor OpenAlex: use concept keywords and standard theorem or method names.",

--- a/src/lib/search/domains/medicine.ts
+++ b/src/lib/search/domains/medicine.ts
@@ -5,7 +5,7 @@ export const medicineDomain: DomainConfig = {
   label: "Medicine & Health Sciences",
   description: "Clinical medicine, public health, biomedical research",
 
-  sources: ["pubmed", "semantic_scholar", "openalex", "clinical_trials"],
+  sources: ["pubmed", "europepmc"],
 
   personas: {
     librarian: "You are a medical librarian. Convert the user's research question into optimized search queries for different academic databases.\n\nFor PubMed: Use MeSH terms with [MeSH] tags, Boolean operators (AND, OR), field tags ([tiab] for title/abstract, [pt] for publication type). Be specific and structured.\nFor Semantic Scholar: Use natural language that captures the conceptual meaning. Be descriptive, not Boolean.\nFor OpenAlex: Use natural language keywords. Include synonyms.\n\nAlso suggest appropriate filters (year range, publication types) based on the query context.",

--- a/src/lib/search/domains/multidisciplinary.ts
+++ b/src/lib/search/domains/multidisciplinary.ts
@@ -5,7 +5,7 @@ export const multidisciplinaryDomain: DomainConfig = {
   label: "Multidisciplinary / Not Sure",
   description: "Search across all scientific disciplines",
 
-  sources: ["pubmed", "semantic_scholar", "openalex", "clinical_trials"],
+  sources: ["pubmed", "europepmc"],
   // Note: arxiv will be added here once the arXiv adapter is built (Issue #20)
 
   personas: {

--- a/src/lib/search/domains/physics.ts
+++ b/src/lib/search/domains/physics.ts
@@ -5,7 +5,7 @@ export const physicsDomain: DomainConfig = {
   label: "Physics & Astronomy",
   description: "Theoretical physics, experimental physics, astrophysics, condensed matter",
 
-  sources: ["arxiv", "semantic_scholar", "openalex"],
+  sources: ["arxiv"],
 
   personas: {
     librarian: "You are a physics research librarian specializing in academic database search optimization.\n\nFor arXiv: Use category prefixes such as hep-th, cond-mat, astro-ph, quant-ph, gr-qc, and nucl-th. Use field search prefixes like ti: for title and abs: for abstract.\nFor Semantic Scholar: Use natural language phrasing that names the phenomenon, method, and subfield.\nFor OpenAlex: Use concept-focused keywords with domain synonyms and canonical terminology.",

--- a/src/lib/search/domains/psychology.ts
+++ b/src/lib/search/domains/psychology.ts
@@ -5,7 +5,7 @@ export const psychologyDomain: DomainConfig = {
   label: "Psychology & Behavioral Science",
   description: "Clinical, cognitive, developmental, social, and experimental psychology",
 
-  sources: ["pubmed", "semantic_scholar", "openalex"],
+  sources: ["pubmed", "europepmc"],
 
   personas: {
     librarian: "You are a psychology research librarian. Convert the user's question into search queries using constructs, scales, populations, interventions, and study-design terminology.\n\nFor PubMed: use MeSH where relevant and combine mental health terms, populations, and outcomes.\nFor Semantic Scholar: use natural language with constructs, paradigms, and validated measures.\nFor OpenAlex: use concept keywords and discipline-standard synonyms.",

--- a/src/lib/search/domains/social-sciences.ts
+++ b/src/lib/search/domains/social-sciences.ts
@@ -5,7 +5,7 @@ export const socialSciencesDomain: DomainConfig = {
   label: "Social Sciences",
   description: "Sociology, political science, anthropology, demography, and interdisciplinary social research",
 
-  sources: ["semantic_scholar", "openalex"],
+  sources: ["europepmc"],
 
   personas: {
     librarian: "You are a social sciences research librarian. Convert the user's question into search queries using population terms, institutions, theory names, policy terms, and methodological descriptors.\n\nFor Semantic Scholar: use descriptive natural language with construct names and methods.\nFor OpenAlex: use concept-based keywords, alternate spellings, and relevant demographic or regional terms.",

--- a/src/lib/search/domains/types.ts
+++ b/src/lib/search/domains/types.ts
@@ -20,6 +20,7 @@ export type DomainId =
 
 export type SourceId =
   | "pubmed"
+  | "europepmc"
   | "semantic_scholar"
   | "openalex"
   | "clinical_trials"

--- a/src/lib/search/run-search.ts
+++ b/src/lib/search/run-search.ts
@@ -1,19 +1,15 @@
 /**
  * Server-side literature search orchestration.
  *
- * Single source of truth for fanning out to PubMed / Semantic Scholar / OpenAlex,
- * fusing with RRF, filtering, and normalizing results. Both the web API route
- * (`/api/research/search`) and the MCP tool (`/api/mcp`) call this — neither
- * reimplements the search logic, and neither performs auth here (auth lives at
- * each transport's boundary).
+ * Single source of truth for fanning out to PubMed / Europe PMC (plus the owned
+ * MedCPT dense lane), fusing with RRF, filtering, and normalizing results. Both
+ * the web API route (`/api/research/search`) and the MCP tool (`/api/mcp`) call
+ * this — neither reimplements the search logic, and neither performs auth here
+ * (auth lives at each transport's boundary).
  */
 
 import { searchPubMed } from "@/lib/search/sources/pubmed";
-import { searchSemanticScholar } from "@/lib/search/sources/semantic-scholar";
-import {
-  searchOpenAlex,
-  enrichCitationsByIds,
-} from "@/lib/search/sources/openalex";
+import { searchEuropePMC } from "@/lib/search/sources/europepmc";
 import { searchMedcptDense } from "@/lib/search/sources/medcpt-dense";
 import { fetchCrossrefByDoi } from "@/lib/search/sources/crossref";
 import { searchClinicalTrials } from "@/lib/search/sources/clinical-trials";
@@ -36,16 +32,18 @@ import { assessConfidence, type Confidence } from "@/lib/search/confidence";
 import { backfillPmidsByDoi } from "@/lib/search/pmid-backfill";
 import type { UnifiedSearchResult } from "@/types/search";
 
-export const SEARCH_SOURCES = ["pubmed", "semantic_scholar", "openalex"] as const;
+export const SEARCH_SOURCES = ["pubmed", "europepmc"] as const;
 export type SearchSourceId = (typeof SEARCH_SOURCES)[number];
 
 /**
  * Sources used when a caller does not specify any. PubMed-first for clinical
- * relevance, OpenAlex for citation counts + open-access links. Semantic Scholar
- * is intentionally NOT in the default set — it is optional and the system works
- * fully without it (it 403s / rate-limits frequently). Pass it explicitly to opt in.
+ * relevance; Europe PMC for open-access links AND native citation counts (its
+ * `citedByCount` replaces the dropped OpenAlex citation-enrichment step). Both
+ * are throttle-tolerant biomedical lexical lanes. OpenAlex and Semantic Scholar
+ * were removed from the pipeline; the owned MedCPT dense lane is the recall
+ * backbone and always contributes (see the guaranteed-floor logic below).
  */
-export const DEFAULT_SOURCES: SearchSourceId[] = ["pubmed", "openalex"];
+export const DEFAULT_SOURCES: SearchSourceId[] = ["pubmed", "europepmc"];
 
 /** Hard ceiling on results per search, shared across web and MCP transports. */
 export const MAX_RESULTS = 50;
@@ -78,7 +76,7 @@ export interface RunLiteratureSearchParams {
   /**
    * Opt-in citation/PMRA neighbour expansion (a high-recall, slower mode for
    * systematic-review-style searches). Off by default to keep the default path
-   * fast — the OpenAlex dense semantic lane already provides corpus-free recall.
+   * fast — the owned MedCPT dense semantic lane already provides corpus-free recall.
    */
   expandCitations?: boolean;
   /**
@@ -155,14 +153,28 @@ function withSourceTimeout<T>(
  * (partial results), marking the rest as dropped. Caps the p95 tail.
  *
  * Set to 8s (was 5s): the owned MedCPT dense lane is the recall backbone — when
- * the lexical lanes are throttled or an upstream (OpenAlex) is down, the dense
+ * the lexical lanes are throttled or an upstream (Europe PMC) is down, the dense
  * lane alone returns the right papers. Under prod serverless latency + event-loop
  * contention from a slow lane, dense and PubMed were finishing just past 5s and
  * being dropped, collapsing the pool to whatever fast junk lane survived. 8s gives
  * the good lanes room; a lane that resolves early still returns immediately (this
  * is a ceiling, not a floor), so it only lengthens the degraded/one-lane-down tail.
+ *
+ * NOTE: the BASE MedCPT dense lane is NOT bound by this deadline — it is the
+ * guaranteed floor and awaited on its own longer timeout (DENSE_FLOOR_TIMEOUT_MS).
+ * Only the lexical lanes and the recency/HyDE dense lanes race this deadline.
  */
 export const FANOUT_DEADLINE_MS = 8000;
+
+/**
+ * Guaranteed-floor timeout (ms) for the BASE MedCPT dense lane. This lane is
+ * CPU-warm, owned, and outage-proof, so it must NEVER be dropped by the fan-out
+ * deadline race — it is awaited independently on this longer budget and always
+ * merged into the fused pool, even when every lexical lane was dropped. Slightly
+ * longer than FANOUT_DEADLINE_MS so a dense lane finishing just past the fan-out
+ * ceiling still contributes rather than collapsing recall to whatever survived.
+ */
+export const DENSE_FLOOR_TIMEOUT_MS = 9000;
 
 /**
  * Dedicated timeout (ms) for the transient-empty recovery pass — a single fresh
@@ -188,10 +200,8 @@ export function recencyYearFloor(currentYear: number, windowYears: number): numb
   return currentYear - windowYears + 1;
 }
 
-// Cap for the post-fusion enrich+rerank pool. Only the top candidates by RRF
-// score can reach the returned page, so bounding both steps here keeps OpenAlex
-// enrichment to a single batch regardless of how many lanes contributed —
-// protecting the shared OpenAlex token bucket from metadata-light lanes.
+// Cap for the post-fusion rerank pool. Only the top candidates by RRF score can
+// reach the returned page, so reranking beyond this is wasted work.
 export const POST_FUSION_POOL = 50;
 
 const DEADLINE = Symbol("fanout-deadline");
@@ -453,19 +463,23 @@ async function runLiteratureSearchUncached(
     );
   }
 
-  if (sources.includes("openalex")) {
+  // Europe PMC: a second throttle-tolerant biomedical lexical lane (replaces the
+  // dropped OpenAlex lane). Wired exactly like the PubMed lane — same year filters
+  // and withSourceTimeout pattern, fed into the same RRF fusion. Carries native
+  // `citedByCount`, so citation counts come from here (and later Scopus) instead
+  // of the removed OpenAlex citation-enrichment step, and native open-access links.
+  if (sources.includes("europepmc")) {
     pushLane(
-      "openalex",
+      "europepmc",
       withSourceTimeout(
-        "OpenAlex",
-        searchOpenAlex(searchQuery, {
+        "Europe PMC",
+        searchEuropePMC(searchQuery, {
           limit: poolPerSource,
           page: page + 1,
           yearStart: params.yearFrom,
           yearEnd: params.yearTo,
-          onlyOpenAccess: params.fullTextOnly,
-        }).then(({ results, total, status }) => ({ source: "openalex", results, total, status }))
-      ).catch((e) => errorOutcome("openalex", e instanceof Error ? e.message : "OpenAlex failed"))
+        }).then(({ results, total, status }) => ({ source: "europepmc", results, total, status }))
+      ).catch((e) => errorOutcome("europepmc", e instanceof Error ? e.message : "Europe PMC failed"))
     );
   }
 
@@ -473,14 +487,21 @@ async function runLiteratureSearchUncached(
   // (Turbopuffer int8 + a Modal-served MedCPT Query-Encoder) — the throttle-proof
   // replacement for the OpenAlex `search.semantic` lane. Retrieves by MEANING,
   // surfacing landmarks that share no surface terms with the query, and cannot be
-  // rate-limited away because we own it. Fused into the candidate pool before RRF,
-  // exactly like the lane it replaces. Runs alongside the core biomedical lexical
-  // lanes (PubMed / OpenAlex) and fails open: dormant (missing_config) until the
-  // index + encoder are configured, so it never degrades live search.
-  if (sources.includes("pubmed") || sources.includes("openalex")) {
-    pushLane(
-      "medcpt_dense",
-      withSourceTimeout(
+  // rate-limited away because we own it. Fused into the candidate pool before RRF.
+  // Runs alongside the core biomedical lexical lanes (PubMed / Europe PMC) and
+  // fails open: dormant (missing_config) until the index + encoder are configured,
+  // so it never degrades live search.
+  const runsDense = sources.includes("pubmed") || sources.includes("europepmc");
+
+  // GUARANTEED FLOOR: the BASE similarity dense lane is the outage-proof recall
+  // backbone, so it must NEVER be dropped by the fan-out deadline race. Unlike the
+  // other lanes it is NOT pushed into `promises` — it is started here (in parallel
+  // with everything else) and awaited AFTER settleWithinDeadline on its own longer
+  // DENSE_FLOOR_TIMEOUT_MS budget, then always merged into the fused pool even when
+  // every lexical lane was dropped. The recency/HyDE dense lanes below stay on the
+  // normal fan-out deadline — only this base lane is the floor.
+  const baseDensePromise: Promise<SourceOutcome> | null = runsDense
+    ? withSourceTimeout(
         "MedCPT Dense",
         searchMedcptDense(searchQuery, {
           limit: poolPerSource,
@@ -491,12 +512,14 @@ async function runLiteratureSearchUncached(
           results,
           total,
           status,
-        }))
+        })),
+        DENSE_FLOOR_TIMEOUT_MS
       ).catch((e) =>
         errorOutcome("medcpt_dense", e instanceof Error ? e.message : "MedCPT dense failed")
       )
-    );
+    : null;
 
+  if (runsDense) {
     // Recency intent: an additional recency-WINDOWED dense lane over the same
     // owned index. The base dense lane ranks purely by semantic similarity, so a
     // newer pivotal paper can sit below older high-similarity hits; restricting to
@@ -568,30 +591,6 @@ async function runLiteratureSearchUncached(
     });
   }
 
-  // Semantic Scholar is opt-in only (never required). Used purely as an extra
-  // citation/metadata signal when explicitly requested and reachable.
-  if (sources.includes("semantic_scholar")) {
-    pushLane(
-      "semantic_scholar",
-      withSourceTimeout(
-        "Semantic Scholar",
-        searchSemanticScholar(searchQuery, {
-          limit: poolPerSource,
-          offset: page * poolPerSource,
-          yearStart: params.yearFrom,
-          yearEnd: params.yearTo,
-        }).then(({ results, total, status }) => ({
-          source: "semantic_scholar",
-          results,
-          total,
-          status,
-        }))
-      ).catch((e) =>
-        errorOutcome("semantic_scholar", e instanceof Error ? e.message : "Semantic Scholar failed")
-      )
-    );
-  }
-
   // ClinicalTrials.gov linking for trial-acronym / NCT / explicit-trial queries.
   if (plan.wantsTrials) {
     pushLane(
@@ -625,6 +624,14 @@ async function runLiteratureSearchUncached(
   // Await lanes up to a global deadline → partial results (a stuck/throttled lane
   // never holds the whole query; dropped lanes are marked "timeout", not "ok").
   const sourceResults = await settleWithinDeadline(promises, laneLabels, FANOUT_DEADLINE_MS);
+
+  // GUARANTEED FLOOR: merge the BASE MedCPT dense lane independently of the fan-out
+  // deadline. It was started in parallel above and is awaited here on its own longer
+  // budget, so it ALWAYS contributes to the fused pool — even when every lexical lane
+  // was dropped at FANOUT_DEADLINE_MS. This is the outage-proof recall backbone.
+  if (baseDensePromise) {
+    sourceResults.push(await baseDensePromise);
+  }
 
   // Wave 2 (opt-in): neighbour/citation expansion on the top seeds — a corpus-free
   // recall booster that pulls PubMed related-articles (PMRA) of the best wave-1
@@ -665,7 +672,7 @@ async function runLiteratureSearchUncached(
   // legitimately empty result (every lane ok) or a dormant lane (missing_config),
   // where a retry cannot help — see isTransientEmpty.
   if (
-    (sources.includes("pubmed") || sources.includes("openalex")) &&
+    runsDense &&
     isTransientEmpty(
       fused.length,
       sourceResults.map((sr) => sr.status)
@@ -707,23 +714,15 @@ async function runLiteratureSearchUncached(
     maxTotal = Math.max(maxTotal, sr.total);
   }
 
-  // Post-fusion enrichment + rerank run CONCURRENTLY (they mutate disjoint fields
-  // of `fused`: enrichment fills citationCount/PMID/DOI/OA; rerank attaches
-  // rerankScore). Running them in parallel instead of back-to-back cuts the
-  // post-fusion critical path ~30-45% and shrinks the window where lane timeouts
-  // accumulate. Both fail-open.
-  //  - enrich: OpenAlex citation/PMID/DOI backfill — the S2-independent landmark signal.
+  // Post-fusion rerank. Citation counts now come natively from Europe PMC's
+  // `citedByCount` (and later Scopus) on each result, so the former OpenAlex
+  // citation-enrichment step is gone — there is no separate metadata backfill to
+  // run concurrently here. Bounded to the top `POST_FUSION_POOL` candidates by RRF
+  // score, in place (slice shares object refs, so the originals in `fused` still
+  // get the mutated rerankScore). Candidates past the pool are never reranked, so
+  // they can't reach the returned page anyway. Fail-open.
   //  - rerank: OpenRouter cohere/rerank-4-pro relevance score (managed, always-warm,
   //    ~1.2s; the dominant relevance signal). MedCPT is off the critical path now.
-  //
-  // Both are bounded to the top `POST_FUSION_POOL` candidates by RRF score, in
-  // place (slice shares object refs, so the originals in `fused` still get the
-  // mutated fields). This caps the OpenAlex enrichment at a single batch and
-  // stops a metadata-light lane (e.g. the MedCPT dense lane, whose precomputed
-  // rows carry no DOI/citation) from injecting EXTRA enrichment batches that
-  // drain OpenAlex's shared token bucket and starve the lexical search lanes of
-  // the next query's fan-out budget. Candidates past the pool are not reranked
-  // anyway, so they can never reach the returned page — enriching them is wasted.
   const enrichRerankPool = fused.slice(0, POST_FUSION_POOL);
   // The cross-encoder rerank is COUNTERPRODUCTIVE for a specific trial-acronym
   // lookup: fed a bare acronym ("KEYNOTE-189"), it scores secondary papers that
@@ -732,24 +731,21 @@ async function runLiteratureSearchUncached(
   // (measured: the GT primary sits in the rerank pool but is pushed out of the top-10
   // only when reranked). For these the exact-match lexical lane + clinical-quality
   // composite + demoteSecondaryTrialResults already float the primary first, so we
-  // skip the rerank (enrichment still runs). Non-acronym queries keep it.
+  // skip the rerank. Non-acronym queries keep it.
   const skipRerank = plan.trialAcronyms.length > 0;
-  await Promise.all([
-    withSourceTimeout("OpenAlex enrich", enrichCitationsByIds(enrichRerankPool), 3500).catch(() => 0),
-    skipRerank
-      ? Promise.resolve(fused)
-      : withSourceTimeout(
-          "Cross-encoder rerank",
-          attachRerankScores(searchQuery, enrichRerankPool, POST_FUSION_POOL),
-          4000
-        ).catch(() => fused),
-  ]);
+  if (!skipRerank) {
+    await withSourceTimeout(
+      "Cross-encoder rerank",
+      attachRerankScores(searchQuery, enrichRerankPool, POST_FUSION_POOL),
+      4000
+    ).catch(() => fused);
+  }
 
-  // PMID backfill: OpenAlex enrichment above fills most PMIDs from its id graph,
-  // but DOI-only results not in that graph still lack one (the PMID metadata gate).
-  // Resolve the residual via NCBI esearch[AID] — bounded to a handful of the top
-  // candidates, fail-open, additive metadata only. Runs AFTER OpenAlex enrich so it
-  // only pays for the true residual.
+  // PMID backfill: PubMed and Europe PMC (MEDLINE records) carry PMIDs natively,
+  // but DOI-only results (Crossref, preprints, non-MEDLINE Europe PMC sources)
+  // still lack one (the PMID metadata gate). Resolve the residual via NCBI
+  // esearch[AID] — bounded to a handful of the top candidates, fail-open, additive
+  // metadata only.
   await withSourceTimeout("PMID backfill", backfillPmidsByDoi(enrichRerankPool), 3000).catch(
     () => 0
   );
@@ -820,11 +816,10 @@ async function fetchSinglePubMed(term: string): Promise<UnifiedSearchResult | nu
 }
 
 /**
- * Fetch a single paper by identifier — Semantic-Scholar-free. Accepts a DOI,
- * PMID, or an internal `pm_<pmid>` id and resolves through stable primary
- * sources in order: PubMed (by PMID or DOI), then Crossref (by DOI), then
- * OpenAlex citation enrichment. `doi_`/`s2_`/`oa_` internal ids are lossy and
- * cannot be reversed — callers should pass the raw `doi`/`pmid` instead.
+ * Fetch a single paper by identifier. Accepts a DOI, PMID, or an internal
+ * `pm_<pmid>` id and resolves through stable primary sources in order: PubMed
+ * (by PMID or DOI), then Crossref (by DOI). `doi_`/`s2_`/`oa_` internal ids are
+ * lossy and cannot be reversed — callers should pass the raw `doi`/`pmid` instead.
  */
 export async function fetchPaperById(params: {
   doi?: string;
@@ -846,8 +841,6 @@ export async function fetchPaperById(params: {
     if (!paper) paper = await fetchCrossrefByDoi(doi);
   }
   if (!paper) return null;
-
-  await enrichCitationsByIds([paper]).catch(() => 0);
 
   return {
     ...paper,

--- a/src/lib/search/sources/__tests__/europepmc.test.ts
+++ b/src/lib/search/sources/__tests__/europepmc.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { searchEuropePMC } from "../europepmc";
+
+// Must use vi.hoisted so mock references are available inside vi.mock factories
+const { mockBreaker, mockResilientFetch } = vi.hoisted(() => {
+  const mockBreaker = {
+    canRequest: vi.fn(() => true),
+    onSuccess: vi.fn(),
+    onFailure: vi.fn(),
+  };
+  const mockResilientFetch = vi.fn();
+  return { mockBreaker, mockResilientFetch };
+});
+
+vi.mock("@/lib/http/resilient-fetch", () => ({
+  resilientFetch: mockResilientFetch,
+}));
+
+vi.mock("@/lib/http/circuit-breaker", () => ({
+  createCircuitBreaker: vi.fn(() => mockBreaker),
+}));
+
+function mockJson(payload: unknown) {
+  mockResilientFetch.mockResolvedValue({
+    json: () => Promise.resolve(payload),
+  } as unknown as Response);
+}
+
+const SAMPLE_RESPONSE = {
+  hitCount: 19468,
+  resultList: {
+    result: [
+      {
+        id: "37012345",
+        source: "MED",
+        pmid: "37012345",
+        doi: "10.1016/j.jcin.2023.01.001",
+        title: "Management of contrast induced nephropathy",
+        abstractText: "A review of prevention strategies for CIN.",
+        authorString: "Smith AB, Jones CD, Brown EF.",
+        journalInfo: {
+          journal: { title: "JACC Cardiovascular Interventions" },
+          yearOfPublication: 2023,
+        },
+        pubYear: "2023",
+        citedByCount: 42,
+        isOpenAccess: "Y",
+        pubTypeList: { pubType: ["Journal Article", "Review"] },
+        fullTextUrlList: {
+          fullTextUrl: [
+            {
+              url: "https://europepmc.org/articles/PMC12345",
+              documentStyle: "html",
+              availability: "Open access",
+            },
+            {
+              url: "https://europepmc.org/articles/PMC12345?pdf=render",
+              documentStyle: "pdf",
+              availability: "Open access",
+            },
+          ],
+        },
+      },
+      {
+        id: "PPR654321",
+        source: "PPR",
+        pmid: "654321",
+        title: "Preprint on nephrotoxicity",
+        abstractText: "Preprint abstract.",
+        authorList: {
+          author: [{ fullName: "Doe J" }, { fullName: "Roe K" }],
+        },
+        journalInfo: { yearOfPublication: 2024 },
+        pubYear: "2024",
+        citedByCount: 0,
+        isOpenAccess: "N",
+        pubTypeList: { pubType: ["Preprint"] },
+      },
+    ],
+  },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockBreaker.canRequest.mockReturnValue(true);
+});
+
+describe("searchEuropePMC", () => {
+  it("maps fields correctly including abstract, citations, and open access", async () => {
+    mockJson(SAMPLE_RESPONSE);
+    const { results, total, status } = await searchEuropePMC(
+      "contrast induced nephropathy management"
+    );
+
+    expect(total).toBe(19468);
+    expect(status).toEqual({ status: "ok" });
+    expect(results).toHaveLength(2);
+
+    const first = results[0];
+    expect(first.title).toBe("Management of contrast induced nephropathy");
+    expect(first.abstract).toBe("A review of prevention strategies for CIN.");
+    expect(first.authors).toEqual(["Smith AB", "Jones CD", "Brown EF"]);
+    expect(first.journal).toBe("JACC Cardiovascular Interventions");
+    expect(first.year).toBe(2023);
+    expect(first.doi).toBe("10.1016/j.jcin.2023.01.001");
+    expect(first.pmid).toBe("37012345");
+    expect(first.citationCount).toBe(42);
+    expect(first.isOpenAccess).toBe(true);
+    expect(first.openAccessPdfUrl).toBe(
+      "https://europepmc.org/articles/PMC12345?pdf=render"
+    );
+    expect(first.publicationTypes).toEqual(["Journal Article", "Review"]);
+    expect(first.studyType).toBe("review");
+    expect(first.sources).toEqual(["europepmc"]);
+  });
+
+  it("omits pmid for non-MED sources and falls back to authorList", async () => {
+    mockJson(SAMPLE_RESPONSE);
+    const { results } = await searchEuropePMC("nephrotoxicity");
+
+    const preprint = results[1];
+    expect(preprint.pmid).toBeUndefined();
+    expect(preprint.authors).toEqual(["Doe J", "Roe K"]);
+    expect(preprint.isOpenAccess).toBe(false);
+    expect(preprint.openAccessPdfUrl).toBeNull();
+    expect(preprint.citationCount).toBe(0);
+  });
+
+  it("appends a PUB_YEAR filter to the query when year bounds are set", async () => {
+    mockJson(SAMPLE_RESPONSE);
+    await searchEuropePMC("aortic stenosis", { yearStart: 2018, yearEnd: 2024 });
+
+    const calledUrl = mockResilientFetch.mock.calls[0][0] as string;
+    expect(decodeURIComponent(calledUrl)).toContain(
+      "AND (PUB_YEAR:[2018 TO 2024])"
+    );
+  });
+
+  it("caps pageSize at 100 and passes the page number", async () => {
+    mockJson(SAMPLE_RESPONSE);
+    await searchEuropePMC("sepsis", { limit: 500, page: 3 });
+
+    const calledUrl = mockResilientFetch.mock.calls[0][0] as string;
+    expect(calledUrl).toContain("pageSize=100");
+    expect(calledUrl).toContain("page=3");
+  });
+
+  it("handles an empty result list", async () => {
+    mockJson({ hitCount: 0, resultList: { result: [] } });
+    const { results, total, status } = await searchEuropePMC("zzzznomatchzzz");
+
+    expect(results).toEqual([]);
+    expect(total).toBe(0);
+    expect(status).toEqual({ status: "ok" });
+  });
+
+  it("handles a missing resultList without throwing", async () => {
+    mockJson({ hitCount: 0 });
+    const { results, total } = await searchEuropePMC("anything");
+
+    expect(results).toEqual([]);
+    expect(total).toBe(0);
+  });
+
+  it("returns an error status and empty results on a non-200 (thrown) response", async () => {
+    mockResilientFetch.mockRejectedValue(new Error("[EuropePMC] HTTP 503"));
+    const { results, total, status } = await searchEuropePMC("failure");
+
+    expect(results).toEqual([]);
+    expect(total).toBe(0);
+    expect(status.status).toBe("error");
+    expect(mockBreaker.onFailure).toHaveBeenCalled();
+  });
+
+  it("returns empty when the circuit breaker is open", async () => {
+    mockBreaker.canRequest.mockReturnValue(false);
+    const { results, total, status } = await searchEuropePMC("anything");
+
+    expect(results).toEqual([]);
+    expect(total).toBe(0);
+    expect(status.status).toBe("error");
+    expect(mockResilientFetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/search/sources/europepmc.ts
+++ b/src/lib/search/sources/europepmc.ts
@@ -1,0 +1,172 @@
+import type { UnifiedSearchResult } from "@/types/search";
+import { mapPubMedPublicationType, getEvidenceLevel } from "@/lib/search/evidence-level";
+import { resilientFetch } from "@/lib/http/resilient-fetch";
+import { createCircuitBreaker } from "@/lib/http/circuit-breaker";
+import {
+  classifyFetchError,
+  okStatus,
+  type SourceStatus,
+} from "@/lib/search/source-status";
+
+const breaker = createCircuitBreaker({ service: "EuropePMC", failureThreshold: 5 });
+
+/** Europe PMC caps pageSize at 100. */
+const MAX_PAGE_SIZE = 100;
+
+interface EuropePMCSearchOptions {
+  limit?: number;
+  page?: number;
+  yearStart?: number;
+  yearEnd?: number;
+}
+
+interface EuropePMCFullTextUrl {
+  url?: string;
+  documentStyle?: string;
+  availability?: string;
+}
+
+interface EuropePMCResult {
+  id?: string;
+  source?: string;
+  pmid?: string;
+  doi?: string;
+  title?: string;
+  abstractText?: string;
+  authorString?: string;
+  authorList?: { author?: { fullName?: string }[] };
+  journalInfo?: {
+    journal?: { title?: string };
+    yearOfPublication?: number;
+  };
+  pubYear?: string;
+  citedByCount?: number;
+  isOpenAccess?: string;
+  pubTypeList?: { pubType?: string[] };
+  fullTextUrlList?: { fullTextUrl?: EuropePMCFullTextUrl[] };
+}
+
+interface EuropePMCResponse {
+  hitCount?: number;
+  resultList?: { result?: EuropePMCResult[] };
+}
+
+/**
+ * Split Europe PMC's `authorString` ("Smith AB, Jones CD.") into individual
+ * author names, stripping the trailing sentence period and empty fragments.
+ * Falls back to `authorList.author[].fullName` when the flat string is absent.
+ */
+function extractAuthors(result: EuropePMCResult): string[] {
+  if (result.authorString) {
+    return result.authorString
+      .split(",")
+      .map((a) => a.trim().replace(/\.$/, "").trim())
+      .filter(Boolean);
+  }
+  const fromList = result.authorList?.author
+    ?.map((a) => a.fullName?.trim())
+    .filter((n): n is string => Boolean(n));
+  return fromList ?? [];
+}
+
+/**
+ * Pick the best open-access PDF link: prefer an "Open access" PDF, then any
+ * open-access link, then any PDF link. Returns null when none qualify.
+ */
+function extractOpenAccessPdfUrl(result: EuropePMCResult): string | null {
+  const urls = result.fullTextUrlList?.fullTextUrl ?? [];
+  const openPdf = urls.find(
+    (u) => u.availability === "Open access" && u.documentStyle === "pdf" && u.url
+  );
+  if (openPdf?.url) return openPdf.url;
+  const open = urls.find((u) => u.availability === "Open access" && u.url);
+  if (open?.url) return open.url;
+  const pdf = urls.find((u) => u.documentStyle === "pdf" && u.url);
+  return pdf?.url ?? null;
+}
+
+function mapResult(result: EuropePMCResult): UnifiedSearchResult | null {
+  const title = result.title?.trim();
+  if (!title) return null;
+
+  const publicationTypes = result.pubTypeList?.pubType ?? [];
+  let studyType = "other";
+  for (const pt of publicationTypes) {
+    const mapped = mapPubMedPublicationType(pt);
+    if (mapped !== "other") {
+      studyType = mapped;
+      break;
+    }
+  }
+  const evidence = getEvidenceLevel(studyType);
+
+  const year =
+    Number(result.pubYear) || result.journalInfo?.yearOfPublication || 0;
+
+  return {
+    title,
+    authors: extractAuthors(result),
+    journal: result.journalInfo?.journal?.title ?? "",
+    year,
+    doi: result.doi || undefined,
+    // Only MEDLINE-sourced records carry a genuine PubMed PMID; other Europe PMC
+    // sources (PMC, PPR preprints, patents) reuse `id`/`pmid` for their own ids.
+    pmid: result.source === "MED" ? result.pmid || undefined : undefined,
+    abstract: result.abstractText || undefined,
+    citationCount: result.citedByCount || 0,
+    publicationTypes,
+    studyType,
+    evidenceLevel: evidence.level,
+    isOpenAccess: result.isOpenAccess === "Y",
+    openAccessPdfUrl: extractOpenAccessPdfUrl(result),
+    sources: ["europepmc"],
+  };
+}
+
+export async function searchEuropePMC(
+  query: string,
+  opts: EuropePMCSearchOptions = {}
+): Promise<{ results: UnifiedSearchResult[]; total: number; status: SourceStatus }> {
+  if (!breaker.canRequest()) {
+    console.warn("[EuropePMC] Circuit open — skipping");
+    return {
+      results: [],
+      total: 0,
+      status: { status: "error", message: "Circuit breaker open — recent EuropePMC failures" },
+    };
+  }
+
+  const limit = Math.min(opts.limit || 20, MAX_PAGE_SIZE);
+  const page = opts.page || 1;
+
+  let searchQuery = query;
+  if (opts.yearStart || opts.yearEnd) {
+    const start = opts.yearStart || 1900;
+    const end = opts.yearEnd || new Date().getFullYear();
+    searchQuery += ` AND (PUB_YEAR:[${start} TO ${end}])`;
+  }
+
+  const url =
+    `https://www.ebi.ac.uk/europepmc/webservices/rest/search` +
+    `?query=${encodeURIComponent(searchQuery)}` +
+    `&format=json&resultType=core&pageSize=${limit}&page=${page}`;
+
+  try {
+    const res = await resilientFetch(url, {}, { service: "EuropePMC", timeout: 6000, maxRetries: 1 });
+    const data: EuropePMCResponse = await res.json();
+
+    const rawResults = data.resultList?.result ?? [];
+    const results: UnifiedSearchResult[] = [];
+    for (const raw of rawResults) {
+      const mapped = mapResult(raw);
+      if (mapped) results.push(mapped);
+    }
+
+    breaker.onSuccess();
+    return { results, total: data.hitCount || 0, status: okStatus() };
+  } catch (error) {
+    breaker.onFailure();
+    console.error("[EuropePMC] Search failed:", error);
+    return { results: [], total: 0, status: classifyFetchError(error) };
+  }
+}

--- a/src/lib/search/sources/scopus.ts
+++ b/src/lib/search/sources/scopus.ts
@@ -1,0 +1,193 @@
+/**
+ * Elsevier / Scopus source lane — OPTIONAL, ENV-GATED.
+ *
+ * Activates only when ELSEVIER_API_KEY (or SCOPUS_API_KEY) is present. With no
+ * key configured it is inert: it returns an empty, "missing_config" outcome and
+ * never throws, so it can sit in the fan-out without affecting behaviour until a
+ * key is wired in.
+ *
+ * Request contract (verified against the Elsevier Developer Portal —
+ * https://dev.elsevier.com/documentation/ScopusSearchAPI.wadl):
+ *   GET https://api.elsevier.com/content/search/scopus?query=<q>&count=<n>
+ *   Auth: `X-ELS-APIKey` header (preferred — keeps the key out of URLs/logs) or
+ *   an `apiKey` query param. COMPLETE view surfaces abstract + full author list.
+ *
+ * Response: `search-results.entry[]`, each entry carrying `dc:title`,
+ * `dc:creator` (first author), `author[]` (COMPLETE view), `prism:publicationName`,
+ * `prism:coverDate`, `prism:doi`, `citedby-count`, `dc:description` (abstract).
+ * A zero-result query returns a single entry with an `error` field.
+ */
+
+import type { UnifiedSearchResult } from "@/types/search";
+import { getEvidenceLevel } from "@/lib/search/evidence-level";
+import { resilientFetch } from "@/lib/http/resilient-fetch";
+import { createCircuitBreaker } from "@/lib/http/circuit-breaker";
+import {
+  classifyFetchError,
+  okStatus,
+  type SourceStatus,
+} from "@/lib/search/source-status";
+
+const breaker = createCircuitBreaker({ service: "Scopus", failureThreshold: 5 });
+
+/** Scopus caps `count` at 25 per request for the search endpoint. */
+const MAX_COUNT = 25;
+
+/** Read the Scopus key from env, accepting either accepted variable name. */
+export function getScopusApiKey(): string | undefined {
+  return process.env.ELSEVIER_API_KEY || process.env.SCOPUS_API_KEY || undefined;
+}
+
+interface ScopusSearchOptions {
+  limit?: number;
+  start?: number;
+  yearStart?: number;
+  yearEnd?: number;
+  view?: "STANDARD" | "COMPLETE";
+}
+
+interface ScopusAuthor {
+  authname?: string;
+  surname?: string;
+  "given-name"?: string;
+  "ce:indexed-name"?: string;
+}
+
+export interface ScopusEntry {
+  "dc:title"?: string;
+  "dc:creator"?: string;
+  "dc:description"?: string;
+  "dc:identifier"?: string;
+  "prism:publicationName"?: string;
+  "prism:coverDate"?: string;
+  "prism:doi"?: string;
+  "prism:url"?: string;
+  "citedby-count"?: string;
+  openaccess?: string;
+  openaccessFlag?: boolean;
+  author?: ScopusAuthor[];
+  /** Present (in place of real fields) when a query returns zero results. */
+  error?: string;
+}
+
+interface ScopusResponse {
+  "search-results"?: {
+    "opensearch:totalResults"?: string;
+    entry?: ScopusEntry[];
+  };
+}
+
+/**
+ * Extract author display names, preferring the COMPLETE-view `author[]` list
+ * (`authname`, then `ce:indexed-name`) and falling back to the STANDARD-view
+ * `dc:creator` (first author only) when the full list is absent.
+ */
+export function extractScopusAuthors(entry: ScopusEntry): string[] {
+  const list = entry.author;
+  if (Array.isArray(list) && list.length > 0) {
+    const names = list
+      .map((a) => a.authname?.trim() || a["ce:indexed-name"]?.trim())
+      .filter((n): n is string => Boolean(n));
+    if (names.length > 0) return names;
+  }
+  const creator = entry["dc:creator"]?.trim();
+  return creator ? [creator] : [];
+}
+
+function yearFromCoverDate(date?: string): number {
+  if (!date) return 0;
+  const m = date.match(/(\d{4})/);
+  return m ? parseInt(m[1], 10) : 0;
+}
+
+/** Map one Scopus entry to a UnifiedSearchResult. Returns null when untitled. */
+export function mapScopusEntry(entry: ScopusEntry): UnifiedSearchResult | null {
+  const title = entry["dc:title"]?.trim();
+  if (!title) return null;
+
+  const evidence = getEvidenceLevel("other");
+
+  return {
+    title,
+    authors: extractScopusAuthors(entry),
+    journal: entry["prism:publicationName"]?.trim() ?? "",
+    year: yearFromCoverDate(entry["prism:coverDate"]),
+    doi: entry["prism:doi"] || undefined,
+    abstract: entry["dc:description"]?.trim() || undefined,
+    citationCount: Number(entry["citedby-count"]) || 0,
+    publicationTypes: [],
+    studyType: "other",
+    evidenceLevel: evidence.level,
+    isOpenAccess: entry.openaccessFlag === true || entry.openaccess === "1",
+    sources: ["scopus"],
+  };
+}
+
+export async function searchScopus(
+  query: string,
+  opts: ScopusSearchOptions = {}
+): Promise<{ results: UnifiedSearchResult[]; total: number; status: SourceStatus }> {
+  const apiKey = getScopusApiKey();
+  if (!apiKey) {
+    return {
+      results: [],
+      total: 0,
+      status: {
+        status: "missing_config",
+        message: "ELSEVIER_API_KEY (or SCOPUS_API_KEY) not set — Scopus source disabled",
+      },
+    };
+  }
+
+  if (!breaker.canRequest()) {
+    return {
+      results: [],
+      total: 0,
+      status: { status: "error", message: "Circuit breaker open — recent Scopus failures" },
+    };
+  }
+
+  const count = Math.min(opts.limit || 20, MAX_COUNT);
+  const start = opts.start ?? 0;
+  const view = opts.view ?? "COMPLETE";
+
+  let searchQuery = query;
+  if (opts.yearStart || opts.yearEnd) {
+    const startYear = opts.yearStart || 1900;
+    const endYear = opts.yearEnd || new Date().getFullYear();
+    // Scopus range syntax is exclusive at both ends: AFT <start-1>, BEF <end+1>.
+    searchQuery += ` AND PUBYEAR AFT ${startYear - 1} AND PUBYEAR BEF ${endYear + 1}`;
+  }
+
+  const url =
+    `https://api.elsevier.com/content/search/scopus` +
+    `?query=${encodeURIComponent(searchQuery)}` +
+    `&count=${count}&start=${start}&view=${view}`;
+
+  try {
+    const res = await resilientFetch(
+      url,
+      { headers: { "X-ELS-APIKey": apiKey, Accept: "application/json" } },
+      { service: "Scopus", timeout: 8000, maxRetries: 1 }
+    );
+    const data: ScopusResponse = await res.json();
+
+    // A zero-result query returns a single synthetic entry carrying `error`.
+    const rawEntries = (data["search-results"]?.entry ?? []).filter((e) => !e.error);
+    const results: UnifiedSearchResult[] = [];
+    for (const entry of rawEntries) {
+      const mapped = mapScopusEntry(entry);
+      if (mapped) results.push(mapped);
+    }
+
+    const total =
+      Number(data["search-results"]?.["opensearch:totalResults"]) || results.length;
+
+    breaker.onSuccess();
+    return { results, total, status: okStatus() };
+  } catch (error) {
+    breaker.onFailure();
+    console.error("[Scopus] Search failed:", error);
+    return { results: [], total: 0, status: classifyFetchError(error, { hasApiKey: true }) };
+  }
+}

--- a/src/lib/search/sources/springer.ts
+++ b/src/lib/search/sources/springer.ts
@@ -1,0 +1,203 @@
+/**
+ * Springer Nature source lane — OPTIONAL, ENV-GATED.
+ *
+ * Activates only when SPRINGER_API_KEY is present. With no key configured it is
+ * inert: it returns an empty, "missing_config" outcome and never throws, so it
+ * can sit in the fan-out without affecting behaviour until a key is wired in.
+ *
+ * Request contract (verified against the Springer Nature Developer Portal —
+ * https://dev.springernature.com/docs/api-endpoints/meta-api/):
+ *   GET https://api.springernature.com/meta/v2/json?q=<q>&p=<n>&s=<start>&api_key=<key>
+ *   `p` = page size, `s` = 1-based start index.
+ *
+ * Response: top-level `records[]` (plus a `result[]` summary with `total`). Each
+ * record carries `title`, `creators[].creator` ("Last, First"), `publicationName`,
+ * `publicationDate` (YYYY-MM-DD), `doi`, `abstract`, `openaccess` ("true"/"false"),
+ * and `url[]` ({ platform, format, value }) — filtered here for the web PDF link.
+ */
+
+import type { UnifiedSearchResult } from "@/types/search";
+import { getEvidenceLevel } from "@/lib/search/evidence-level";
+import { resilientFetch } from "@/lib/http/resilient-fetch";
+import { createCircuitBreaker } from "@/lib/http/circuit-breaker";
+import {
+  classifyFetchError,
+  okStatus,
+  type SourceStatus,
+} from "@/lib/search/source-status";
+
+const breaker = createCircuitBreaker({ service: "Springer", failureThreshold: 5 });
+
+/** Springer Meta caps the page size (`p`) at 100; default is 10. */
+const MAX_PAGE_SIZE = 100;
+
+/** Read the Springer key from env. */
+export function getSpringerApiKey(): string | undefined {
+  return process.env.SPRINGER_API_KEY || undefined;
+}
+
+interface SpringerSearchOptions {
+  limit?: number;
+  /** 1-based start index (Springer's `s` param). */
+  start?: number;
+  yearStart?: number;
+  yearEnd?: number;
+}
+
+interface SpringerCreator {
+  creator?: string;
+}
+
+interface SpringerUrl {
+  platform?: string;
+  format?: string;
+  value?: string;
+}
+
+export interface SpringerRecord {
+  title?: string;
+  creators?: SpringerCreator[];
+  publicationName?: string;
+  publicationDate?: string;
+  doi?: string;
+  abstract?: string;
+  /** "true" | "false" — Springer serialises the open-access flag as a string. */
+  openaccess?: string;
+  url?: SpringerUrl[];
+  contentType?: string;
+}
+
+interface SpringerResultSummary {
+  total?: string;
+}
+
+interface SpringerResponse {
+  result?: SpringerResultSummary[];
+  records?: SpringerRecord[];
+}
+
+/**
+ * Convert Springer's "Last, First" creator strings into natural "First Last"
+ * display order. Names without a comma are passed through untouched.
+ */
+export function extractSpringerAuthors(record: SpringerRecord): string[] {
+  return (record.creators ?? [])
+    .map((c) => c.creator?.trim())
+    .filter((n): n is string => Boolean(n))
+    .map((name) => {
+      const comma = name.indexOf(",");
+      if (comma === -1) return name;
+      const family = name.slice(0, comma).trim();
+      const given = name.slice(comma + 1).trim();
+      return given ? `${given} ${family}` : family;
+    });
+}
+
+/**
+ * Pick the best web link: prefer the PDF, then any HTML web link. Returns null
+ * when no `platform: "web"` link is present.
+ */
+export function extractSpringerPdfUrl(record: SpringerRecord): string | null {
+  const urls = (record.url ?? []).filter((u) => u.platform === "web" && u.value);
+  const pdf = urls.find((u) => u.format === "pdf");
+  if (pdf?.value) return pdf.value.replace(/^http:/, "https:");
+  const html = urls.find((u) => u.format === "html") ?? urls[0];
+  return html?.value ? html.value.replace(/^http:/, "https:") : null;
+}
+
+function yearFromPublicationDate(date?: string): number {
+  if (!date) return 0;
+  const m = date.match(/(\d{4})/);
+  return m ? parseInt(m[1], 10) : 0;
+}
+
+/** Map one Springer record to a UnifiedSearchResult. Returns null when untitled. */
+export function mapSpringerRecord(record: SpringerRecord): UnifiedSearchResult | null {
+  const title = record.title?.trim();
+  if (!title) return null;
+
+  const evidence = getEvidenceLevel("other");
+  const isOpenAccess = record.openaccess === "true";
+
+  return {
+    title,
+    authors: extractSpringerAuthors(record),
+    journal: record.publicationName?.trim() ?? "",
+    year: yearFromPublicationDate(record.publicationDate),
+    doi: record.doi || undefined,
+    abstract: record.abstract?.trim() || undefined,
+    citationCount: 0,
+    publicationTypes: [],
+    studyType: "other",
+    evidenceLevel: evidence.level,
+    isOpenAccess,
+    openAccessPdfUrl: isOpenAccess ? extractSpringerPdfUrl(record) : null,
+    sources: ["springer"],
+  };
+}
+
+export async function searchSpringer(
+  query: string,
+  opts: SpringerSearchOptions = {}
+): Promise<{ results: UnifiedSearchResult[]; total: number; status: SourceStatus }> {
+  const apiKey = getSpringerApiKey();
+  if (!apiKey) {
+    return {
+      results: [],
+      total: 0,
+      status: {
+        status: "missing_config",
+        message: "SPRINGER_API_KEY not set — Springer source disabled",
+      },
+    };
+  }
+
+  if (!breaker.canRequest()) {
+    return {
+      results: [],
+      total: 0,
+      status: { status: "error", message: "Circuit breaker open — recent Springer failures" },
+    };
+  }
+
+  const pageSize = Math.min(opts.limit || 20, MAX_PAGE_SIZE);
+  const start = opts.start ?? 1;
+
+  let searchQuery = query;
+  if (opts.yearStart || opts.yearEnd) {
+    const startYear = opts.yearStart || 1900;
+    const endYear = opts.yearEnd || new Date().getFullYear();
+    // Springer's constraint syntax: onlinedatefrom / onlinedateto (YYYY-MM-DD).
+    searchQuery += ` onlinedatefrom:${startYear}-01-01 onlinedateto:${endYear}-12-31`;
+  }
+
+  const url =
+    `https://api.springernature.com/meta/v2/json` +
+    `?q=${encodeURIComponent(searchQuery)}` +
+    `&p=${pageSize}&s=${start}&api_key=${encodeURIComponent(apiKey)}`;
+
+  try {
+    const res = await resilientFetch(
+      url,
+      { headers: { Accept: "application/json" } },
+      { service: "Springer", timeout: 8000, maxRetries: 1 }
+    );
+    const data: SpringerResponse = await res.json();
+
+    const rawRecords = data.records ?? [];
+    const results: UnifiedSearchResult[] = [];
+    for (const record of rawRecords) {
+      const mapped = mapSpringerRecord(record);
+      if (mapped) results.push(mapped);
+    }
+
+    const total = Number(data.result?.[0]?.total) || results.length;
+
+    breaker.onSuccess();
+    return { results, total, status: okStatus() };
+  } catch (error) {
+    breaker.onFailure();
+    console.error("[Springer] Search failed:", error);
+    return { results: [], total: 0, status: classifyFetchError(error, { hasApiKey: true }) };
+  }
+}


### PR DESCRIPTION
## The root cause this fixes
The live academic tab (`/api/search/unified?tab=academic`) used a **separate, inferior fan-out** than `runLiteratureSearch` — it had **no MedCPT dense lane** and included **ClinicalTrials.gov + arXiv**. So every ranking/dense fix from #111/#113/#114 landed in a pipeline the live tab never called, and when OpenAlex went down the live tab collapsed to trial protocols.

## What changed
- **Route the live academic tab → `runLiteratureSearch`** (the keystone) — the live tab now gets the dense corpus + reranker + quality-ranker, and ClinicalTrials/arXiv are gone from literature (trials remain via the dedicated route).
- **Drop OpenAlex + Semantic Scholar** entirely (flaky / commercial-license risk). `SEARCH_SOURCES = [pubmed, europepmc]`.
- **Add Europe PMC** — free, no key, biomedical-first, carries abstracts + citations + OA links.
- **Dense corpus = guaranteed floor** — awaited outside the fan-out deadline on its own 9s timeout; always contributes even if every lexical lane is dropped.
- **Env-gated Scopus + Springer lanes** added (inert until keys are wired — follow-up activates them).

## Live proof (real pipeline)
**"management of contrast-induced nephropathy"** → `pubmed:777, europepmc:4994, medcpt_dense:25` (no OpenAlex/S2/trials/arXiv). Top-10 all on-topic CIN papers (Update on CIN prevention/diagnosis/therapy 2026, Biomarkers in CIN 2025, hydration-alternatives 2024…). Same for HFpEF.

## Tests
tsc + eslint clean · **490 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEgTUohzwMogXKPsWVdwJx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional support for additional literature sources, including Europe PMC, Scopus, and Springer.
  * Updated academic search routing to use a streamlined source set and improved resilience when one source is unavailable.
  * Added clearer source labels and updated domain source availability across search areas.

* **Bug Fixes**
  * Improved fallback behavior so searches continue returning results during upstream outages.
  * Refined result handling, sorting, and pagination for academic searches.

* **Documentation**
  * Updated setup guidance and resilience notes for literature search.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->