### PR TITLE
feat(search): activate Scopus + Springer literature lanes

### DIFF
--- a/src/lib/mcp/__tests__/tools.test.ts
+++ b/src/lib/mcp/__tests__/tools.test.ts
@@ -127,8 +127,17 @@ describe("search_papers input schema", () => {
     expect(() => schema.parse({ query: "x", maxResults: 51 })).toThrow();
   });
 
+  it("accepts the valid sources (pubmed, europepmc, scopus, springer)", () => {
+    expect(() =>
+      schema.parse({
+        query: "x",
+        sources: ["pubmed", "europepmc", "scopus", "springer"],
+      })
+    ).not.toThrow();
+  });
+
   it("rejects unknown sources", () => {
-    expect(() => schema.parse({ query: "x", sources: ["scopus"] })).toThrow();
+    expect(() => schema.parse({ query: "x", sources: ["openalex"] })).toThrow();
   });
 });
 
@@ -162,14 +171,17 @@ describe("get_search_capabilities tool", () => {
     expect(caps.sources.map((s) => s.id)).toEqual([
       "pubmed",
       "europepmc",
+      "scopus",
+      "springer",
     ]);
     expect(caps.limits.maxResults).toBe(50);
     expect(caps.outputFields).toContain("doi");
     expect(caps.outputFields).toContain("evidenceLevel");
     expect(caps.outputFields).toContain("whyRelevant");
-    // Both active literature sources (PubMed + Europe PMC) are on by default.
+    // All four active literature sources (PubMed + Europe PMC + Scopus + Springer)
+    // are on by default.
     const defaults = caps.sources.filter((s) => s.default).map((s) => s.id);
-    expect(defaults).toEqual(["pubmed", "europepmc"]);
+    expect(defaults).toEqual(["pubmed", "europepmc", "scopus", "springer"]);
   });
 });
 

--- a/src/lib/mcp/tools.ts
+++ b/src/lib/mcp/tools.ts
@@ -232,4 +232,8 @@ const SOURCE_DESCRIPTIONS: Record<SearchSourceId, string> = {
   pubmed: "PubMed / MEDLINE — biomedical literature with MeSH and evidence levels",
   europepmc:
     "Europe PMC — biomedical literature and preprints with native citation counts and open-access links",
+  scopus:
+    "Scopus (Elsevier) — broad multidisciplinary abstracts and citation counts",
+  springer:
+    "Springer Nature — journal and book full text with open-access PDF links",
 };

--- a/src/lib/search/run-search.ts
+++ b/src/lib/search/run-search.ts
@@ -10,6 +10,8 @@
 
 import { searchPubMed } from "@/lib/search/sources/pubmed";
 import { searchEuropePMC } from "@/lib/search/sources/europepmc";
+import { searchScopus } from "@/lib/search/sources/scopus";
+import { searchSpringer } from "@/lib/search/sources/springer";
 import { searchMedcptDense } from "@/lib/search/sources/medcpt-dense";
 import { fetchCrossrefByDoi } from "@/lib/search/sources/crossref";
 import { searchClinicalTrials } from "@/lib/search/sources/clinical-trials";
@@ -32,18 +34,26 @@ import { assessConfidence, type Confidence } from "@/lib/search/confidence";
 import { backfillPmidsByDoi } from "@/lib/search/pmid-backfill";
 import type { UnifiedSearchResult } from "@/types/search";
 
-export const SEARCH_SOURCES = ["pubmed", "europepmc"] as const;
+export const SEARCH_SOURCES = ["pubmed", "europepmc", "scopus", "springer"] as const;
 export type SearchSourceId = (typeof SEARCH_SOURCES)[number];
 
 /**
  * Sources used when a caller does not specify any. PubMed-first for clinical
  * relevance; Europe PMC for open-access links AND native citation counts (its
- * `citedByCount` replaces the dropped OpenAlex citation-enrichment step). Both
- * are throttle-tolerant biomedical lexical lanes. OpenAlex and Semantic Scholar
- * were removed from the pipeline; the owned MedCPT dense lane is the recall
- * backbone and always contributes (see the guaranteed-floor logic below).
+ * `citedByCount` replaces the dropped OpenAlex citation-enrichment step). Scopus
+ * adds broad multidisciplinary coverage plus its own `citedby-count`; Springer
+ * Nature adds book/journal full text and open-access PDFs. All four are
+ * throttle-tolerant lexical lanes, each key-gated so an unconfigured lane stays
+ * inert (missing_config) rather than degrading search. OpenAlex and Semantic
+ * Scholar were removed from the pipeline; the owned MedCPT dense lane is the
+ * recall backbone and always contributes (see the guaranteed-floor logic below).
  */
-export const DEFAULT_SOURCES: SearchSourceId[] = ["pubmed", "europepmc"];
+export const DEFAULT_SOURCES: SearchSourceId[] = [
+  "pubmed",
+  "europepmc",
+  "scopus",
+  "springer",
+];
 
 /** Hard ceiling on results per search, shared across web and MCP transports. */
 export const MAX_RESULTS = 50;
@@ -480,6 +490,44 @@ async function runLiteratureSearchUncached(
           yearEnd: params.yearTo,
         }).then(({ results, total, status }) => ({ source: "europepmc", results, total, status }))
       ).catch((e) => errorOutcome("europepmc", e instanceof Error ? e.message : "Europe PMC failed"))
+    );
+  }
+
+  // Scopus (Elsevier): a broad multidisciplinary lexical lane carrying its own
+  // `citedby-count`. Wired exactly like the PubMed / Europe PMC lanes — same year
+  // filters and withSourceTimeout pattern, fed into the same RRF fusion. Key-gated
+  // internally: without ELSEVIER_API_KEY / SCOPUS_API_KEY it returns an empty
+  // missing_config outcome and never throws, so it is safe to always include here.
+  if (sources.includes("scopus")) {
+    pushLane(
+      "scopus",
+      withSourceTimeout(
+        "Scopus",
+        searchScopus(searchQuery, {
+          limit: poolPerSource,
+          yearStart: params.yearFrom,
+          yearEnd: params.yearTo,
+        }).then(({ results, total, status }) => ({ source: "scopus", results, total, status }))
+      ).catch((e) => errorOutcome("scopus", e instanceof Error ? e.message : "Scopus failed"))
+    );
+  }
+
+  // Springer Nature: journal/book full text with native open-access PDF links.
+  // Wired exactly like the other lexical lanes — same year filters and
+  // withSourceTimeout pattern, fused via the same RRF. Key-gated internally:
+  // without SPRINGER_API_KEY it returns an empty missing_config outcome and never
+  // throws, so it is safe to always include in the fan-out.
+  if (sources.includes("springer")) {
+    pushLane(
+      "springer",
+      withSourceTimeout(
+        "Springer",
+        searchSpringer(searchQuery, {
+          limit: poolPerSource,
+          yearStart: params.yearFrom,
+          yearEnd: params.yearTo,
+        }).then(({ results, total, status }) => ({ source: "springer", results, total, status }))
+      ).catch((e) => errorOutcome("springer", e instanceof Error ? e.message : "Springer failed"))
     );
   }
 

--- a/src/lib/search/sources/scopus.ts
+++ b/src/lib/search/sources/scopus.ts
@@ -149,9 +149,14 @@ export async function searchScopus(
 
   const count = Math.min(opts.limit || 20, MAX_COUNT);
   const start = opts.start ?? 0;
-  const view = opts.view ?? "COMPLETE";
+  // STANDARD is the entitlement a plain API key carries; COMPLETE needs an
+  // institutional subscription token (X-ELS-Insttoken) and 401s without it.
+  const view = opts.view ?? "STANDARD";
 
-  let searchQuery = query;
+  // Field-scope the query to title/abstract/keywords — a bare term string searches
+  // everything (affiliations, refs) and dilutes relevance; TITLE-ABS-KEY is the
+  // standard relevance search and is what a plain key is entitled to run.
+  let searchQuery = `TITLE-ABS-KEY(${query})`;
   if (opts.yearStart || opts.yearEnd) {
     const startYear = opts.yearStart || 1900;
     const endYear = opts.yearEnd || new Date().getFullYear();


### PR DESCRIPTION
Follow-up to #115. The Scopus + Springer adapters shipped env-gated; keys are now provisioned (Vercel prod+preview + op-run), so this wires them into the `runLiteratureSearch` fan-out and `SEARCH_SOURCES`/`DEFAULT_SOURCES`.

Also fixes the Scopus lane: default to `STANDARD` view (COMPLETE 401s without an institutional token) and field-scope with `TITLE-ABS-KEY` for relevance.

**Live-verified all five lanes contribute:**
- "management of resistant hypertension" → pubmed 1148, europepmc 62983, scopus 2777, springer 65428, dense 25
- "aortic stenosis amyloidosis" → pubmed 629, europepmc 4418, scopus 778, springer 3885, dense 25

Active literature set is now **PubMed + Europe PMC + Scopus + Springer + dense corpus**. 478 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEgTUohzwMogXKPsWVdwJx