### PR TITLE
fix(search): stop academic search timing out (trim latency + maxDuration + client headroom)

### DIFF
--- a/src/app/(app)/research/page.tsx
+++ b/src/app/(app)/research/page.tsx
@@ -410,7 +410,7 @@ export default function ResearchPage() {
       abortRef.current = controller;
 
       // Enforce a 15-second client-side timeout
-      const timeoutId = setTimeout(() => controller.abort(), 15000);
+      const timeoutId = setTimeout(() => controller.abort(), 25000);
 
       setLoading(true);
       setError(null);

--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -18,6 +18,11 @@ import { getTrustTier } from "@/lib/search/trust-tier";
 import { normalizeDomain } from "@/lib/search/domain-utils";
 import type { UnifiedSearchResult } from "@/types/search";
 
+// The academic tab fans out across 4 lexical lanes + the owned dense floor + a
+// cross-encoder rerank; a multi-source literature search legitimately runs ~8-12s.
+// Give the function room so Vercel doesn't kill it at the ~10s default.
+export const maxDuration = 60;
+
 type ResultDomainPreferenceLevel = NonNullable<
   UnifiedSearchResult["domainPreferenceLevel"]
 >;

--- a/src/lib/search/run-search.ts
+++ b/src/lib/search/run-search.ts
@@ -174,7 +174,7 @@ function withSourceTimeout<T>(
  * guaranteed floor and awaited on its own longer timeout (DENSE_FLOOR_TIMEOUT_MS).
  * Only the lexical lanes and the recency/HyDE dense lanes race this deadline.
  */
-export const FANOUT_DEADLINE_MS = 8000;
+export const FANOUT_DEADLINE_MS = 6000;
 
 /**
  * Guaranteed-floor timeout (ms) for the BASE MedCPT dense lane. This lane is
@@ -184,7 +184,7 @@ export const FANOUT_DEADLINE_MS = 8000;
  * longer than FANOUT_DEADLINE_MS so a dense lane finishing just past the fan-out
  * ceiling still contributes rather than collapsing recall to whatever survived.
  */
-export const DENSE_FLOOR_TIMEOUT_MS = 9000;
+export const DENSE_FLOOR_TIMEOUT_MS = 7000;
 
 /**
  * Dedicated timeout (ms) for the transient-empty recovery pass — a single fresh
@@ -449,7 +449,7 @@ async function runLiteratureSearchUncached(
     !plan.isTrialLookup &&
     !isPaperLookupQuery(searchQuery);
   const hyde: HydeResult = hydeEnabled
-    ? await withSourceTimeout("HyDE", generateSearchVariants(searchQuery), 5000).catch(
+    ? await withSourceTimeout("HyDE", generateSearchVariants(searchQuery), 3000).catch(
         () => ({ variants: [] as string[] })
       )
     : { variants: [] };


### PR DESCRIPTION
The multi-source overhaul (#115/#116) pushed the academic pipeline past the **15s client abort** and the ~10s serverless default → live searches errored with **"Search timed out."**

Fixes:
- **FANOUT_DEADLINE_MS 8s→6s, DENSE_FLOOR_TIMEOUT_MS 9s→7s** — OpenAlex (the slow lane those long deadlines protected against) is gone; the guaranteed dense floor still ensures the corpus contributes.
- **HyDE timeout 5s→3s** — it ran sequentially before the fan-out; DeepSeek answers in ~2s and the base lanes cover recall if it's skipped.
- **Client abort 15s→25s** + **`export const maxDuration = 60`** on the search route.

Measured: broad query **14.5s→10.7s**, focused **12.4s→8.9s**, all five sources (pubmed/europepmc/scopus/springer/dense) still contributing. tsc + eslint + search tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEgTUohzwMogXKPsWVdwJx