### PR TITLE
fix(search): honest pagination (cap navigable total + show real match count) + keep-warm cron

### DIFF
--- a/src/app/(app)/research/page.tsx
+++ b/src/app/(app)/research/page.tsx
@@ -209,6 +209,7 @@ export default function ResearchPage() {
   const [hasSearched, setHasSearched] = useState(false);
   const [page, setPage] = useState(0);
   const [totalResults, setTotalResults] = useState(0);
+  const [matchedTotal, setMatchedTotal] = useState(0);
   const [hasMore, setHasMore] = useState(false);
   const [augmentedQueries, setAugmentedQueries] = useState<
     SearchResponse["augmentedQueries"] | null
@@ -431,6 +432,7 @@ export default function ResearchPage() {
         const data: SearchResponse = await res.json();
         setResults(data.results);
         setTotalResults(data.total);
+        setMatchedTotal(data.matchedTotal ?? data.total);
         setHasMore(data.hasMore);
         setSourceCounts(data.sourceCounts);
         setSourceStatuses(data.sourceStatuses || {});
@@ -845,7 +847,9 @@ export default function ResearchPage() {
                   </span>
                 )
               )}{" "}
-              — {totalResults} total results
+              — {matchedTotal > totalResults
+                ? `${matchedTotal.toLocaleString()} papers matched across sources · showing the top ${totalResults}`
+                : `${totalResults} results`}
             </p>
             {augmentedQueries && (
               <button

--- a/src/app/api/cron/warm/route.ts
+++ b/src/app/api/cron/warm/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+import { runLiteratureSearch } from "@/lib/search/run-search";
+
+// A low-traffic serverless app scales to zero, so the FIRST user search after idle
+// pays a cold start (Modal dense endpoint + the function itself) and can blow past
+// the client abort. This cron exercises the real literature pipeline on a schedule
+// so the owned dense lane, the reranker, and the upstream connections stay warm and
+// the result cache stays primed. Scheduled from vercel.json.
+export const maxDuration = 30;
+export const dynamic = "force-dynamic";
+
+const WARM_QUERY = "recent advances in cardiology";
+
+export async function GET(request: Request) {
+  const secret = process.env.CRON_SECRET;
+  // Vercel Cron sends `Authorization: Bearer <CRON_SECRET>`. If the secret is
+  // configured, require it — so the endpoint can't be spammed to run searches.
+  if (secret) {
+    const auth = request.headers.get("authorization");
+    if (auth !== `Bearer ${secret}`) {
+      return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+    }
+  }
+
+  const startedAt = Date.now();
+  try {
+    const r = await runLiteratureSearch({ query: WARM_QUERY, perPage: 1 });
+    return NextResponse.json({
+      ok: true,
+      warmedMs: Date.now() - startedAt,
+      sources: Object.keys(r.sourceCounts),
+    });
+  } catch (error) {
+    // Never fail the cron — a warm miss is not an incident.
+    return NextResponse.json({
+      ok: false,
+      warmedMs: Date.now() - startedAt,
+      error: error instanceof Error ? error.message : "warm failed",
+    });
+  }
+}

--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -478,6 +478,7 @@ export async function GET(req: Request) {
     const response: SearchResponse = {
       results,
       total,
+      matchedTotal: literature.matchedTotal,
       page,
       perPage,
       hasMore,

--- a/src/lib/mcp/__tests__/tools.test.ts
+++ b/src/lib/mcp/__tests__/tools.test.ts
@@ -56,6 +56,7 @@ describe("search_papers tool", () => {
     mockedRun.mockResolvedValue({
       results: [makePaper()],
       total: 1,
+      matchedTotal: 1,
       page: 0,
       perPage: 10,
       hasMore: false,

--- a/src/lib/search/run-search.ts
+++ b/src/lib/search/run-search.ts
@@ -107,7 +107,10 @@ export type LiteraturePaper = UnifiedSearchResult & {
 
 export interface LiteratureSearchResult {
   results: LiteraturePaper[];
+  /** Navigable result count (capped to {@link MAX_NAVIGABLE_RESULTS}) — drives pagination. */
   total: number;
+  /** True cross-source match count (uncapped) — for an honest "N papers matched" context line. */
+  matchedTotal: number;
   page: number;
   perPage: number;
   hasMore: boolean;
@@ -213,6 +216,13 @@ export function recencyYearFloor(currentYear: number, windowYears: number): numb
 // Cap for the post-fusion rerank pool. Only the top candidates by RRF score can
 // reach the returned page, so reranking beyond this is wasted work.
 export const POST_FUSION_POOL = 50;
+
+// Cap the navigable page count. `total` used to be the largest source's raw hit
+// count (millions), so the UI showed "page 2 of 340,000 pages" — but we only fetch
+// + fuse + rerank a bounded pool per page, source APIs cap deep pagination (~10k
+// offset), and relevance degrades fast past the first pages. Bound navigable pages
+// to an honest depth; the true cross-source match count is surfaced as `matchedTotal`.
+export const MAX_NAVIGABLE_RESULTS = 200;
 
 const DEADLINE = Symbol("fanout-deadline");
 
@@ -835,12 +845,14 @@ async function runLiteratureSearchUncached(
     inLibrary: false,
   }));
 
+  const navigableTotal = Math.min(maxTotal, MAX_NAVIGABLE_RESULTS);
   return {
     results,
-    total: maxTotal,
+    total: navigableTotal,
+    matchedTotal: maxTotal,
     page,
     perPage,
-    hasMore: filtered.length > perPage,
+    hasMore: filtered.length > perPage && (page + 1) * perPage < navigableTotal,
     sourceCounts,
     sourceStatuses,
     confidence: assessConfidence(pageResults),

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -102,7 +102,10 @@ export interface SearchFilters {
 
 export interface SearchResponse {
   results: UnifiedSearchResult[];
+  /** Navigable result count (capped) — drives pagination. */
   total: number;
+  /** True cross-source match count (uncapped) — for an honest "N papers matched" line. */
+  matchedTotal?: number;
   page: number;
   perPage: number;
   hasMore: boolean;

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "crons": [
+    {
+      "path": "/api/cron/warm",
+      "schedule": "*/5 * * * *"
+    }
+  ]
+}


### PR DESCRIPTION
Two polish fixes from the live re-test.

## Honest pagination
`total` was the largest source's raw hit count (millions), so the UI showed **"page 2 of 340,000 pages"** — but we only fetch/fuse/rerank a bounded pool and the source APIs cap deep pagination (~10k). Now:
- Navigable `total` is capped to `MAX_NAVIGABLE_RESULTS` (200) → honest page count
- The true cross-source match count is surfaced as `matchedTotal` → shown as **"N papers matched across sources · showing the top 200"**, so the richness signal stays but is truthful

The top results were always correctly fetched + RRF-fused + cross-encoder reranked — only the page *count* was inflated.

## Keep-warm cron
First user search after idle paid a cold start and could time out. Add `/api/cron/warm` (secured by `CRON_SECRET`, set in Vercel) + a `vercel.json` cron that exercises the literature pipeline every 5 min, keeping the dense lane + reranker + connections warm and the cache primed.

tsc + eslint + 478 search/mcp tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEgTUohzwMogXKPsWVdwJx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a scheduled background warm-up task to keep search responses ready and improve responsiveness.
  * Search results now show a clearer count when more papers match than are shown on screen.
  * Unified search responses now include a more accurate total for matched papers across sources.

* **Bug Fixes**
  * Improved pagination behavior so the displayed result count better reflects what can actually be browsed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->