### PR TITLE
fix(deploy): remove */5 cron that broke the Hobby build

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,0 @@
-{
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "crons": [
-    {
-      "path": "/api/cron/warm",
-      "schedule": "*/5 * * * *"
-    }
-  ]
-}


### PR DESCRIPTION
The `*/5` keep-warm cron in vercel.json fails the build on a Hobby account ("limited to daily cron jobs"), which blocked #118's deploy (auto and manual) and left `main` un-deployable. Remove it. The `/api/cron/warm` route stays and can be pinged by an external uptime service (or a Vercel Pro cron) for keep-warm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEgTUohzwMogXKPsWVdwJx