### PR TITLE
feat(search): Phase 1 — free reranker + whole-pool rerank + citation signal (top-10 74%→83%)

### DIFF
--- a/docs/literature-search/DEEP-IR-STUDY-2026-07.md
+++ b/docs/literature-search/DEEP-IR-STUDY-2026-07.md
@@ -1,0 +1,667 @@
+# Deep IR / Rerank Literature Study — Biomedical Academic Search (2026-07)
+
+**Purpose.** Implementation-grade evidence base for fixing four *measured* failures in the
+academic-retrieval engine (federated: MedCPT-dense + PubMed + Europe PMC + Springer +
+Elsevier/Scopus + SerpAPI Scholar; RRF k=60 fusion; Cohere `rerank-4-pro` reranks top-50).
+Goes deeper than the prior survey: concrete parameter values, ablation numbers, algorithm
+details, and OSS pointers. Every claim is labeled **CONFIRMED** (stated in the cited source)
+or **INFERRED** (synthesis/arithmetic). Cited by URL/paper throughout.
+
+The four measured failures this study answers to:
+- **F1 — Ranking, not retrieval.** Landmarks are in the fused pool 90% of the time but reach
+  top-10 only 74% (16-pt buried-then-lost gap).
+- **F2 — Rerank coverage + score mixing.** Reranker rescores top-50 of a 100–190 pool, but the
+  final sort runs over the WHOLE pool; un-reranked lexical scores saturate ~1.0 and beat
+  calibrated cross-encoder scores (0.4–0.7).
+- **F3 — Older landmark RCTs buried** (PARTNER 3, ARISTOTLE, Evolut, EMPEROR-Reduced all
+  in-pool, out of top-10), plausibly worsened by a multiplicative recency boost.
+- **F4 — Query-phrasing sensitivity** (same landmark found under one phrasing, missed under
+  another).
+
+---
+
+## 0. Executive summary — the recipe the literature supports
+
+1. **Rerank the whole pool, sort ONLY on the reranker, append the un-reranked tail below —
+   never interleave by raw score.** This single change fixes F2 and most of F1. The
+   "un-reranked-item-with-higher-raw-score-wins-global-sort" bug is documented verbatim in a
+   production engine (Elasticsearch #120670) and is provably worse than even *tuned* linear
+   interpolation (Askari et al. 2024: tuned BM25+CE interpolation MRR@10 0.290 < CE-alone
+   0.342). **[CONFIRMED]**
+2. **Stop using RRF as the final arbiter.** RRF structurally caps a single-lane item at
+   `1/(k+1) = 1/61 ≈ 0.0164`; a mediocre two-lane item easily scores ~0.028 (+72%). Use
+   RRF/weighted-RRF only as a *recall-oriented pool builder with per-lane guaranteed top-N
+   inclusion*, then let a union-pool cross-encoder (or a convex-combination score, α≈0.8) decide
+   final order. Fixes F1's single-lane burial. **[CONFIRMED formula; INFERRED arithmetic]**
+3. **Recency = mild additive/learned feature; citations = monotone log landmark feature.
+   Kill the multiplicative recency boost.** Every validated academic ranker (PubMed Best Match,
+   Semantic Scholar, Dong 2010, Dai 2011) does this; multiplicative boosts scale unpredictably
+   against query-varying relevance magnitudes. Fixes F3. **[CONFIRMED]**
+4. **Query understanding: document-side doc2query at index time + ontology/MeSH+acronym
+   expansion + 3–5 LLM query variants fused by RRF.** Ontology-grounded expansion is the single
+   biggest lever for the EMPA-REG↔SGLT2-CVOT paraphrase case and the most *robustness*-improving
+   technique measured (+15.7% under query perturbation). Fixes F4. **[CONFIRMED]**
+5. **Reranker choice: deploy the free biomedical-native MedCPT-CE now; keep Cohere for a narrow
+   final tier; add listwise LLM rerank only as an optional async premium for hard queries.**
+   The cross-encoder is the workhorse; listwise LLM adds ~+2–3 nDCG@10 at ~80× latency.
+   **[CONFIRMED]**
+
+---
+
+## A. Rerank coverage, depth, and score combination (→ F1, F2)
+
+### A.1 How deep to rerank vs pool size
+
+| System | Retrieve | Rerank depth | Final sort | Source |
+|---|---|---|---|---|
+| sentence-transformers "Retrieve & Re-Rank" | top-100 | **all 100** | **by CE score only** | [sbert docs](https://sbert.net/examples/sentence_transformer/applications/retrieve_rerank/README.html) **[CONFIRMED]** |
+| BEIR reference "BM25+CE" | top-100 | **top-100** | by CE score | [BEIR arXiv:2104.08663](https://arxiv.org/pdf/2104.08663), [benchmark script](https://github.com/UKPLab/beir/blob/main/examples/benchmarking/benchmark_bm25_ce_reranking.py) **[CONFIRMED]** |
+| Expando-Mono-Duo (pyserini) | BM25 top-1000 | monoT5 over **~1000**, duoT5 over **top-50** (O(n²)) | cascade | [arXiv:2101.05667](https://arxiv.org/pdf/2101.05667) **[CONFIRMED]** |
+| rank_llm (listwise) | top-100 | window 20 / stride 10 over **100** | permutation | [castorini/rank_llm](https://github.com/castorini/rank_llm) **[CONFIRMED]** |
+| Cohere Rerank | ≤1000 docs/request | all sent docs scored; `top_n` limits *returned* | by rerank score | [Cohere best practices](https://docs.cohere.com/docs/reranking-best-practices) **[CONFIRMED]** |
+| Pinecone hosted rerank | — | **max 100 docs** | by rerank score | [Pinecone rerank](https://docs.pinecone.io/guides/search/rerank-results) **[CONFIRMED]** |
+
+**Key point for our engine:** the de-facto standard is *retrieve wide (100–1000), rerank a fixed
+top-N (50–100), sort ONLY the reranked subset by the reranker, place reranked items above
+everything not reranked.* No mainstream default sorts a full mixed-score pool — that is precisely
+our F2 anti-pattern. **[CONFIRMED across sbert/BEIR/Cohere/Pinecone/OpenSearch]**
+
+**Depth cost/quality curve.** A reported cross-encoder ablation: Recall@5 = **0.458 @ depth20 →
+0.826 @ depth50 → 0.888 @ depth100** — sharp gains through 50, flattening after. **[CONFIRMED,
+industry blog — directional, not peer-reviewed]** ([GenAI Revolution](https://blog.thegenairevolution.com/article/cross-encoder-reranking-the-low-cost-fix-for-rag-misses)).
+A second source: "with only 20 candidates reranking is ineffective… performance increases sharply
+at 50 and continues to improve at 100." **[CONFIRMED]** ([arXiv:2604.01733](https://arxiv.org/html/2604.01733v1)).
+For our 100–190 pool, Cohere rerank-4-pro accepts ≤1000 docs in **one** API round-trip (not
+per-pair GPU time), so **reranking the entire pool costs one call, not N calls** — the marginal
+cost of 50→190 is negligible. **[CONFIRMED cap; INFERRED cost implication]**
+
+### A.2 How to combine first-stage and reranker scores — and the evidence AGAINST averaging
+
+**The dominant production pattern is (a): pure reorder by reranker score over the reranked
+subset; the first-stage score is discarded for ordering within that subset.** (sbert, BEIR,
+Cohere, Pinecone, OpenSearch rerank processor.) **[CONFIRMED]**
+
+**Smoking gun against linear averaging — Askari et al., "Injecting the score of the first-stage
+retriever as text improves BERT-based re-rankers"** ([arXiv:2301.09728](https://arxiv.org/abs/2301.09728),
+Discover Computing 2024, [DOI](https://link.springer.com/article/10.1007/s10791-024-09435-8)).
+MS MARCO Dev MRR@10 **[CONFIRMED]**:
+- BM25 alone: **0.187**
+- BERT cross-encoder alone: **0.342**
+- **tuned linear interpolation `α·BM25 + (1−α)·CE`, best α=0.1: 0.290** ← *worse than CE alone*
+- Direct quotes: "a linear combination of the two scores has shown to **decrease effectiveness**…
+  compared to only using the CE re-ranker"; "linear and non-linear (MLP) interpolation… **even
+  leads to lower effectiveness** than using the cross-encoder as sole re-ranker"; optimum at
+  α=0.1 means "BM25 wants to be nearly zero-weighted."
+
+Since even a *tuned* interpolation underperforms CE-alone, our *un-tuned, un-normalized* global
+sort mixing saturated RRF/lexical scores (~1.0) with calibrated CE scores (0.4–0.7) is strictly
+worse. **[CONFIRMED premise; INFERRED "strictly worse" step]**
+
+**Why raw combination fails — calibration mismatch.** BM25/cosine/RRF scores "exist in different
+spaces and come from different distributions"; naive weighted combination is "flawed" and BM25
+outliers saturate and compress everything else. Cohere itself warns rerank scores are "useful for
+ranking but not for direct comparison." **[CONFIRMED]** ([OpenSearch RRF](https://opensearch.org/blog/introducing-reciprocal-rank-fusion-hybrid-search/),
+[Cohere best practices](https://docs.cohere.com/docs/reranking-best-practices)).
+
+**The exact bug, in a production engine — Elasticsearch #120670.** `text_similarity_reranker`
+enforces a `rank_window_size`; but when the reranker returns low/negative scores, **un-reranked
+documents leak past the window and mix into the top** — "looks outside rank_window_size when
+returned scores are negative… if you force the scores to be positive, it will work as expected."
+Structurally identical to our F2. The ecosystem fix is a *hard* window boundary: reranked-on-top,
+non-reranked strictly below. **[CONFIRMED]** ([elastic/elasticsearch#120670](https://github.com/elastic/elasticsearch/issues/120670)).
+
+### A.3 Correct alternatives (ranked for our situation)
+
+- **(A) Pure reorder** — reranked subset by reranker score, non-reranked tail appended below in
+  first-stage order. Matches every standard system; **zero parameters; fixes F2 alone.**
+  **[CONFIRMED as standard]**
+- **(B) Rank-based fusion (RRF) of reranker-rank with first-stage-rank** — `1/(k+rank)`, k=60,
+  on *ranks* not scores → immune to saturation. Consistent with our existing k=60 lane fusion;
+  calibration-free. Use if we want first-stage signal to survive as a tie-break. **[CONFIRMED]**
+- **(C) Normalize then weighted sum** — Weaviate `relativeScoreFusion` (min-max, weight `alpha`
+  default 0.5) or z-score/DBSF. **Min-max is outlier-sensitive** (a single saturated BM25 score
+  compresses the rest — exactly our problem); **z-score/DBSF is more robust.** **[CONFIRMED]**
+  ([Weaviate fusion](https://weaviate.io/blog/hybrid-search-fusion-algorithms)).
+- **(D) Calibrate reranker scores (Platt / isotonic) then threshold** — Platt for small
+  calibration sets; isotonic when you have enough labels (corrects any monotonic distortion).
+  Overkill unless you need cross-query-comparable scores or a hard relevance threshold; for pure
+  ordering, (A)/(B) suffice with no training data. **[CONFIRMED methods; INFERRED "overkill"]**
+  ([Regression-Compatible Listwise Objectives, arXiv:2211.01494](https://arxiv.org/pdf/2211.01494)).
+
+**Consensus:** rank-based fusion (RRF) is the most robust, lowest-tuning method; score
+normalization retains more info but is outlier-sensitive; **never raw weighted sum without
+normalization.** **[CONFIRMED]**
+
+### A.4 What to do with candidates OUTSIDE the rerank depth
+
+Correct behavior: **reranked items (by reranker score) at the top; non-reranked candidates
+appended below in first-stage order; never interpolated into the same score space, never
+interleaved.** Options assessed: *interleave by raw score* = WRONG (our current design, the
+documented failure); *drop* = acceptable if rerank depth ≥ result count and depth-recall is high;
+**append-below-in-first-stage-order = RECOMMENDED default** (what Elastic's window semantics
+enforce). **[CONFIRMED behavior; INFERRED recommendation]**
+
+---
+
+## B. Fusion for single-lane recall (→ F1)
+
+### B.1 RRF mechanics and the burial mechanism
+
+**Cormack, Clarke & Büttcher, SIGIR 2009** ([PDF](https://cormack.uwaterloo.ca/cormacksigir09-rrf.pdf)):
+`RRFscore(d) = Σ_lanes 1/(k + rank_lane(d))`, k=60. **[CONFIRMED]** k=60 was chosen empirically
+(best on their LETOR-3 validation), not derived; `+k` smooths the rank-1→rank-2 gap so a single
+lane's top hit cannot swamp multi-lane agreement. RRF beat Condorcet Fuse, CombMNZ, and every
+individual LTR method. **[CONFIRMED qualitatively; exact MAP table not machine-extractable —
+image PDF]**
+
+**The burial arithmetic (INFERRED from the confirmed formula):**
+- Single-lane landmark at rank 1: `1/(60+1) = 0.01639`.
+- Mediocre item found by two lanes at ranks 10, 12: `1/70 + 1/72 = 0.02818` — **~72% higher.**
+- A single-lane item is *structurally capped* at `1/61 ≈ 0.0164` regardless of relevance — RRF
+  has **no notion** of "one lane found this at rank 1 because it is the definitive paper." This
+  is the root cause of PubMed-only landmark burial (F1). **[INFERRED arithmetic; CONFIRMED cap]**
+
+### B.2 Weighted RRF
+
+Elastic/OpenSearch: each retriever contributes `weight × 1/(rank + rank_constant)`,
+`rank_constant=60` default, weights ≥0. **[CONFIRMED]** ([Elastic weighted RRF](https://www.elastic.co/search-labs/blog/weighted-reciprocal-rank-fusion-rrf)).
+Giving PubMed weight `w=3`, a PubMed-only rank-1 landmark scores `3×1/61 = 0.0492`, now beating
+the two-lane mediocre item (0.0282). **Per-source weighting is the cheapest lever to keep a
+trusted lane competitive** — but blunt: it boosts *everything* that lane returns and still
+"ignores raw scores," so it cannot tell a confident rank-1 from an unconfident one. **[CONFIRMED
+formula; INFERRED arithmetic]**
+
+### B.3 Convex combination beats RRF — Bruch et al., "An Analysis of Fusion Functions for Hybrid Retrieval" (TOIS 2023)
+
+[arXiv:2210.11934](https://arxiv.org/abs/2210.11934) / [ACM](https://dl.acm.org/doi/10.1145/3596512).
+Convex combination `f = α·f_Sem + (1−α)·f_Lex`; their tuned system **TM2C2 uses α=0.8**.
+NDCG@1000 **[CONFIRMED]**:
+
+| | Lexical | Semantic | **Convex (α=0.8)** | RRF (η=60) |
+|---|---|---|---|---|
+| MS MARCO (in-domain) | 0.309 | 0.441 | **0.454** | 0.425 |
+| HotpotQA (BEIR, OOD) | 0.682 | 0.520 | **0.699** | 0.675 |
+
+- Convex combination wins **in- and out-of-domain**, is **sample-efficient** (one param α,
+  α=0.8 transferred across domains). **[CONFIRMED]**
+- RRF is **parameter-sensitive**: swept η∈{1..100}; tuned optima (e.g. η_Lex=10, η_Sem=4) differ
+  materially from the "safe 60." **[CONFIRMED]**
+- Why CC helps single-source items: "Because RRF is a function of ranks, it disregards the
+  distribution of scores… the distance between raw scores plays no role." CC **preserves the
+  magnitude** of a lane's confident relevance signal. **[CONFIRMED]**
+- Normalization detail (Lemma 4.2): min-max and z-score are rank-equivalent under a matching α;
+  *bounded* normalization matters, the specific scheme does not. **[CONFIRMED]**
+
+### B.4 "Reranker rescues single-lane items"
+
+Standard pattern: RRF top-100 union pool → cross-encoder rerank of the *union* → top-10. Measured
+cross-encoder rescue: Success@10 0.54→0.65; **+17.2pp MRR@3, +12.1pp Recall@5** over unreranked
+hybrid. **[CONFIRMED]** ([arXiv:2604.01733](https://arxiv.org/html/2604.01733v1)). A cross-encoder
+scores query–doc pairs with **no lane-count term**, so it is inherently blind to fusion bias and
+can rescue a single-lane landmark — **but only if the doc is in the pool.** "With only 20
+candidates reranking is ineffective… sharp increase at 50, continues at 100." No paper isolates
+"reranker recovers *single-source* docs" as a named result (**[INFERRED]**), but it follows
+directly: RRF-then-truncate can drop the landmark before the reranker sees it.
+
+### B.5 Recommendation — keep a single-lane landmark competitive (3 layers, priority order)
+
+1. **Guaranteed pool inclusion (highest leverage, cheapest).** Before truncating the fused pool,
+   force-include **top-20–30 from each lane** (PubMed especially) into the rerank candidate set,
+   regardless of fused RRF score. Pool size ≥50, ideally 100. **[INFERRED, grounded in B.4
+   threshold]**
+2. **Fusion score = convex combination** `α·sem + (1−α)·lex`, per-lane min-max normalized,
+   **α≈0.7–0.8** (Bruch transferable 0.8). If staying on RRF, use **weighted RRF, PubMed weight
+   1.5–3×.** **[CONFIRMED α; INFERRED weight range]**
+3. **Cross-encoder rerank the UNION pool** (not per-lane) to top-k — the lane-count-agnostic
+   layer that actually restores the landmark. **[CONFIRMED]**
+
+Net: **RRF alone is the wrong final arbiter for single-lane landmarks.** Use it as a recall pool
+builder with per-lane guaranteed inclusion; decide final order with a union-pool cross-encoder
+and/or convex combination.
+
+---
+
+## C. Recency vs landmark tension (→ F3)
+
+### C.1 PubMed "Best Match" — Fiorini et al. 2018, PLOS Biology
+
+[Article](https://journals.plos.org/plosbiology/article?id=10.1371/journal.pbio.2005343).
+Two stages: BM25 retrieval → **top-500 re-ranked by LambdaMART** (boosted trees). **[CONFIRMED]**
+Feature ablation: most critical are **Document features (publication year, past usage/click
+history)** and **Query-Document features (BM25 relevance)**; Query features minor.
+**Recency is a mild LEARNED feature, NOT a multiplier** — the *old* TF-IDF system gave recent
+articles "an artificial boost" (hand-tuned multiplicative bump); Best Match replaced that with
+publication year as one learned signal among dozens. NDCG **0.48 vs 0.15** for old TF-IDF (~3×).
+**[CONFIRMED]**
+
+### C.2 Semantic Scholar — citations vs recency (AI2)
+
+[Blog](https://medium.com/ai2-blog/building-a-better-search-engine-for-semantic-scholar-ea23a0b661e7),
+[s2search code](https://github.com/allenai/s2search). Reranker features include `paper_n_citations`,
+`paper_n_key_citations`, **`paper_n_citations_divided_by_oldness`** (citations-per-age rate),
+`paper_oldness`, `paper_year_is_in_query`. **[CONFIRMED]**
+- **Citation features carry an UPWARD monotonicity constraint** — a landmark cannot be pushed
+  down for being highly cited. **[CONFIRMED]**
+- **Recency (`paper_oldness`) is the ONLY feature with NO monotonicity constraint** — a soft,
+  data-learned preference deliberately allowed to be non-monotone. **[CONFIRMED]**
+- **Correction to the "log-citations" premise:** S2's public code uses **raw counts + a
+  citations/age rate with monotone constraints, NOT an explicit log transform.** Log-compression
+  is common practice elsewhere but is **[INFERRED]**, not what S2 documents. The load-bearing
+  choice is the **monotone constraint**, not the transform.
+
+### C.3 Multiplicative recency boosts are harmful
+
+- **Dai, Shokouhi, Davison, "Learning to Rank for Freshness and Relevance," SIGIR 2011**
+  ([PDF](https://www.cse.lehigh.edu/~brian/pubs/2011/SIGIR/learning-to-rank.pdf)): optimizing
+  freshness "can even do harm in some cases"; fix is a **single joint LTR model with a
+  query-adaptive freshness–relevance tradeoff.** **[CONFIRMED quote]**
+- **Dong et al., "Towards Recency Ranking in Web Search," WSDM 2010**
+  ([PDF](https://841.io/doc/recency.pdf)): recency handled via (a) a classifier detecting
+  recency-sensitive queries + (b) **multiple recency FEATURES in a machine-learned ranker** — not
+  a global `score×decay`. **[CONFIRMED]**
+- **Scaling instability** ([Elastic multiplicative boosting](https://www.elastic.co/search-labs/blog/bm25-ranking-multiplicative-boosting-elasticsearch)):
+  a multiplicative boost "doesn't scale together" with BM25 because "BM25 values vary
+  substantially across queries." So `score×recency_decay` has **unpredictable query-dependent
+  magnitude** — on a query with compressed relevance scores the decay term dominates and buries
+  older landmark RCTs (exactly F3). **[CONFIRMED]**
+
+### C.4 Recommendation
+
+1. **Kill the multiplicative recency boost.** Replace `score×decay(age)` with **additive**
+   `final = relevance + w_r·recency_feature`, `recency_feature∈[0,1]`, `w_r` small — recency
+   can *tie-break*, never *override* relevance. Rule of thumb: cap max recency contribution to
+   **≤~10–15% of the relevance dynamic range** (mirrors PubMed treating pub-year as one of dozens
+   of features). **[INFERRED, grounded in C.1–C.3]**
+2. **Recency = monotone-but-soft; landmark signal = monotone-and-hard.** Use a saturating recency
+   curve (a soft half-life where a 20-year pivotal RCT keeps most of its relevance), not an
+   exponential decaying to zero. Citation strength gets an **upward monotone constraint** (S2).
+   **[CONFIRMED design; INFERRED curve]**
+3. **Landmark signal = `log(1 + citations)`** (or S2's citations/age rate + raw count) as an
+   explicit feature — log-compression stops a single 50k-citation review from dominating while
+   guaranteeing pivotal older RCTs clear the recency-favored noise. **[INFERRED; S2 uses raw +
+   monotone constraint — either works]**
+4. **Condition recency on query intent** (Dong/Dai): a crude keyword classifier (year mentioned,
+   "latest/recent/new" vs "seminal/landmark/original") captures most of the benefit — apply
+   recency weight only on recency-sensitive queries. **[CONFIRMED principle]**
+5. **Restore a real citation source first.** (Engine-specific: OpenAlex backfill is dead code,
+   citations hardcoded 0.) All of C.4 is inert until citation counts are non-zero — this is the
+   prerequisite for using citations as the landmark counterweight to recency.
+
+---
+
+## D. Query understanding for phrasing robustness (→ F4)
+
+### D.1 Multi-query LLM generation + fusion
+
+- **LangChain MultiQueryRetriever default = 3 variants**, union/dedupe (not score fusion).
+  **[CONFIRMED]** ([docs](https://python.langchain.com/docs/how_to/MultiQueryRetriever/)).
+- **RAG-Fusion = original + ~4 LLM variants, fused with RRF (k=60).** Reported +8–10% answer
+  accuracy / +30–40% comprehensiveness (LLM-judge/human, small deployment — **directional only**).
+  **[CONFIRMED method; INFERRED/soft numbers]** ([repo](https://github.com/Raudaschl/rag-fusion),
+  [arXiv:2402.03367](https://arxiv.org/abs/2402.03367)).
+- **Jagerman et al., "Query Expansion by Prompting LLMs" (Google, 2023)**
+  ([arXiv:2305.03653](https://arxiv.org/abs/2305.03653)). Fuses expansion terms into the query,
+  **original query repeated 5×** to up-weight. MS MARCO BM25 baseline Recall@1K 87.82 → **CoT
+  90.61 (+2.79)**; **CoT/PRF MRR@10 22.62 (+3.85), nDCG@10 26.89 (+3.45).** **CoT prompting is the
+  best prompt type.** **[CONFIRMED]**
+- **query2doc (EMNLP 2023)** ([arXiv:2303.07678](https://arxiv.org/abs/2303.07678)): LLM writes a
+  pseudo-document, prepend to query; **+3–15% BM25, >15% on TREC DL19/20.** **[CONFIRMED
+  directional]**
+- **Optimal N:** no clean biomedical ablation exists (**[genuine gap]**); deployed defaults
+  cluster **3 (LangChain) – 5 (RAG-Fusion)**. Beyond ~5, mostly latency + rank noise that RRF's
+  k-smoothing absorbs. **[INFERRED]**
+
+### D.2 HyDE — Gao et al. 2022 ([arXiv:2212.10496](https://arxiv.org/abs/2212.10496))
+
+Generate hypothetical answer-doc(s), embed, retrieve by that embedding. TREC-DL **[CONFIRMED]**:
+
+| | nDCG@10 | Recall@1k |
+|---|---|---|
+| DL19: BM25 / Contriever / **HyDE** | 50.6 / 44.5 / **61.3** | 75.0 / 74.6 / **88.0** |
+| DL20: BM25 / Contriever / **HyDE** | 48.0 / 42.1 / **57.9** | 78.6 / 75.4 / **84.4** |
+
+Averages embeddings of **N=8 hypothetical docs** + query (**[INFERRED default]**). Helps zero-shot
++ vocabulary-divergent queries (our case); hurts when the LLM hallucinates off-topic or a strong
+*supervised* dense retriever already exists. **No headline biomedical numbers**; later biomedical
+work finds generic LLM pseudo-doc expansion can inject non-clinical noise (see D.6). **[CONFIRMED
+numbers; INFERRED N]**
+
+### D.3 PubMed ATM / MeSH / entity normalization (the acronym bridge)
+
+- **PubMed Automatic Term Mapping**: untagged terms matched against MeSH → journals → author
+  tables; on a MeSH hit it (a) adds the MeSH term, (b) **explodes** to narrower terms, (c) ORs in
+  all **Entry Terms (synonyms)**. This is the acronym↔full-name/drug-synonym bridge.
+  Programmatic: NCBI **E-utilities** `esearch` returns `QueryTranslation` showing the expansion.
+  **[CONFIRMED]** ([ATM](https://www.nlm.nih.gov/pubs/techbull/nd04/nd04_atm.html),
+  [E-utilities](https://www.ncbi.nlm.nih.gov/books/NBK25501/)).
+- **Does MeSH expansion help?** Lu, Kim & Wilbur 2009 (64 TREC Genomics topics): "can generally
+  improve retrieval performance, but the improvement may not affect end users in realistic
+  situations" — measurable aggregate lift, **modest**. Keep it on; expect small+safe. **[CONFIRMED]**
+  ([Springer](https://link.springer.com/article/10.1007/s10791-008-9074-8)).
+- **Tools:** **scispaCy** `AbbreviationDetector` (acronym↔long-form within a doc) + `EntityLinker`
+  (UMLS/MeSH/RxNorm via char-3gram TF-IDF) — most deployable; **MetaMapLite** (UMLS CUIs,
+  high-precision, slower); **pyMeSHSim**. **[CONFIRMED]** ([scispaCy arXiv:1902.07669](https://arxiv.org/pdf/1902.07669)).
+- **Critical gap:** trial-acronym↔full-name (EMPA-REG ↔ "empagliflozin cardiovascular outcome
+  trial") is **often NOT in UMLS/MeSH** (trial names aren't standard concepts). Needs a
+  **supplementary trial-acronym gazetteer** — harvest from ClinicalTrials.gov and via scispaCy's
+  AbbreviationDetector at index time. **[CONFIRMED gap]**
+
+### D.4 doc2query / docTTTTTquery (document-side, index-time)
+
+castorini/docTTTTTquery, MS MARCO passage **[CONFIRMED]**: BM25 MRR@10 **18.6 → 27.2 (+8.6,
+~+46%)**, latency 55→64 ms. **40 predicted queries/passage** ("only tiny gain past 40").
+([repo](https://github.com/castorini/docTTTTTquery)). Pushes neural cost to indexing time → query
+latency stays ~BM25. **Cheapest durable recall win if the corpus is static and we control
+indexing.** Best practice = **both** doc2query (index) + light query expansion (query time).
+**[CONFIRMED numbers; INFERRED recommendation]**
+
+### D.5 RM3 pseudo-relevance feedback — OFF for our case
+
+Anserini/Pyserini defaults: `fbDocs=10, fbTerms=10, fbOrigWeight/λ=0.5`. **[CONFIRMED]** But RM3
+**helps verbose queries, frequently hurts SHORT queries** via drift — and our failing query
+("family sglt2 cvot trials") is short and jargon-dense, exactly where RM3 drifts. **Prefer
+LLM/ontology expansion.** If used: only when query length >~5 tokens. **[CONFIRMED caveat]**
+
+### D.6 Biomedical-specific evidence
+
+- **BMQExpander — ontology-guided LLM expansion (arXiv:2508.11784)** — most on-point.
+  nDCG@10 **[CONFIRMED]**: TREC-COVID 0.656→**0.801 (+22.1%)**, NFCorpus 0.325→**0.363 (+11.7%)**,
+  SciFact 0.665→**0.704 (+5.9%)**. Uses UMLS (MSH, SNOMEDCT_US, NCI, CSP). **Beats generic LLM
+  expansion** (Query2Doc 0.667, CSQE 0.742 on TREC-COVID). **Robustness under query perturbation
+  +15.7% over the strongest baseline — directly our F4 metric,** and the strongest evidence that
+  ontology-grounded expansion beats free-form LLM expansion for paraphrase stability.
+  ([arXiv:2508.11784](https://arxiv.org/abs/2508.11784)).
+- **JAMIA 2026 critical eval of generative QE (doi:10.1093/jamia/ocag037)** — cautionary: naive
+  LLM expansion is **inconsistent and can regress below baseline** (BioASQ-Y/N GPT-4o Recall@10
+  0.417–0.512 vs baseline 0.491). **Gate LLM expansion.** **[CONFIRMED]**
+
+### D.7 Recommended query-understanding stack (evidence-ordered)
+
+1. **Document-side doc2query/docTTTTTquery at index time** (~40 predicted queries/doc). Large
+   lexical-recall lift, zero query latency, closes the paraphrase gap on the *document* side.
+   Strongest cheap win if corpus static. **[CONFIRMED mechanism]**
+2. **Ontology/MeSH + acronym expansion, always-on, conservative.** scispaCy `AbbreviationDetector`
+   at index time + MeSH Entry Terms at query time + a **trial-acronym gazetteer**. **Biggest lever
+   for the exact EMPA-REG↔SGLT2-CVOT case; +5–22% nDCG@10; +15.7% robustness.** **[CONFIRMED]**
+3. **LLM multi-query: 3–5 variants (one expanding acronyms, one using generic/family terms),
+   fuse result lists with RRF k=60.** RRF safely absorbs bad variants; cache aggressively.
+   **[CONFIRMED defaults]**
+4. **HyDE/query2doc: ON but GATED, dense arm only** (N≈4–8, RRF'd in as an *additional* dense
+   query, never replacing the raw query). Fire only when raw-query results are thin/low-confidence
+   (JAMIA regression risk). **[CONFIRMED numbers + gating rationale]**
+5. **RM3: OFF by default** (short biomedical queries drift). **[CONFIRMED]**
+
+---
+
+## E. Cross-encoder choice for biomedicine (→ F1, F2)
+
+**Caveat up front:** no public benchmark runs MedCPT-CE, Cohere, monoT5-3B, and bge-reranker-v2-m3
+head-to-head on the *same* biomedical pool. Cross-model numbers below stitch different papers with
+different first-stage retrieval — comparability flagged. **[CONFIRMED caveat]**
+
+### E.1 MedCPT (own paper) — Jin et al., Bioinformatics 2023 ([arXiv:2307.00589](https://arxiv.org/abs/2307.00589))
+
+nDCG@10, BEIR biomedical **[CONFIRMED]**:
+
+| | TREC-COVID | NFCorpus | BioASQ | SciFact | SciDocs |
+|---|---|---|---|---|---|
+| **MedCPT (retriever + CE rerank)** | 0.757 | 0.350 | 0.553 | 0.761 | 0.172 |
+| MedCPT retriever only (no CE) | 0.697 | 0.340 | 0.332 | 0.724 | 0.123 |
+| GTR-XXL (4.8B) | 0.501 | 0.342 | 0.324 | 0.662 | 0.161 |
+
+- **The CE tier is the value-add:** BioASQ **0.332→0.553 (+0.221)**, TREC-COVID **0.697→0.757
+  (+0.060)**. This is the single most important datapoint for the two-tier question — the reranker
+  does most of the biomedical lift. **[CONFIRMED]**
+- Average BEIR nDCG@10 ≈ **0.510**, beating GTR-XXL (4.8B) and cpt-text-XL (175B) despite MedCPT
+  being ~330M total params. Training: 255M PubMed click logs (retriever), 18.3M query-article
+  pairs (CE). **[CONFIRMED]**
+
+### E.2 Empirical reranker analysis (different setup: BM25 candidates) — arXiv:2508.16757
+
+nDCG@10 ×100 **[CONFIRMED numbers; INFERRED comparability]**:
+
+| Reranker | TREC-COVID | NFCorpus | SciFact |
+|---|---|---|---|
+| monoT5-3B | 80.71 | 38.97 | 76.57 |
+| mxbai-rerank-large | 85.33 | 37.08 | 75.10 |
+| Cohere Rerank-v2 | 81.81 | 36.36 | 74.44 |
+| RankGPT (GPT-4) | 85.51 | 38.47 | 74.95 |
+| bge-reranker-large | 74.30 | 34.80 | 74.10 |
+| bge-reranker-v2-m3 | 74.79 | 33.84 | 73.48 |
+
+These rerank *BM25* candidates; MedCPT's numbers rerank *its own bi-encoder's* candidates — so you
+**cannot** conclude monoT5-3B > MedCPT from these tables. On NFCorpus everyone sits 34–39.
+**bge-reranker-v2-m3 is the weakest on biomedical here** (multilingual-general, no domain tuning)
+and larger (0.6B) than MedCPT-CE — **do not switch to it for biomedical** unless non-English is
+needed. **[CONFIRMED]**
+
+### E.3 Latency / cost / size **[CONFIRMED except where noted]**
+
+| Reranker | Params / base | Max seq | Latency | Cost | Self-host |
+|---|---|---|---|---|---|
+| **MedCPT-CE** | **~109M (PubMedBERT-base)** | 512 | smallest → fastest CE here (~5× smaller than bge-v2-m3; no clean published ms — **INFERRED**) | **$0** | Yes |
+| bge-reranker-v2-m3 | ~0.6B | 512 | ~50 ms/pair L40S; ~1.5 s top-30; 46 QPS @ 21.9 ms on 4090 | $0 | Yes |
+| monoT5-3B | 3B | 512 | highest of the CEs; needs big GPU | $0 (big GPU) | Yes |
+| **Cohere rerank-4-pro** | undisclosed | 4096 | 80–150 ms p50 | **$2.50/1k = $0.0025/search** | No (API) |
+
+MedCPT-CE (~109M PubMedBERT) is the cheapest cross-encoder to run → ideal **wide first rerank
+tier**. Cohere's per-search fee is what you spend on a **narrow final tier only.** **[CONFIRMED]**
+
+### E.4 Cascade reranking works — Expando-Mono-Duo ([arXiv:2101.05667](https://arxiv.org/abs/2101.05667))
+
+BM25 top-1000 → monoT5 pointwise → **duoT5 pairwise on top-50** (O(n²) → restricted). The textbook
+cheap-wide→expensive-narrow pattern. TREC-COVID cascade helped (duoT5 nDCG@20 0.7219 vs monoT5-only
+0.6596, different rounds — directional). MedCPT is *itself* a two-tier system (bi-encoder →
+PubMedBERT CE) and its ablation (E.1) is direct proof the biomedical gain comes from adding a
+domain CE tier. **[CONFIRMED]**
+
+**Caveat on OUR specific two-tier idea (MedCPT wide → Cohere narrow):** both are strong *pointwise*
+rerankers, so a second pointwise pass risks diminishing returns (mono→mono). The cascade wins in
+the literature come from a *different-shaped* second stage (**pairwise duoT5 or listwise
+RankGPT**), not a second pointwise CE. **A/B required.** **[INFERRED]**
+
+### E.5 Recommendation (evidence-ordered)
+
+1. **Deploy MedCPT-CE as primary reranker now — highest ROI.** Only reranker trained on biomedical
+   relevance; ~109M/512/self-host/$0; its CE tier delivers the biomedical lift (BioASQ +0.22).
+   Near-free upgrade over Cohere-only for on-topic PubMed content. **[CONFIRMED basis]**
+2. **Two-tier: MedCPT-CE wide (top-100–150) → Cohere rerank-4-pro narrow (top-10–20)** — worth it
+   *if measured*; economics clean (MedCPT prunes ~90% free, Cohere sees ~15–20 docs so per-search
+   cost unchanged). **A/B it** (mono→mono redundancy risk). **[INFERRED]**
+3. **Highest ceiling / can eat latency:** MedCPT-CE wide → **listwise LLM rerank on top-20** (the
+   complementary second stage the cascade literature rewards). **[CONFIRMED numbers; INFERRED
+   stack]**
+4. **Suggested depths:** retrieve ~1000 → MedCPT-CE → top-100 → paid/listwise narrow top-10–20 →
+   display (mirrors validated Expando-Mono-Duo pattern). **[CONFIRMED pattern]**
+5. **Decisive step:** run our own harness (MedCPT-CE vs Cohere vs monoT5-3B on the *same* PubMed
+   pool + our judged queries) — the only apples-to-apples the public literature lacks.
+
+---
+
+## F. Listwise LLM rerank as a final top-30 stage
+
+### F.1 RankGPT — Sun et al., EMNLP 2023 ([arXiv:2304.09542](https://arxiv.org/abs/2304.09542))
+
+- **Window 20, step 10 — CONFIRMED** (paper §6.1; `rank_gpt.py`:
+  `sliding_windows(..., rank_end=100, window_size=20, step=10)`). Rerank top-100, one back-to-front
+  pass, windows [80,100]…[0,20] → **9 LLM calls/pass**. **[CONFIRMED window/step; INFERRED call
+  count]**
+- nDCG@10 **[CONFIRMED]**:
+
+| | DL19 | DL20 | BEIR avg |
+|---|---|---|---|
+| BM25 | 50.58 | 47.96 | 43.42 |
+| monoT5-3B | 71.83 | 68.89 | 51.36 |
+| RankGPT (gpt-4) | **75.59** | **70.56** | **53.68** |
+
+- Gain over BM25 **+25/+22.6**; gain over monoT5-3B only **+3.8/+1.7** — **marginal lift over a
+  strong cross-encoder is modest.** Distilled DeBERTa-Large (~440M) on 10K ChatGPT permutations
+  scores 53.03 BEIR avg, beating monoT5-3B. **[CONFIRMED / INFERRED subtraction]**
+
+### F.2 RankZephyr / RankVicuna (castorini, [arXiv:2312.02724](https://arxiv.org/abs/2312.02724))
+
+7B, window 20/stride 10. nDCG@10 **[CONFIRMED]**: RankZephyr **DL19 78.16 / DL20 81.59**, beating
+RankGPT-4 (74.64/70.76). **Open 7B matches/beats its GPT-4 teacher zero-shot.** TREC-COVID
+(biomedical): RankZephyr 85.35, RankGPT-4 87.92. **[CONFIRMED]**
+
+### F.3 Setwise (SIGIR 2024, [arXiv:2310.09497](https://arxiv.org/abs/2310.09497)) — efficiency
+
+TREC-DL19, Flan-T5-XL, top-100 **[CONFIRMED]**:
+
+| Method | LLM calls | Prompt tokens | Latency (s) | nDCG@10 |
+|---|---|---|---|---|
+| Listwise.generation (RankGPT-style) | 245 | 119,163 | 71.4 | — |
+| **Setwise.heapsort** | **129.5** | **41,666** | **9.6** | **0.693** |
+| Pairwise.heapsort | 241.9 | 110,127 | 20.5 | 0.705 |
+
+Setwise ≈ half the calls, ~1/3 the tokens, **~62% cost cut vs pairwise, ≤0.012 nDCG loss.** The
+listwise-generation baseline needing **245 calls / 71s per query** is the strongest cautionary
+datapoint on naive listwise cost. **[CONFIRMED]**
+
+### F.4 TourRank ([arXiv:2406.11678](https://arxiv.org/abs/2406.11678)) — parallel tournament
+
+Group tournament (100→50→30→…), ensembled over tournaments; **groups within a stage run in
+parallel** (latency ≈ one call deep per stage, vs RankGPT's sequential 9-window chain).
+TourRank-10 ≈ 71.98 nDCG@10 avg on TREC-DL vs RankGPT 69.09; single tournament already competitive
+and cheap. **[CONFIRMED cross-paper]**
+
+### F.5 rank_llm ([castorini/rank_llm](https://github.com/castorini/rank_llm)) — exact params
+
+- **License: Apache-2.0.** **[CONFIRMED]**
+- **Default sliding window: window_size=20, step_size=10** (matches RankGPT; in
+  `SlidingWindowReranker`/`reorder`; example `src/rank_llm/scripts/run_rank_llm.py`). LiT5-Distill-v2
+  configs use window_size=100 single long window. Backends: vLLM, SGLang, TensorRT-LLM.
+  **[CONFIRMED]**
+
+### F.6 Token/latency arithmetic — top-100→top-30, w=20/s=10 **[INFERRED from confirmed params]**
+
+- **Calls:** `1 + (100−20)/10 = 9 calls/pass`, one pass. **[CONFIRMED window count]**
+- **Input tokens:** 20 passages × ~130 tok (title+truncated abstract) + ~250 instruction ≈
+  ~2,850/window → **~25,700/query**; with ~300-tok abstracts ~56k/query. (Anchor: Setwise measured
+  ~119k for its config.) **[INFERRED; CONFIRMED anchor]**
+- **Latency:** local 7B (RankZephyr) ~0.35–0.40 s/window → ~3.2–3.6 s/query batched, up to ~25
+  s/query single-GPU with full passages (Rank-DistiLLM). **FIRST single-token decoding
+  ([arXiv:2406.15657](https://arxiv.org/abs/2406.15657)): ~50% latency cut, nDCG-neutral.** API
+  GPT-4o: 9 sequential calls ≈ 10–30 s/query. **[CONFIRMED anchors; INFERRED totals]**
+- **Cross-encoder contrast:** monoELECTRA reranks the same top-100 in **~300 ms vs RankZephyr ~25
+  s — ~83× faster** (Rank-DistiLLM, [arXiv:2405.07920](https://arxiv.org/abs/2405.07920)).
+  **[CONFIRMED]**
+
+### F.7 Biomedical listwise evidence + gap
+
+TREC-COVID nDCG@10: RankGPT-4 85.51, RankZephyr 80.70, monoT5-3B 80.71 (BM25 ~59.5). **Lift over
+BM25 large (+~25); lift over a strong cross-encoder ~0–5, method-dependent.** **BioASQ /
+clinical-trial listwise numbers are sparse — genuine gap.** Robustness: "listwise methods show the
+smallest performance drop on novel queries" — favors listwise for fast-moving biomedical
+literature. **[CONFIRMED]**
+
+### F.8 Recommendation — qualified yes, optional premium tier only
+
+The cross-encoder is the workhorse; listwise LLM adds **~+2–3 nDCG@10 at ~80× latency**
+(Rank-DistiLLM: distilled cross-encoders "match the effectiveness of LLMs… orders of magnitude
+more efficient"). If you add it:
+- **Depth: top-50 not top-100** (halves calls to ~4 windows; most gain is in the top ~50). Output
+  top-30.
+- **Window/step: w=20/s=10** (proven), or single w=50 long-context window (1 call, some quality
+  cost).
+- **Model: RankZephyr-7B** (Apache-2.0 via rank_llm, matches/beats GPT-4, self-hostable — no data
+  egress, important for biomedical/PII) on **vLLM + FIRST single-token decoding.** Reserve
+  GPT-4o/RankGPT-4 as an eval oracle only.
+- **Cheaper alternatives keeping most of the win:** **Setwise.heapsort** (~62% cost cut) or
+  **TourRank-1** (parallel).
+- **Guardrail:** gate behind the cross-encoder — invoke only when the CE top scores are
+  close/ambiguous, and/or run it **async** off the hot path. **[CONFIRMED conclusions]**
+
+---
+
+## G. Deliverable 1 — prioritized recommendations mapped to the four measured failures
+
+| # | Failure | Fix (parameters) | Evidence | Expected effect |
+|---|---|---|---|---|
+| 1 | **F2** score-mixing | **Rerank the whole 100–190 pool in one Cohere call; sort ONLY by reranker; append un-reranked tail below in first-stage order; never interleave by raw score.** | Askari 2024 (tuned interp 0.290<CE 0.342); Elastic #120670 (identical bug); sbert/BEIR standard **[CONFIRMED]** | Removes rank-55-beats-rank-5 inversions; directly lifts the 74%→ toward 90% top-10 rate |
+| 2 | **F1** single-lane burial | **Per-lane guaranteed inclusion (top-20–30/lane, PubMed esp.) before pool truncation; then union-pool rerank. Replace RRF-as-final-arbiter with convex combination α≈0.8 (min-max normalized) OR weighted RRF PubMed 1.5–3×.** | RRF cap 1/61; Bruch TOIS 2023 (CC 0.454>RRF 0.425); cross-encoder rescue +17.2pp MRR@3 **[CONFIRMED]** | Single-lane landmarks reach the reranker and get judged on relevance, not lane-count |
+| 3 | **F3** older RCTs buried | **Kill `score×recency_decay`. Use additive `relevance + w_r·recency`, recency∈[0,1], contribution ≤10–15% of relevance range, soft half-life. Add `log(1+citations)` monotone landmark feature. Condition recency on query intent. (Restore a citation source first.)** | PubMed Best Match, S2 monotone constraints, Dong 2010, Dai 2011, Elastic scaling instability **[CONFIRMED]** | Pivotal older RCTs (PARTNER 3, ARISTOTLE) stop being decayed out of top-10 |
+| 4 | **F4** phrasing sensitivity | **doc2query at index (~40 q/doc) + MeSH/scispaCy acronym expansion + trial-acronym gazetteer + 3–5 LLM query variants fused by RRF k=60; HyDE gated to dense arm; RM3 off.** | BMQExpander +15.7% robustness / +22.1% COVID; doc2query +8.6 MRR@10; Jagerman CoT +2.79 R@1k **[CONFIRMED]** | Same landmark retrieved across paraphrases (EMPA-REG ↔ SGLT2-CVOT) |
+
+---
+
+## H. Deliverable 2 — exact fusion + rerank recipe the literature supports
+
+```
+STAGE 0  QUERY UNDERSTANDING
+  - 3–5 LLM query variants (CoT prompt; one expands acronyms, one uses generic/family terms)
+  - MeSH Entry-Term expansion via E-utilities QueryTranslation + trial-acronym gazetteer
+  - HyDE only if raw-query pool is thin/low-confidence (N≈4–8, dense arm, RRF'd in)
+
+STAGE 1  RETRIEVE (per lane, wide)
+  - dense MedCPT + BM25 lexical + each federated API; corpus indexed with doc2query (~40 q/doc)
+  - top ~1000 candidates target (each lexical lane must send a sort param)
+
+STAGE 2  BUILD POOL (recall-oriented, NOT the final arbiter)
+  - RRF k=60 (or weighted RRF, PubMed 1.5–3×) across variant-lists AND lanes
+  - GUARANTEE per-lane top-20–30 inclusion before truncation  ← fixes single-lane burial
+  - pool size ≥ 100 (ideally the full 150–190)
+
+STAGE 3  RERANK THE WHOLE POOL (wide)
+  - MedCPT-CE (self-hosted, $0, biomedical-native) over the ENTIRE pool
+  - reranker input: full structured abstract (raise the 2000-char cap; keep Results/Conclusions)
+
+STAGE 4  NARROW RERANK (optional, paid/premium)
+  - Cohere rerank-4-pro OR listwise (RankZephyr-7B, w20/s10, FIRST decoding) over top-20–50
+  - gate: only when top CE scores are close/ambiguous; can run async
+
+STAGE 5  FINAL ORDER
+  - sort reranked items by reranker score ONLY
+  - fold in metadata as MILD ADDITIVE features on the reranked set:
+        final = rerank_score
+              + w_cite · log(1+citations)          (monotone up)     w_cite small
+              + w_rec  · recency_feature∈[0,1]       (soft, query-gated) ≤10–15% of range
+              + w_type · study_type_prior            (RCT/meta-analysis up)
+  - append any un-reranked tail BELOW, in first-stage order; never interleave by raw score
+```
+
+Parameter cheat-sheet: **RRF k=60**; **convex α=0.8** (if replacing RRF as arbiter); **per-lane
+guaranteed top-20–30**; **rerank depth = full pool (≤190)** wide, **top-20–50** narrow;
+**doc2query 40 q/doc**; **3–5 query variants**; **listwise w=20/s=10** (or w=50 single window);
+**recency additive ≤10–15% of relevance range**; **citations `log(1+c)` monotone**.
+
+---
+
+## I. Deliverable 3 — copy-pasteable OSS specifics (repo + file + license)
+
+| What to lift | Repo / file | License | Exact detail |
+|---|---|---|---|
+| **MedCPT cross-encoder** (biomedical-native reranker) | [ncbi/MedCPT-Cross-Encoder](https://huggingface.co/ncbi/MedCPT-Cross-Encoder), [github.com/ncbi/MedCPT](https://github.com/ncbi/MedCPT) | **Public domain (US-gov)** | ~109M PubMedBERT-base, max_seq 512; query+article pair → relevance logit |
+| **Listwise sliding-window rerank** | [castorini/rank_llm](https://github.com/castorini/rank_llm) `src/rank_llm/rerank/` ; RankGPT `rank_gpt.py` `sliding_windows(rank_end=100, window_size=20, step=10)` | **Apache-2.0** | w=20, s=10, one back-to-front pass over top-100 = 9 calls; RankZephyr weights `castorini/rank_zephyr_7b_v1_full` |
+| **BM25+dense fusion, RRF, BEIR eval** | [castorini/pyserini](https://github.com/castorini/pyserini), [Expando-Mono-Duo arXiv:2101.05667](https://arxiv.org/abs/2101.05667) | **Apache-2.0** | monoT5 over ~1000, duoT5 over top-50 cascade depth pattern |
+| **BEIR biomedical regression harness** | [beir-cellar/beir](https://github.com/UKPLab/beir) `examples/benchmarking/benchmark_bm25_ce_reranking.py` | **Apache-2.0** | reference BM25+CE reranks top-100; TREC-COVID/NFCorpus/BioASQ/SciFact |
+| **Convex-combination fusion (α=0.8)** | Bruch et al. TOIS 2023 [arXiv:2210.11934](https://arxiv.org/abs/2210.11934) | paper | `α·sem + (1−α)·lex`, min-max normalized, α=0.8 transferable |
+| **doc2query document expansion** | [castorini/docTTTTTquery](https://github.com/castorini/docTTTTTquery) | **Apache-2.0** | 40 predicted queries/passage (T5); +8.6 MRR@10 on MS MARCO |
+| **Acronym + entity expansion** | [scispaCy](https://github.com/allenai/scispacy) `AbbreviationDetector`, `EntityLinker` (UMLS/MeSH/RxNorm) | **Apache-2.0** | index-time acronym↔long-form; char-3gram TF-IDF linker |
+| **MeSH/ATM expansion** | NCBI [E-utilities](https://www.ncbi.nlm.nih.gov/books/NBK25501/) `esearch` `QueryTranslation` | public | shows the exact MeSH+synonym+explode expansion to mirror |
+| **Semantic Scholar ranking features** | [allenai/s2search](https://github.com/allenai/s2search) | **Apache-2.0** | monotone citation constraints; `n_citations_divided_by_oldness`; recency unconstrained |
+| **FIRST single-token listwise decoding** | [arXiv:2406.15657](https://arxiv.org/abs/2406.15657) | paper | ~50% listwise latency cut, nDCG-neutral |
+| **Setwise efficient rerank** | [ielab/setwise](https://github.com/ielabgroup/llm-rankers) [arXiv:2310.09497](https://arxiv.org/abs/2310.09497) | paper/repo | heapsort variant: ~62% cost cut vs pairwise, ≤0.012 nDCG loss |
+
+---
+
+## J. Honest gaps / caveats
+
+- **No head-to-head biomedical reranker benchmark** on the same pool (MedCPT vs Cohere vs
+  monoT5-3B vs bge) — must run our own harness for a decisive answer.
+- **Two-tier MedCPT→Cohere is mono→mono** — cascade wins in the literature come from a
+  differently-shaped second stage (pairwise/listwise). A/B required. **[INFERRED]**
+- **Trial-acronym↔full-name mapping is not in UMLS/MeSH** — needs a custom gazetteer.
+- **No clean "optimal N query variants" ablation** on a biomedical benchmark; 3–5 is deployed
+  practice, not a proven optimum.
+- **HyDE's exact default N (≈8) and biomedical numbers** are under-reported.
+- **BioASQ / clinical-trial-specific listwise numbers** are sparse — TREC-COVID + NFCorpus are the
+  main biomedical evidence base.
+- Cormack RRF and Dong/Dai PDFs are image/binary — formulas/feature designs confirmed via
+  abstracts + secondary sources; exact MAP/DCG tables not machine-extracted.
+- RAG-Fusion gains are LLM-judge/human ratings on a small deployment — directional only.
+
+---
+
+*Compiled 2026-07 from five parallel literature+OSS research streams. Prior context:
+`DIAGNOSIS-AND-PLAN-2026-07.md`, `RERANKER-DECISION.md`.*

--- a/docs/literature-search/DESIGN-BRIEF-search-at-stake.md
+++ b/docs/literature-search/DESIGN-BRIEF-search-at-stake.md
@@ -1,0 +1,99 @@
+# What's At Stake — Briefing for the Design Agent (Academic Search)
+
+You are designing the search/composer experience for **ScholarSync**, an AI academic-research
+platform. This document exists so you understand the *backend reality* your UI sits on top of —
+what's broken, what we fixed, what we can't fix in the backend, and therefore **what the UI must do
+to make search feel good.** The punchline: several quality problems are *cheaper and more robust to
+solve in the UI than in the ranking backend.* Design accordingly.
+
+---
+
+## 1. The product in one line
+A federated academic search + research engine over: our **own vector corpus** (PubMed abstracts
+embedded with MedCPT, in Turbopuffer), plus live APIs — **PubMed, Europe PMC, Springer,
+Elsevier/Scopus, Google Scholar (SerpAPI)**. Results are reranked by a **free self-hosted MedCPT
+cross-encoder**. On top of search sit workflows: Deep Research (agentic), Systematic Review, Screen,
+Draft & Cite, Slides, Integrity Check.
+
+## 2. The core problem we've been fighting
+Output quality was "at best average" despite heavy engineering. Root causes, now diagnosed with a
+live measurement harness (not guesses):
+
+- **The old evaluation was lying.** It froze the candidate pool and only measured *re-ordering*, so
+  first-stage recall failures were invisible. Headline "beats Elicit" was really 67% vs an 80% bar,
+  judged on **titles with no abstracts** and with the answer key shown to the judges. Lesson for UI:
+  *what the user can see determines what they trust* — abstracts, evidence, provenance matter.
+- **Ranking, not retrieval, is the bottleneck.** Landmark papers are in the candidate pool ~90% of
+  the time but reach the top-10 only ~75%. The right papers are *found* and then *buried*.
+- **The reranker saturates.** For an on-topic query, the cross-encoder scores ~20 papers all at
+  ≈1.00 — it cannot tell the landmark trial (PARTNER 3, 3,600 citations) apart from 19 recent
+  lookalikes. The tie-break then decides everything, and the tie-break has **no citation/landmark
+  signal** (citation counts were dropped from the pipeline). So foundational trials land at #12–16,
+  just outside the top 10.
+- **Phrasing changes the answer, legitimately.** "TAVR low-risk **six-year** outcomes" correctly
+  surfaces 6-year papers and buries the 2019 original; "**PARTNER trials**" wants the landmark at
+  #1. The backend often *cannot know which the user meant.* **This is the UI's job to resolve.**
+
+## 3. What we tried in the backend (and the honest scorecard)
+- **✅ Fixed — free reranker.** The paid reranker (OpenRouter) silently ran out of credits and
+  degraded live search to keyword-only. Switched to the free self-hosted MedCPT cross-encoder
+  ($0 idle, biomedical-SOTA). This fixed a live production outage *and* removed a per-search cost —
+  critical pre-revenue.
+- **✅ Kept — rerank the whole candidate pool** and sort reranked results strictly above the
+  un-reranked tail (was only reranking the top 50, letting keyword scores out-rank the model).
+- **❌ Reverted — demote RRF fusion weight.** Hypothesis that fusion math buried single-lane papers.
+  Measured: no improvement, slightly worse. Wrong cause.
+- **❌ Not pursued — kill the recency multiplier.** Measurement showed it doesn't even fire on the
+  buried-landmark queries. Wrong cause.
+- **▶ The real backend lever (scoped, not yet built): restore the citation/landmark signal** so a
+  3,600-citation trial can float past 19 tied lookalikes into the top 10.
+
+## 4. What the backend CANNOT fix — and the UI must
+1. **Intent ambiguity.** landmark vs latest vs exhaustive is a *user* fact. A ranking heuristic can't
+   infer it reliably (we proved this — two heuristics failed). The UI must capture it.
+2. **Query quality.** Vague queries retrieve badly. The single cheapest quality win in the whole
+   system is nudging the user toward a precise question *before* the search runs.
+3. **Scope.** Whether to search our corpus, all of PubMed, or clinical trials changes precision
+   massively. Only the user knows. Show it; let them set it; show the counts (trust).
+4. **Trust in a slow/agentic run.** Deep Research runs for minutes and costs compute. Users forgive
+   slowness only when they see *what it's doing* and *why*.
+
+## 5. Lessons from Elicit's UI (what to steal, what we already beat)
+Elicit's mobile home = one prompt box with **`Find papers ▾`** (mode selector inside the box:
+TOOLS = Find papers / Chat with papers / Extract data; WORKFLOWS = Research agent / Report /
+Systematic review), a **`Source: Research papers (138M) / Clinical trials (500K)`** scope selector
+with counts, a live **"Please ask a precise research question"** coaching hint, **Resume + Suggested**
+cards under the box, and a left rail whose history uses **distinct icons per run type**
+(search / report / agent).
+
+- **Steal:** source scope *with live counts*; the precise-question coaching hint; suggested
+  reformulations; agent runs as persistent, resumable, icon-typed history objects; a saturation /
+  "we've found ~everything" signal (Elicit under-shows this; it's what clinicians actually want).
+- **We already beat them on intent:** their mode is a *pre-selected dropdown* (friction, and users
+  guess wrong). Ours is a **correctable routing chip** — type naturally, we detect intent and show
+  "Will run: X · from Y", tap to change, never a black box. Keep this; it's better.
+
+## 6. Design implications — where the UI moves search quality
+Ranked by leverage (UI work that substitutes for backend heuristics we can't make reliable):
+
+1. **Intent facet on the routing chip for DISCOVER/search** — beyond output type (Slides, Report),
+   capture the ranking-relevant intent: **Landmark trials · Latest evidence · Exhaustive review.**
+   This flag is what flips citation-boost on/off in the backend. Highest leverage: it resolves the
+   phrasing ambiguity the backend can't.
+2. **Source/scope chip with counts** in the composer — "All sources ▾ (PubMed 37M · Trials 500K ·
+   Your library 214)". Trust + precision. Directly supports our federation story.
+3. **Quiet precision coaching** — a calm, non-nagging hint when a query is too vague ("Add a
+   population or outcome for sharper results"). Fits the "one calm box" mood; don't make it loud.
+4. **Deep Research (agentic) needs its own flow:** an up-front **clarifier** (landmark/latest/
+   exhaustive, scope, date window) → **streamed steps** (searching → screening 180 → 24 relevant →
+   following citations) → a **discovery/stopping signal** ("new-paper discovery flattened — likely
+   complete") → a **resumable, cite-checked report.** This is the differentiator tier.
+5. **Show evidence + provenance on results** — study type, citation count, and support/contradict
+   signals (the design tokens already encode include/maybe/exclude/contradicting). This is what makes
+   a medical engine trustworthy and is our moat vs generic search.
+
+## 7. The mood to hold
+Calm, editorial, authoritative — a "research desk," not a flashy consumer app. The existing home
+("Good morning, Dr. Singh — your research desk") and the "one calm box" composer are right. Search-
+quality affordances (scope, coaching, intent) must be **quiet and confident**, surfaced at the moment
+of need, never cluttering the rest state. Restraint is the brand.

--- a/docs/literature-search/DIAGNOSIS-AND-PLAN-2026-07.md
+++ b/docs/literature-search/DIAGNOSIS-AND-PLAN-2026-07.md
@@ -1,0 +1,160 @@
+# Academic Search — Diagnosis & Rebuild Plan (2026-07)
+
+Consolidated from four parallel audits (live-pipeline trace, eval-harness autopsy,
+competitor teardowns, IR-literature + OSS survey). This is the reference doc for the
+academic-retrieval rebuild. Scope: academic/literature lane only (not web/news/discussions).
+
+---
+
+## Bottom line
+
+The ingredients are right; the wiring is wrong. A MedCPT-embedded PubMed corpus in
+turbopuffer is the exact architecture NCBI, Ai2 (SPECTER2), and Exa converged on, and
+MedCPT is SOTA for zero-shot biomedical retrieval. Output is mediocre because of three
+self-inflicted wounds, not because of the sources.
+
+1. **We optimized a benchmark that cannot see the real problem.** The 87-query harness
+   freezes the candidate pool and measures *reordering only*. First-stage recall — the
+   biggest quality lever per all the research — is structurally invisible to it.
+2. **The ranker dilutes and out-competes its own best signal.** The cross-encoder rescores
+   only the top 50, but ranking runs over the full 150–250 pool, so saturated lexical
+   scores (~1.0) beat calibrated model scores (0.4–0.7). A rank-55 keyword match can
+   out-rank a rank-5 reranked paper.
+3. **The signals the ranker weights are mostly empty.** Citation counts are hardcoded to 0
+   in most sources; the OpenAlex backfill that fixed this was dropped and is now dead code.
+
+The "leads Elicit 47/29/11" headline is a below-gate result reframed as a win: it is 67%
+beat-or-tie against the project's own 80% gate, judged on **titles with no abstracts** and
+**with the answer key handed to the judges**. On the seed TAVR query, Manan still misses
+PARTNER 3 entirely and loses to Elicit — inside that same "winning" run.
+
+Env note (verified 2026-07): OPENROUTER_API_KEY, COHERE_API_KEY, SERPAPI_API_KEY,
+SPRINGER_API_KEY, ELSEVIER_API_KEY are all set in Vercel Production. The reranker key is
+live — so the problem is dilution (wound #2), not a dead key.
+
+---
+
+## Diagnosis A — the eval is a rerank harness mistaken for a retrieval harness
+
+- **Frozen pool = rerank-only.** `eval/literature-search/candidate-cache.ts` content-addresses
+  the post-enrichment pool by `sha1(query + sources + year-window)` and replays it (30-day TTL).
+  Every CYCLE (04/05/06, HyDE, MMR, floor A/Bs) measured reordering. A paper missing from the
+  pool is invisible and unrecoverable. `REPRODUCIBLE-HARNESS.md` states this limit itself.
+- **Live runs distrusted.** The one instrument that could catch recall drift (unfrozen live
+  runs) is repeatedly dismissed as "throttle noise" — biasing the harness against seeing recall misses.
+- **Headline is below-gate.** `council-2026-06-owned/council-summary.json`: `pctBeatTie:67` vs an
+  ≥80% gate. Deterministic `remeasure-owned`: recall@10 **0.851** (gate 0.95 ✗), best-in-top-3
+  **0.784** (gate 0.85 ✗). Both quality metrics fail the project's own gates.
+- **Judges see less than a user.** `build-blinded-packet.ts` renders top-10 as title+year+venue+
+  PMID+DOI only — no abstracts, studyType/citedByCount stripped — yet judges score clinical
+  relevance and trust from titles. Blinding alone dropped one packet 74%→65%.
+- **Council "recall" is not independent** — the rubric prints the must-have answer key above each
+  query, so it re-derives the deterministic metric.
+- **Overfitting: real, disciplined, non-transferable.** ~3.5 of 14 ranking modules (~40–50% of
+  claimed ranking gain) are reverse-engineered from named benchmark failures: `entity-drift.ts`
+  (hardcoded tirzepatide/empagliflozin/dapagliflozin tables), `trial-ranking.ts`
+  (SECONDARY_TITLE_MARKERS built to demote PARTNER 3 sub-reports), query-planner skip-list. To
+  their credit: no `if id===` cheats, all table-driven+gated, CYCLE-04 reverted when it showed no
+  gain. But the vocabulary is cardiology/endo/onc-specific and the multi-domain tables are EMPTY —
+  the headline wins do not transfer. The ralph-search scorecard self-grades 19 cycles at 9.8–10/10
+  on the same SGLT2/HF vocabulary it was tuned on.
+
+## Diagnosis B — the live pipeline (top root causes, ranked)
+
+1. **Lexical vs model relevance share one sort.** Rerank touches `fused.slice(0,50)` but
+   `rankAndAnnotate` runs on the full pool (`run-search.ts:784,819`); papers past 50 fall back to
+   lexical relevance which saturates ~1.0 and out-competes calibrated 0.4–0.7 model scores. Genuine
+   inversion. **Fix: rerank the whole ranked pool, or truncate the pool to exactly what was reranked.**
+2. **Citation/journal signals near-zero.** citationCount hardcoded 0 in pubmed/springer/medcpt/crossref;
+   real only from EuropePMC + key-gated Scopus. `enrichCitationsByIds` (OpenAlex) has zero non-test
+   callers — dead. So the "metadata-dominant" composite collapses to ~0.70·relevance + 0.20·rrf.
+3. **`isTrialLookup` fires on the bare word "trial"** (`query-planner.ts:200`) → skips rerank AND
+   applies trial demotions to broad evidence queries. **Fix: gate on acronym/NCT only.**
+4. **Relevance double-counted** — 0.50 linear weight AND a multiplicative gate on the noisiest signal.
+5. **Scopus STANDARD view = no abstracts** (`scopus.ts:154`) → title-only docs dilute the pool and
+   rerank budget; never sets studyType/pmid.
+6. **Study-type blank for most non-PubMed candidates** → high-evidence papers default to Level V.
+7. **Shallow, lexical-heavy recall** — 25/source, dense floor capped at 50, three of four lexical
+   lanes send no sort param; dense backbone infra-gated on Modal+Turbopuffer.
+8. **Reranker input truncated to 2000 chars** (`rerank.ts:41,47`) → structured abstracts lose
+   Results/Conclusions, degrading the 0.50-weight signal.
+9. **≥3-result cache guard + 1h TTL** can pin a thin/mediocre throttle-window result for everyone.
+10. **Dedup keeps first-seen (PubMed-first) as primary**, merging richer records onto poorer ones
+    (source-order wins, not richest-record wins).
+
+**Through-line:** the last ~10 commits (#111–#120) added ranking sophistication while thinning the
+substrate the rankers depend on (dropped OpenAlex citations, abstract-less Scopus, hardcoded
+study-type/citation to zero, capped recall). A ranker can only sort what retrieval gives it.
+
+**Docs actively mislead:** ARCHITECTURE.md / SOURCE-MATRIX.md describe the pre-#111 pipeline
+(OpenAlex default, MedCPT reranker primary, relevance 0.30 not 0.50). Reconcile or delete.
+
+---
+
+## What the good engines do (competitor + literature, independently convergent)
+
+Universal, table-stakes pattern (PubMed Best Match, S2, Elicit, Consensus, Perplexity, OpenScholar,
+PaperQA2, Undermind): **hybrid retrieve (BM25 + dense, RRF-fused) → cross-encoder rerank a small
+top-k → fold in citation + recency + venue + STUDY-TYPE → LLM re-score/summarize the final ~20.**
+Missing any of these is a bug relative to the field. We are missing the BM25 lane, our rerank is
+diluted, our quality signals are empty — three of five.
+
+Differentiators (deep-search tier): adaptive agentic loop that reformulates from what it found;
+**PaperQA2 RCS** (LLM scores each candidate 1–10 + writes a query-focused summary — the mechanism
+behind its superhuman precision); Undermind's discovery-curve stopping rule; citation-graph traversal
+for recall; LLM query understanding (NL/PICO → keyword queries per API, fixes PubMed/Scopus choking
+on question-like input); Scite-style supporting/contradicting evidence signal (medical moat).
+
+Legally stealable (Apache-2.0/MIT/public-domain, provider-agnostic → re-point onto OpenRouter/MedCPT):
+- **ncbi/MedCPT** (public domain) — deploy the matched cross-encoder reranker we already have embeddings for.
+- **Future-House/paper-qa** (Apache-2.0) — RCS pipeline + agent tool structure. Highest-value single lift.
+- **AkariAsai/OpenScholar** (Apache-2.0) — self-feedback retrieval loop + science-tuned BGE reranker.
+- **castorini/pyserini + rank_llm** (Apache-2.0) — BM25+dense fusion, RRF, listwise LLM rerank, BEIR eval.
+- **beir-cellar/beir** (Apache-2.0) — TREC-COVID/NFCorpus/BioASQ/SciFact regression harness.
+- **FlagOpen/FlagEmbedding** (MIT), **titipata/pubmed_parser** (MIT), **allenai/specter2 + SciNCL** — citation-proximity embeddings for the "similar papers" / landmark channel.
+
+Full research: `scratchpad/biomedical-retrieval-playbook.md` (also mirrored in chat transcript).
+
+---
+
+## The plan (decisions locked with the owner)
+
+Owner decisions: (1) **eval honesty first**; (2) overfit heuristics **frozen, deleted as replaced**;
+(3) corpus-vs-federation **decided after the recall probe**.
+
+### Phase 0 — make the eval honest (BEFORE any ranking change)
+Everything else is unfalsifiable until this exists.
+- **Unfrozen first-stage recall probe.** Separate "must-have present ANYWHERE in the pool" from
+  "in top 10", averaged over N runs to beat throttle noise. This is the instrument the harness
+  never had — and it also answers the corpus-vs-federation question (which lane is missing the
+  landmark papers).
+- **BEIR biomedical regression harness** (TREC-COVID / NFCorpus / BioASQ / SciFact): nDCG@10,
+  Recall@100. Accept/reject every future change on these numbers.
+- **Held-out query set** the pipeline was never tuned on; forbid CYCLE heuristics from referencing it.
+- **Honest council**: show judges abstracts (or stop scoring relevance); stop handing them the answer
+  key for the recall dimension; report the below-gate number as below-gate.
+- **Sample real user queries** + add a non-clinical/multi-domain slice.
+
+### Phase 1 — fix what we already own (highest impact ÷ effort; gated on Phase 0 metrics)
+- Add BM25 lexical lane; RRF-fuse with MedCPT dense.
+- Fix score-blending: rerank the whole ranked pool (or truncate pool to reranked set); stop averaging
+  raw reranker into raw quality.
+- Restore ONE citation/metadata source (rewire `enrichCitationsByIds` or re-add OpenAlex as default lane).
+- Deploy the free `ncbi/MedCPT-Cross-Encoder` alongside/instead of Cohere; A/B on BEIR-biomedical.
+- Narrow `isTrialLookup` to acronym/NCT; raise reranker char cap / smarter abstract slice; fix or drop Scopus.
+
+### Phase 2 — precision jump
+- LLM query understanding (NL/PICO → keyword queries per source).
+- RCS contextual scoring on the reranked top-k.
+
+### Phase 3 — differentiator tier (behind a "deep search" mode)
+- Citation-graph traversal for recall; quality gate that re-queries instead of serving weak results;
+  adaptive loop with Undermind-style saturation stopping.
+
+Delete the overfit heuristic pile as the general pipeline demonstrably covers its cases.
+
+### Guardrails
+- No ranking change ships without moving the honest Phase-0 metrics (recall floor + BEIR + held-out).
+- Every ranking signal must appear in `rankingTrace` (explainability).
+- Missing metadata is flagged, never invented; retracted papers flagged + demoted, never dropped.
+- Reconcile ARCHITECTURE.md / SOURCE-MATRIX.md to the pipeline as actually built.

--- a/docs/literature-search/RERANKER-DECISION.md
+++ b/docs/literature-search/RERANKER-DECISION.md
@@ -1,7 +1,20 @@
 # Academic Reranker Decision — OpenRouter `cohere/rerank-4-pro`
 
+> **SUPERSEDED 2026-07-04 → free self-hosted MedCPT cross-encoder is now PRIMARY.**
+> The paid OpenRouter account ran out of credits (HTTP 402) and took live academic
+> reranking down to the keyword-overlap floor; the Cohere fallback was rate-limited
+> (429). For a pre-revenue product a per-search paid reranker is the wrong dependency.
+> The free `ncbi/MedCPT-Cross-Encoder` on Modal (A10G, scale-to-zero, **$0 idle**,
+> biomedical-SOTA, same embedding space as the corpus) is now the literature primary,
+> enabled by default whenever `MEDCPT_RERANK_URL` is set (no opt-in flag). The paid
+> lanes are demoted to optional fallbacks. Trade accepted: a ~20s cold start after
+> idle (absorbed by a longer ceiling + one retry; fails open to the tail if it misses)
+> in exchange for zero per-search spend. Escape hatch: `ACADEMIC_USE_MEDCPT_RERANK=0`
+> forces the MedCPT lane off. See `src/lib/search/rerank.ts`. The rationale below is
+> retained for history but no longer describes the live config.
+
 **Date:** 2026-06-29
-**Status:** Adopted (live)
+**Status:** SUPERSEDED 2026-07-04 (see banner above)
 **Scope:** Literature/academic search reranking only. **Retrieval is unchanged.**
 
 ## Decision

--- a/eval/literature-search/__tests__/recall-probe-lib.test.ts
+++ b/eval/literature-search/__tests__/recall-probe-lib.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import {
+  isDenseLane,
+  isFederatedLane,
+  aggregateMustHave,
+  classifyDenseLiveness,
+  summarizeOverall,
+  laneAttribution,
+  nonOkStatuses,
+  type MustHaveRunObservation,
+} from "../recall-probe-lib";
+
+describe("lane classification", () => {
+  it("treats every medcpt_dense variant as the owned dense corpus", () => {
+    expect(isDenseLane("medcpt_dense")).toBe(true);
+    expect(isDenseLane("medcpt_dense_recent")).toBe(true);
+    expect(isDenseLane("medcpt_dense_hyde_2")).toBe(true);
+    expect(isDenseLane("medcpt_dense_recovery")).toBe(true);
+  });
+
+  it("treats federated API lanes as not-dense", () => {
+    for (const lane of ["pubmed", "europepmc", "scopus", "springer", "clinical_trials", "web"]) {
+      expect(isDenseLane(lane)).toBe(false);
+      expect(isFederatedLane(lane)).toBe(true);
+    }
+  });
+});
+
+describe("aggregateMustHave", () => {
+  it("averages presence across runs and unions lanes", () => {
+    const runs: MustHaveRunObservation[] = [
+      { inPool: true, inTop10: true, lanes: ["pubmed"] },
+      { inPool: true, inTop10: false, lanes: ["pubmed", "medcpt_dense"] },
+      { inPool: false, inTop10: false, lanes: [] },
+    ];
+    const agg = aggregateMustHave(runs);
+    expect(agg.inPoolRate).toBeCloseTo(2 / 3);
+    expect(agg.inTop10Rate).toBeCloseTo(1 / 3);
+    expect(agg.lanesUnion).toEqual(["medcpt_dense", "pubmed"]);
+    expect(agg.laneCounts).toEqual({ pubmed: 2, medcpt_dense: 1 });
+    expect(agg.missedByAllLanes).toBe(false);
+  });
+
+  it("flags a must-have missed on every run", () => {
+    const runs: MustHaveRunObservation[] = [
+      { inPool: false, inTop10: false, lanes: [] },
+      { inPool: false, inTop10: false, lanes: [] },
+    ];
+    const agg = aggregateMustHave(runs);
+    expect(agg.inPoolRate).toBe(0);
+    expect(agg.missedByAllLanes).toBe(true);
+  });
+});
+
+describe("classifyDenseLiveness", () => {
+  it("alive when any run returned results", () => {
+    expect(
+      classifyDenseLiveness([
+        { status: { status: "ok" }, count: 0 },
+        { status: { status: "ok" }, count: 12 },
+      ])
+    ).toBe("alive");
+  });
+
+  it("dormant when every run is missing_config", () => {
+    expect(
+      classifyDenseLiveness([
+        { status: { status: "missing_config" }, count: 0 },
+        { status: { status: "missing_config" }, count: 0 },
+      ])
+    ).toBe("dormant");
+  });
+
+  it("configured_empty when reachable (ok) but always zero", () => {
+    expect(classifyDenseLiveness([{ status: { status: "ok" }, count: 0 }])).toBe(
+      "configured_empty"
+    );
+  });
+
+  it("degraded when reachable but every run errored/timed out", () => {
+    expect(
+      classifyDenseLiveness([
+        { status: { status: "timeout" }, count: 0 },
+        { status: { status: "error" }, count: 0 },
+      ])
+    ).toBe("degraded");
+  });
+});
+
+describe("summarizeOverall + gap", () => {
+  it("computes the retrieval-vs-ranking gap", () => {
+    const s = summarizeOverall([
+      { inPoolRate: 1, inTop10Rate: 0.5, lanesUnion: [], laneCounts: {}, missedByAllLanes: false },
+      { inPoolRate: 1, inTop10Rate: 1, lanesUnion: [], laneCounts: {}, missedByAllLanes: false },
+      { inPoolRate: 0, inTop10Rate: 0, lanesUnion: [], laneCounts: {}, missedByAllLanes: true },
+    ]);
+    expect(s.mustHaveCount).toBe(3);
+    expect(s.meanInPoolRate).toBeCloseTo(2 / 3);
+    expect(s.meanInTop10Rate).toBeCloseTo(0.5);
+    expect(s.gap).toBeCloseTo(2 / 3 - 0.5);
+    expect(s.missedByAllLanesCount).toBe(1);
+  });
+});
+
+describe("laneAttribution", () => {
+  it("credits owned dense vs federated and their exclusives", () => {
+    const attr = laneAttribution([
+      // found by federated only
+      { inPoolRate: 1, inTop10Rate: 1, lanesUnion: ["pubmed"], laneCounts: {}, missedByAllLanes: false },
+      // found by dense only
+      { inPoolRate: 1, inTop10Rate: 0, lanesUnion: ["medcpt_dense"], laneCounts: {}, missedByAllLanes: false },
+      // found by both
+      { inPoolRate: 1, inTop10Rate: 1, lanesUnion: ["europepmc", "medcpt_dense_hyde_0"], laneCounts: {}, missedByAllLanes: false },
+      // missed → excluded
+      { inPoolRate: 0, inTop10Rate: 0, lanesUnion: [], laneCounts: {}, missedByAllLanes: true },
+    ]);
+    expect(attr.perLane).toEqual({
+      pubmed: 1,
+      medcpt_dense: 1,
+      europepmc: 1,
+      medcpt_dense_hyde_0: 1,
+    });
+    expect(attr.denseFoundCount).toBe(2);
+    expect(attr.federatedFoundCount).toBe(2);
+    expect(attr.foundByDenseOnly).toBe(1);
+    expect(attr.foundByFederatedOnly).toBe(1);
+  });
+});
+
+describe("nonOkStatuses", () => {
+  it("returns only degraded lanes", () => {
+    const out = nonOkStatuses({
+      pubmed: { status: "ok" },
+      scopus: { status: "missing_config", message: "no key" },
+      europepmc: { status: "timeout", message: "slow" },
+    });
+    expect(out).toEqual([
+      { lane: "scopus", status: "missing_config", message: "no key" },
+      { lane: "europepmc", status: "timeout", message: "slow" },
+    ]);
+  });
+});

--- a/eval/literature-search/beir/.gitignore
+++ b/eval/literature-search/beir/.gitignore
@@ -1,0 +1,3 @@
+# Downloaded BEIR datasets (reproducible via the harness).
+.data/
+# Emitted run output lives under ../runs/ which is already gitignored.

--- a/eval/literature-search/beir/README.md
+++ b/eval/literature-search/beir/README.md
@@ -1,0 +1,72 @@
+# BEIR biomedical regression harness
+
+A standing, **external-benchmark** regression harness for our literature-search
+ranking. It scores our ranking against public, labeled BEIR biomedical datasets
+using the BEIR/trec_eval convention (nDCG@10, Recall@100), so quality is measured
+on data the pipeline was **never tuned on** — the opposite of the frozen-pool 87q
+harness that measured re-ranking against its own answer key.
+
+## Datasets
+
+| dataset      | on public mirror | corpus | test queries | notes |
+|--------------|:----------------:|-------:|-------------:|-------|
+| `nfcorpus`   | ✅ | 3.6K   | 323 | PubMed / NutritionFacts |
+| `scifact`    | ✅ | 5.2K   | 300 | scientific claim verification |
+| `trec-covid` | ✅ | 171K   | 50  | CORD-19; deep pools → low Recall@100 by construction |
+| `bioasq`     | ❌ | —      | —   | **blocked**: needs BioASQ registration + a custom corpus build; not on the public mirror. The downloader skips it and the runner reports it rather than faking a number. |
+
+## How it works
+
+1. **First stage — BM25** (`bm25.ts`, Anserini/BEIR defaults k1=0.9, b=0.4) over the
+   dataset corpus produces candidate docIds. Our production ranker is a *reranker*
+   (it reorders candidates, it doesn't scan a corpus), so a lexical first stage is
+   required on a fixed corpus.
+2. **Ranking stage**
+   - `--rank bm25` — score the BM25 ranking directly (the lexical baseline).
+   - `--rank rerank` — hand the BM25 top-C to our **production reranker**
+     (`src/lib/search/rerank.ts` → `cohere/rerank-4-pro` via OpenRouter) and score
+     the reordered head. This is our system's ranking quality on external labels.
+3. **Score** nDCG@10 + Recall@100 (`beir-score.ts`, verified against
+   `usnistgov/trec_eval` `m_ndcg_cut.c`: linear gain, log2 discount, recall over rel>0).
+
+### What it does and does not measure
+On a fixed corpus we can only exercise our **ranking** quality, not our live
+multi-source retrieval. **nDCG@10** is the metric reranking actually moves.
+**Recall@100** is bounded by the candidate depth `C`: with `C=100` the reranked
+top-100 is the same *set* as the BM25 top-100 (reranking reorders, it cannot add
+docs), so Recall@100 equals the BM25 pool's recall. BEIR corpora carry no
+journal/citation/evidence metadata, so our metadata quality signals don't apply
+here — this isolates **relevance**.
+
+## Running
+
+```bash
+# 1. Download datasets (public mirror; idempotent)
+tsx eval/literature-search/beir/fetch-dataset.ts nfcorpus scifact trec-covid
+
+# 2a. BM25 baseline (no secrets)
+tsx eval/literature-search/beir/run-beir.ts --dataset nfcorpus --label baseline --rank bm25
+
+# 2b. Our reranker (needs OPENROUTER_API_KEY — run under op-run)
+op-run -- tsx eval/literature-search/beir/run-beir.ts \
+  --dataset trec-covid --label rerank --rank rerank --candidates 100
+
+# Optional cost/time cap for large query sets:
+op-run -- tsx eval/literature-search/beir/run-beir.ts \
+  --dataset nfcorpus --label rerank --rank rerank --max-queries 50
+```
+
+Output lands in `eval/literature-search/runs/beir-<label>/<dataset>.json` (the
+`runs/` tree is gitignored — reproducible via this harness). Downloaded corpora
+live in `.data/` (gitignored).
+
+## Baseline numbers (BM25, this harness)
+
+| dataset      | nDCG@10 | Recall@100 | published BM25 (BEIR) |
+|--------------|--------:|-----------:|-----------------------|
+| nfcorpus     | 0.307   | 0.232      | ~0.325 / ~0.250 |
+| scifact      | 0.656   | 0.876      | ~0.665 / ~0.908 |
+| trec-covid   | 0.600   | 0.104      | ~0.656 / ~0.109 |
+
+Our BM25 sits just under the published Anserini BM25 (which adds Porter stemming +
+the full Lucene analyzer) — close enough to confirm the harness is correct.

--- a/eval/literature-search/beir/__tests__/beir-io.test.ts
+++ b/eval/literature-search/beir/__tests__/beir-io.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readCorpus, readQueries, readQrels } from "../beir-io";
+
+let dir: string;
+
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), "beir-io-"));
+  writeFileSync(
+    join(dir, "corpus.jsonl"),
+    [
+      JSON.stringify({ _id: "MED-1", title: "Aspirin", text: "reduces risk" }),
+      "", // blank line must be tolerated
+      JSON.stringify({ _id: "MED-2", title: "Statins", text: "cholesterol" }),
+    ].join("\n")
+  );
+  writeFileSync(
+    join(dir, "queries.jsonl"),
+    [
+      JSON.stringify({ _id: "Q1", text: "aspirin risk", metadata: {} }),
+      JSON.stringify({ _id: "Q2", text: "statins" }),
+    ].join("\n")
+  );
+  mkdirSync(join(dir, "qrels"), { recursive: true });
+  writeFileSync(
+    join(dir, "qrels", "test.tsv"),
+    ["query-id\tcorpus-id\tscore", "Q1\tMED-1\t2", "Q1\tMED-2\t0", "Q2\tMED-2\t1"].join("\n")
+  );
+});
+
+afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+describe("beir-io", () => {
+  it("streams corpus.jsonl into a docId→{title,text} map, tolerating blank lines", async () => {
+    const corpus = await readCorpus(dir);
+    expect(corpus.size).toBe(2);
+    expect(corpus.get("MED-1")).toEqual({ title: "Aspirin", text: "reduces risk" });
+  });
+
+  it("reads queries keyed by id", () => {
+    const q = readQueries(dir);
+    expect(q.size).toBe(2);
+    expect(q.get("Q1")!.text).toBe("aspirin risk");
+  });
+
+  it("parses qrels TSV, skipping the header, into nested graded maps", () => {
+    const qrels = readQrels(dir, "test");
+    expect(qrels.get("Q1")!.get("MED-1")).toBe(2);
+    expect(qrels.get("Q1")!.get("MED-2")).toBe(0);
+    expect(qrels.get("Q2")!.get("MED-2")).toBe(1);
+    expect(qrels.has("query-id")).toBe(false);
+  });
+});

--- a/eval/literature-search/beir/__tests__/beir-score.test.ts
+++ b/eval/literature-search/beir/__tests__/beir-score.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { ndcgAtK, recallAtK, meanIgnoringNull, type Qrels } from "../beir-score";
+
+// qrels: d1 highly relevant (2), d2 relevant (1), others unjudged (0).
+const qrels: Qrels = new Map([
+  ["d1", 2],
+  ["d2", 1],
+  ["d0", 0],
+]);
+
+describe("ndcgAtK (graded, linear gain, trec_eval convention)", () => {
+  it("matches a hand-computed value", () => {
+    // ranking [d3(0), d1(2), d2(1)]:
+    //   DCG  = 0/log2(2) + 2/log2(3) + 1/log2(4) = 1.26186 + 0.5 = 1.76186
+    //   IDCG = 2/log2(2) + 1/log2(3)             = 2 + 0.63093   = 2.63093
+    //   nDCG = 0.66970
+    const ndcg = ndcgAtK(["d3", "d1", "d2"], qrels, 3);
+    expect(ndcg).not.toBeNull();
+    expect(ndcg!).toBeCloseTo(0.6697, 4);
+  });
+
+  it("is 1.0 for the ideal ranking", () => {
+    expect(ndcgAtK(["d1", "d2", "d0"], qrels, 3)!).toBeCloseTo(1.0, 6);
+  });
+
+  it("truncates at k", () => {
+    // At k=1 only d3 (irrelevant) counts → DCG 0 → nDCG 0.
+    expect(ndcgAtK(["d3", "d1", "d2"], qrels, 1)!).toBeCloseTo(0, 6);
+  });
+
+  it("returns null when the query has no positively judged docs", () => {
+    expect(ndcgAtK(["a", "b"], new Map([["x", 0]]), 10)).toBeNull();
+  });
+});
+
+describe("recallAtK (relevant = grade > 0)", () => {
+  it("counts relevant docs retrieved over total relevant", () => {
+    expect(recallAtK(["d3", "d1", "d2"], qrels, 3)!).toBeCloseTo(1.0, 6); // both found
+    expect(recallAtK(["d3", "d1"], qrels, 2)!).toBeCloseTo(0.5, 6); // only d1 of {d1,d2}
+    expect(recallAtK(["d3"], qrels, 1)!).toBeCloseTo(0, 6);
+  });
+
+  it("ignores graded value, only presence matters", () => {
+    expect(recallAtK(["d2", "d1"], qrels, 100)!).toBeCloseTo(1.0, 6);
+  });
+
+  it("returns null when there are no relevant docs", () => {
+    expect(recallAtK(["a"], new Map([["x", 0]]), 10)).toBeNull();
+  });
+});
+
+describe("meanIgnoringNull", () => {
+  it("averages only non-null values", () => {
+    expect(meanIgnoringNull([1, null, 0])!).toBeCloseTo(0.5, 6);
+    expect(meanIgnoringNull([null, null])).toBeNull();
+  });
+});

--- a/eval/literature-search/beir/__tests__/bm25.test.ts
+++ b/eval/literature-search/beir/__tests__/bm25.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { tokenize, buildIndex, search } from "../bm25";
+
+describe("tokenize", () => {
+  it("lowercases, splits on non-alphanumerics, drops stopwords and 1-char tokens", () => {
+    expect(tokenize("The COVID-19 vaccine, a trial!")).toEqual([
+      "covid",
+      "19",
+      "vaccine",
+      "trial",
+    ]);
+  });
+});
+
+describe("BM25 search", () => {
+  const docs = [
+    { id: "d1", text: "aspirin reduces cardiovascular risk in diabetes" },
+    { id: "d2", text: "aspirin aspirin aspirin dosing guidelines" },
+    { id: "d3", text: "statins and cholesterol in cardiovascular disease" },
+  ];
+  const index = buildIndex(docs);
+
+  it("ranks a doc with the rarer matching term above a doc with only common terms", () => {
+    // "statins" appears only in d3 (high idf) → d3 should top this query.
+    const ranked = search(index, "statins cardiovascular", 3);
+    expect(ranked[0]).toBe("d3");
+  });
+
+  it("rewards term frequency (saturating)", () => {
+    // d2 repeats 'aspirin' → outranks d1 for a bare 'aspirin' query.
+    const ranked = search(index, "aspirin", 3);
+    expect(ranked[0]).toBe("d2");
+    expect(ranked).toContain("d1");
+    expect(ranked).not.toContain("d3"); // d3 has no 'aspirin'
+  });
+
+  it("returns at most topN and only docs sharing a query term", () => {
+    const ranked = search(index, "aspirin", 1);
+    expect(ranked).toHaveLength(1);
+  });
+
+  it("returns empty for a query with no corpus term overlap", () => {
+    expect(search(index, "oncology immunotherapy", 10)).toEqual([]);
+  });
+
+  it("is deterministic (stable tie-break by docId)", () => {
+    const a = search(index, "cardiovascular", 10);
+    const b = search(index, "cardiovascular", 10);
+    expect(a).toEqual(b);
+  });
+});

--- a/eval/literature-search/beir/beir-io.ts
+++ b/eval/literature-search/beir/beir-io.ts
@@ -1,0 +1,72 @@
+/**
+ * Readers for the BEIR on-disk format (as shipped in the public zips):
+ *   corpus.jsonl   — {"_id","title","text",...} one JSON object per line
+ *   queries.jsonl  — {"_id","text","metadata"}   one JSON object per line
+ *   qrels/<split>.tsv — TSV "query-id\tcorpus-id\tscore" with a header row
+ *
+ * corpus.jsonl is streamed line-by-line (TREC-COVID's is large), so we never
+ * hold the whole file as one string.
+ */
+
+import { createReadStream } from "node:fs";
+import { createInterface } from "node:readline";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export interface BeirDoc {
+  title: string;
+  text: string;
+}
+
+/** Stream corpus.jsonl into a Map<docId, {title, text}>. */
+export async function readCorpus(datasetDir: string): Promise<Map<string, BeirDoc>> {
+  const corpus = new Map<string, BeirDoc>();
+  const rl = createInterface({
+    input: createReadStream(join(datasetDir, "corpus.jsonl"), "utf8"),
+    crlfDelay: Infinity,
+  });
+  for await (const line of rl) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const obj = JSON.parse(trimmed) as { _id: string; title?: string; text?: string };
+    corpus.set(String(obj._id), { title: obj.title ?? "", text: obj.text ?? "" });
+  }
+  return corpus;
+}
+
+export interface BeirQuery {
+  id: string;
+  text: string;
+}
+
+export function readQueries(datasetDir: string): Map<string, BeirQuery> {
+  const out = new Map<string, BeirQuery>();
+  const raw = readFileSync(join(datasetDir, "queries.jsonl"), "utf8");
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const obj = JSON.parse(trimmed) as { _id: string; text?: string };
+    out.set(String(obj._id), { id: String(obj._id), text: obj.text ?? "" });
+  }
+  return out;
+}
+
+/** qrels/<split>.tsv → Map<queryId, Map<docId, score>>. Ignores the header row. */
+export function readQrels(
+  datasetDir: string,
+  split = "test"
+): Map<string, Map<string, number>> {
+  const out = new Map<string, Map<string, number>>();
+  const raw = readFileSync(join(datasetDir, "qrels", `${split}.tsv`), "utf8");
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const [qid, docId, scoreStr] = trimmed.split(/\t/);
+    if (qid === "query-id" || scoreStr === undefined) continue; // header / malformed
+    const score = Number(scoreStr);
+    if (Number.isNaN(score)) continue;
+    if (!out.has(qid)) out.set(qid, new Map());
+    out.get(qid)!.set(docId, score);
+  }
+  return out;
+}

--- a/eval/literature-search/beir/beir-score.ts
+++ b/eval/literature-search/beir/beir-score.ts
@@ -1,0 +1,70 @@
+/**
+ * BEIR-convention retrieval metrics: graded nDCG@k and Recall@k against a qrels
+ * relevance map keyed by CORPUS DOC ID.
+ *
+ * This mirrors trec_eval / pytrec_eval (the library BEIR itself uses) so the
+ * numbers are comparable to published BEIR results:
+ *   - gain is LINEAR (the raw relevance grade, e.g. 0/1/2), NOT 2^rel − 1
+ *   - discount is 1 / log2(rank + 1) with 1-based rank (position 0 → 1/log2(2) = 1)
+ *   - Recall counts a doc as relevant iff its grade > 0
+ * Verified against usnistgov/trec_eval `m_ndcg_cut.c`.
+ *
+ * These are docId-keyed and graded, which is why they are a separate module from
+ * `src/lib/search/eval/metrics.ts` (which is must-have/PMID keyed and binary). The
+ * conventions (log2 discount, @k truncation) are deliberately kept parallel.
+ *
+ * Pure functions, no I/O — unit tested by vitest.
+ */
+
+export type Qrels = Map<string, number>;
+
+/** DCG of a ranked docId list against graded qrels, truncated at k. */
+function dcgAtK(ranked: string[], qrels: Qrels, k: number): number {
+  let dcg = 0;
+  const top = ranked.slice(0, k);
+  for (let i = 0; i < top.length; i++) {
+    const gain = qrels.get(top[i]) ?? 0;
+    if (gain > 0) dcg += gain / Math.log2(i + 2);
+  }
+  return dcg;
+}
+
+/** Ideal DCG: gains sorted descending, truncated at k. */
+function idealDcgAtK(qrels: Qrels, k: number): number {
+  const grades = [...qrels.values()].filter((g) => g > 0).sort((a, b) => b - a);
+  let idcg = 0;
+  const top = grades.slice(0, k);
+  for (let i = 0; i < top.length; i++) idcg += top[i] / Math.log2(i + 2);
+  return idcg;
+}
+
+/**
+ * nDCG@k (graded, linear gain). Returns null when the query has NO positively
+ * judged documents (undefined ideal) so the aggregator can exclude it, matching
+ * trec_eval's handling of queries with no relevant docs.
+ */
+export function ndcgAtK(ranked: string[], qrels: Qrels, k: number): number | null {
+  const idcg = idealDcgAtK(qrels, k);
+  if (idcg === 0) return null;
+  return dcgAtK(ranked, qrels, k) / idcg;
+}
+
+/**
+ * Recall@k = (relevant docs, grade > 0, appearing in the top k) / (total relevant
+ * docs). Returns null when there are no relevant docs (undefined denominator).
+ */
+export function recallAtK(ranked: string[], qrels: Qrels, k: number): number | null {
+  const relevant = new Set([...qrels.entries()].filter(([, g]) => g > 0).map(([d]) => d));
+  if (relevant.size === 0) return null;
+  const top = ranked.slice(0, k);
+  let found = 0;
+  for (const d of top) if (relevant.has(d)) found++;
+  return found / relevant.size;
+}
+
+/** Mean of non-null values (queries with no relevant docs are excluded). */
+export function meanIgnoringNull(values: (number | null)[]): number | null {
+  const nums = values.filter((v): v is number => v !== null && !Number.isNaN(v));
+  if (nums.length === 0) return null;
+  return nums.reduce((a, b) => a + b, 0) / nums.length;
+}

--- a/eval/literature-search/beir/bm25.ts
+++ b/eval/literature-search/beir/bm25.ts
@@ -1,0 +1,116 @@
+/**
+ * Minimal, dependency-free BM25 for the BEIR harness FIRST STAGE.
+ *
+ * Why a first stage at all: our production ranking stage (`rerankResults` in
+ * src/lib/search/rerank.ts) is a cross-encoder reranker — it re-orders a
+ * candidate set, it does not scan a corpus. On a fixed BEIR corpus we therefore
+ * generate candidates with lexical BM25, then hand the top-N to our reranker.
+ * BM25 here uses the Anserini/BEIR biomedical defaults (k1=0.9, b=0.4) so the
+ * BM25-only column is itself a recognizable baseline.
+ *
+ * Lucene-style non-negative IDF: idf = ln(1 + (N − df + 0.5)/(df + 0.5)).
+ *
+ * Pure and deterministic — unit tested by vitest.
+ */
+
+export const BM25_K1 = 0.9;
+export const BM25_B = 0.4;
+
+const STOPWORDS = new Set([
+  "the", "a", "an", "and", "or", "of", "to", "in", "on", "for", "with", "at",
+  "by", "from", "as", "is", "are", "was", "were", "be", "been", "it", "its",
+  "this", "that", "these", "those", "which", "what", "how", "does", "do", "did",
+]);
+
+export function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .split(" ")
+    .filter((t) => t.length >= 2 && !STOPWORDS.has(t));
+}
+
+export interface Bm25Doc {
+  id: string;
+  text: string;
+}
+
+interface Posting {
+  docId: string;
+  tf: number;
+}
+
+export interface Bm25Index {
+  postings: Map<string, Posting[]>;
+  df: Map<string, number>;
+  docLen: Map<string, number>;
+  avgdl: number;
+  n: number;
+  k1: number;
+  b: number;
+}
+
+export function buildIndex(
+  docs: Bm25Doc[],
+  opts: { k1?: number; b?: number } = {}
+): Bm25Index {
+  const postings = new Map<string, Posting[]>();
+  const df = new Map<string, number>();
+  const docLen = new Map<string, number>();
+  let totalLen = 0;
+
+  for (const doc of docs) {
+    const tokens = tokenize(doc.text);
+    docLen.set(doc.id, tokens.length);
+    totalLen += tokens.length;
+    const tf = new Map<string, number>();
+    for (const t of tokens) tf.set(t, (tf.get(t) ?? 0) + 1);
+    for (const [term, count] of tf) {
+      if (!postings.has(term)) postings.set(term, []);
+      postings.get(term)!.push({ docId: doc.id, tf: count });
+      df.set(term, (df.get(term) ?? 0) + 1);
+    }
+  }
+
+  return {
+    postings,
+    df,
+    docLen,
+    avgdl: docs.length ? totalLen / docs.length : 0,
+    n: docs.length,
+    k1: opts.k1 ?? BM25_K1,
+    b: opts.b ?? BM25_B,
+  };
+}
+
+function idf(index: Bm25Index, term: string): number {
+  const df = index.df.get(term) ?? 0;
+  return Math.log(1 + (index.n - df + 0.5) / (df + 0.5));
+}
+
+/** Rank docIds by BM25 for a query, returning the top-N (ties broken by docId for
+ * determinism). */
+export function search(index: Bm25Index, query: string, topN: number): string[] {
+  const terms = tokenize(query);
+  const scores = new Map<string, number>();
+  const seenQueryTerms = new Set<string>();
+
+  for (const term of terms) {
+    if (seenQueryTerms.has(term)) continue; // count each query term's idf once
+    seenQueryTerms.add(term);
+    const postings = index.postings.get(term);
+    if (!postings) continue;
+    const termIdf = idf(index, term);
+    for (const { docId, tf } of postings) {
+      const dl = index.docLen.get(docId) ?? 0;
+      const denom = tf + index.k1 * (1 - index.b + (index.b * dl) / (index.avgdl || 1));
+      const contribution = termIdf * ((tf * (index.k1 + 1)) / denom);
+      scores.set(docId, (scores.get(docId) ?? 0) + contribution);
+    }
+  }
+
+  return [...scores.entries()]
+    .sort((a, b) => (b[1] - a[1]) || (a[0] < b[0] ? -1 : 1))
+    .slice(0, topN)
+    .map(([docId]) => docId);
+}

--- a/eval/literature-search/beir/fetch-dataset.ts
+++ b/eval/literature-search/beir/fetch-dataset.ts
@@ -1,0 +1,63 @@
+/**
+ * Download + extract a public BEIR dataset zip into `.data/<name>/`.
+ *
+ * Datasets live at the canonical UKP mirror the BEIR project publishes:
+ *   https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/<name>.zip
+ * Each zip contains corpus.jsonl, queries.jsonl, and qrels/{train,dev,test}.tsv.
+ *
+ * Uses the system `curl` + `unzip` (present on macOS/Linux) to avoid adding a
+ * zip dependency. Idempotent: skips extraction if the dataset dir already exists.
+ *
+ * Usage: tsx eval/literature-search/beir/fetch-dataset.ts <name> [<name> ...]
+ *
+ * NOTE ON BIOASQ: BioASQ is NOT on this public mirror — it requires BioASQ
+ * account registration and a custom corpus build (see BEIR docs). It is skipped
+ * by this downloader; the runner reports it as blocked rather than faking it.
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+export const DATA_DIR = join(HERE, ".data");
+const MIRROR = "https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets";
+
+/** Datasets known to be on the public mirror (small + biomedical first). */
+export const PUBLIC_BIOMED_DATASETS = ["nfcorpus", "scifact", "trec-covid"] as const;
+
+export function datasetDir(name: string): string {
+  return join(DATA_DIR, name);
+}
+
+export function fetchDataset(name: string): string {
+  const dir = datasetDir(name);
+  if (existsSync(join(dir, "corpus.jsonl"))) {
+    console.log(`[beir] ${name}: already present at ${dir}`);
+    return dir;
+  }
+  mkdirSync(DATA_DIR, { recursive: true });
+  const zipPath = join(DATA_DIR, `${name}.zip`);
+  const url = `${MIRROR}/${name}.zip`;
+  console.log(`[beir] ${name}: downloading ${url}`);
+  execFileSync("curl", ["-sS", "-L", "-f", "-o", zipPath, url], { stdio: "inherit" });
+  console.log(`[beir] ${name}: extracting`);
+  execFileSync("unzip", ["-o", "-q", zipPath, "-d", DATA_DIR], { stdio: "inherit" });
+  rmSync(zipPath, { force: true });
+  if (!existsSync(join(dir, "corpus.jsonl"))) {
+    throw new Error(
+      `[beir] ${name}: extraction did not produce ${dir}/corpus.jsonl — check the mirror layout`
+    );
+  }
+  console.log(`[beir] ${name}: ready at ${dir}`);
+  return dir;
+}
+
+function main() {
+  const names = process.argv.slice(2);
+  const targets = names.length ? names : [...PUBLIC_BIOMED_DATASETS];
+  for (const name of targets) fetchDataset(name);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main();

--- a/eval/literature-search/beir/run-beir.ts
+++ b/eval/literature-search/beir/run-beir.ts
@@ -1,0 +1,175 @@
+/**
+ * BEIR biomedical regression harness — runs our retrieval+ranking against
+ * external, labeled BEIR datasets and reports nDCG@10 + Recall@100 per dataset.
+ *
+ * Pipeline per query:
+ *   1. BM25 first stage over the dataset corpus → ranked candidate docIds
+ *      (our production ranker is a reranker, not a corpus scanner — see bm25.ts).
+ *   2. Ranking stage:
+ *        --rank bm25   : score the BM25 ranking directly (the lexical baseline).
+ *        --rank rerank : hand the BM25 top-C to our PRODUCTION reranker
+ *                        (src/lib/search/rerank.ts → cohere/rerank-4-pro via
+ *                        OpenRouter) and score the reordered head + BM25 tail.
+ *   3. Score nDCG@10 and Recall@100 (trec_eval/BEIR convention — see beir-score.ts).
+ *
+ * What this measures honestly: on a FIXED external corpus we can only exercise
+ * our RANKING quality, not our live multi-source retrieval. nDCG@10 is the metric
+ * reranking actually moves. Recall@100 is bounded by the candidate depth C: with
+ * C=100 the reranked top-100 is the same SET as the BM25 top-100, so Recall@100
+ * equals the BM25 pool's recall (reranking reorders, it cannot add docs). The
+ * BEIR corpora also carry no journal/citation/evidence metadata, so our
+ * metadata-based quality signals do not apply here — this isolates relevance.
+ *
+ * Output: eval/literature-search/runs/beir-<label>/<dataset>.json + summary.json
+ * (the runs/ tree is gitignored — reproducible via this harness).
+ *
+ * Usage:
+ *   op-run -- tsx eval/literature-search/beir/run-beir.ts \
+ *     --dataset nfcorpus --label baseline --rank bm25
+ *   op-run -- tsx eval/literature-search/beir/run-beir.ts \
+ *     --dataset trec-covid --label rerank --rank rerank --candidates 100 [--max-queries N]
+ */
+
+import { writeFileSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { UnifiedSearchResult } from "@/types/search";
+import { rerankResults, hasReranker } from "@/lib/search/rerank";
+import { fetchDataset } from "./fetch-dataset";
+import { readCorpus, readQueries, readQrels } from "./beir-io";
+import { buildIndex, search } from "./bm25";
+import { ndcgAtK, recallAtK, meanIgnoringNull, type Qrels } from "./beir-score";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const RUNS_DIR = join(HERE, "..", "runs");
+const SCORE_DEPTH = 1000; // BM25 ranking depth kept for Recall@100 scoring.
+
+interface Args {
+  dataset: string;
+  label: string;
+  rank: "bm25" | "rerank";
+  candidates: number;
+  maxQueries: number | null;
+}
+
+function parseArgs(argv: string[]): Args {
+  const a: Args = {
+    dataset: "nfcorpus",
+    label: "baseline",
+    rank: "bm25",
+    candidates: 100,
+    maxQueries: null,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--dataset") a.dataset = argv[++i];
+    else if (argv[i] === "--label") a.label = argv[++i];
+    else if (argv[i] === "--rank") a.rank = argv[++i] === "rerank" ? "rerank" : "bm25";
+    else if (argv[i] === "--candidates") a.candidates = Number(argv[++i]) || 100;
+    else if (argv[i] === "--max-queries") a.maxQueries = Number(argv[++i]) || null;
+  }
+  return a;
+}
+
+interface CorpusDoc {
+  title: string;
+  text: string;
+}
+
+/** Rerank the BM25 top-C via our production reranker; return the full ranking
+ * (reranked head ++ BM25 tail). Falls back to the BM25 order if no reranker. */
+async function rerankHead(
+  query: string,
+  bm25Ranked: string[],
+  corpus: Map<string, CorpusDoc>,
+  candidates: number
+): Promise<string[]> {
+  const head = bm25Ranked.slice(0, candidates);
+  const tail = bm25Ranked.slice(candidates);
+  const inputs = head.map((docId) => {
+    const doc = corpus.get(docId);
+    return {
+      __docId: docId,
+      title: doc?.title ?? "",
+      abstract: doc?.text ?? "",
+    } as unknown as UnifiedSearchResult;
+  });
+  const reranked = await rerankResults(query, inputs, head.length);
+  // rerankResults returns the head reordered (mapping by index), preserving our
+  // __docId. If it fell back (same array / no scores) the order is unchanged.
+  const rerankedIds = reranked.map(
+    (r) => (r as unknown as { __docId: string }).__docId
+  );
+  return [...rerankedIds, ...tail];
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  console.log(
+    `[beir] dataset=${args.dataset} label=${args.label} rank=${args.rank} candidates=${args.candidates}` +
+      (args.maxQueries ? ` maxQueries=${args.maxQueries}` : "")
+  );
+  if (args.rank === "rerank" && !hasReranker()) {
+    throw new Error(
+      "[beir] --rank rerank requires a reranker (OPENROUTER_API_KEY/COHERE_API_KEY). Run under `op-run --`."
+    );
+  }
+
+  const dir = fetchDataset(args.dataset);
+  const corpus = await readCorpus(dir);
+  const queries = readQueries(dir);
+  const qrels = readQrels(dir, "test");
+  console.log(
+    `[beir] corpus=${corpus.size} docs · queries(test qrels)=${qrels.size} · building BM25 index…`
+  );
+
+  const index = buildIndex([...corpus.entries()].map(([id, d]) => ({ id, text: `${d.title} ${d.text}` })));
+
+  const queryIds = [...qrels.keys()].filter((qid) => queries.has(qid));
+  const targets = args.maxQueries ? queryIds.slice(0, args.maxQueries) : queryIds;
+
+  const ndcgs: (number | null)[] = [];
+  const recalls: (number | null)[] = [];
+  let done = 0;
+  for (const qid of targets) {
+    const q = queries.get(qid)!;
+    const rel = qrels.get(qid) as Qrels;
+    const bm25Ranked = search(index, q.text, SCORE_DEPTH);
+    const ranking =
+      args.rank === "rerank"
+        ? await rerankHead(q.text, bm25Ranked, corpus, args.candidates)
+        : bm25Ranked;
+    ndcgs.push(ndcgAtK(ranking, rel, 10));
+    recalls.push(recallAtK(ranking, rel, 100));
+    done++;
+    if (done % 25 === 0) console.log(`[beir]   scored ${done}/${targets.length}`);
+  }
+
+  const result = {
+    dataset: args.dataset,
+    label: args.label,
+    rank: args.rank,
+    candidates: args.candidates,
+    scoredQueries: targets.length,
+    totalTestQueries: queryIds.length,
+    corpusDocs: corpus.size,
+    metrics: {
+      ndcgAt10: meanIgnoringNull(ndcgs),
+      recallAt100: meanIgnoringNull(recalls),
+    },
+    generatedAt: new Date().toISOString(),
+  };
+
+  const outDir = join(RUNS_DIR, `beir-${args.label}`);
+  mkdirSync(outDir, { recursive: true });
+  writeFileSync(join(outDir, `${args.dataset}.json`), JSON.stringify(result, null, 2));
+
+  const nd = result.metrics.ndcgAt10;
+  const rc = result.metrics.recallAt100;
+  console.log(
+    `[beir] ${args.dataset} (${args.rank}) → nDCG@10=${nd?.toFixed(4) ?? "n/a"} · ` +
+      `Recall@100=${rc?.toFixed(4) ?? "n/a"} · scored ${targets.length} queries`
+  );
+  console.log(`[beir] wrote ${join(outDir, `${args.dataset}.json`)}`);
+}
+
+main();

--- a/eval/literature-search/council/.gitignore
+++ b/eval/literature-search/council/.gitignore
@@ -1,2 +1,5 @@
 raw-*.txt
 *.err
+
+# Generated neutral abstract cache (reproducible via build-abstract-cache.ts).
+abstract-cache.json

--- a/eval/literature-search/council/__tests__/abstract-format.test.ts
+++ b/eval/literature-search/council/__tests__/abstract-format.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizeAbstract,
+  ABSTRACT_MAX_CHARS,
+  ABSTRACT_UNAVAILABLE,
+} from "../abstract-format";
+
+describe("normalizeAbstract", () => {
+  it("returns empty string for empty/nullish input", () => {
+    expect(normalizeAbstract("")).toBe("");
+    expect(normalizeAbstract(undefined)).toBe("");
+    expect(normalizeAbstract(null)).toBe("");
+    expect(normalizeAbstract("   \n\t ")).toBe("");
+  });
+
+  it("collapses all whitespace to single spaces", () => {
+    expect(normalizeAbstract("a\n\n  b\t c")).toBe("a b c");
+  });
+
+  it("strips Europe PMC HTML tags and keeps heading words readable", () => {
+    const raw =
+      "<h4>Background</h4>In patients with heart failure, dapagliflozin reduced events.<h4>Methods</h4>A randomized trial.";
+    const out = normalizeAbstract(raw);
+    expect(out).not.toContain("<");
+    expect(out).not.toContain(">");
+    // Leading structured heading is stripped; interior heading kept as readable text.
+    expect(out.startsWith("In patients")).toBe(true);
+    expect(out).toContain("Methods: A randomized trial");
+  });
+
+  it("strips a leading plain-text section heading with a colon", () => {
+    expect(normalizeAbstract("Background: The disease is common.")).toBe(
+      "The disease is common."
+    );
+    expect(normalizeAbstract("RESULTS — 200 patients enrolled.")).toBe(
+      "200 patients enrolled."
+    );
+  });
+
+  it("decodes the common HTML entities", () => {
+    expect(normalizeAbstract("aspirin &amp; warfarin &lt; placebo")).toBe(
+      "aspirin & warfarin < placebo"
+    );
+  });
+
+  it("truncates on a word boundary with an ellipsis", () => {
+    const long = "word ".repeat(300).trim(); // ~1500 chars
+    const out = normalizeAbstract(long, 50);
+    expect(out.length).toBeLessThanOrEqual(51); // 50 + ellipsis char
+    expect(out.endsWith("…")).toBe(true);
+    expect(out).not.toContain("wor…"); // clipped at a space, not mid-word
+  });
+
+  it("does not truncate text at or under the limit", () => {
+    const short = "A concise abstract.";
+    expect(normalizeAbstract(short, ABSTRACT_MAX_CHARS)).toBe(short);
+    expect(normalizeAbstract(short, ABSTRACT_MAX_CHARS).endsWith("…")).toBe(false);
+  });
+
+  it("exposes a stable placeholder distinct from any normalized abstract", () => {
+    expect(ABSTRACT_UNAVAILABLE).toContain("unavailable");
+    expect(normalizeAbstract(ABSTRACT_UNAVAILABLE)).not.toBe("");
+  });
+});

--- a/eval/literature-search/council/abstract-format.ts
+++ b/eval/literature-search/council/abstract-format.ts
@@ -1,0 +1,64 @@
+/**
+ * Pure helpers for rendering result abstracts inside the BLINDED council packet.
+ *
+ * Blinding rule: an abstract is a property of the PAPER, not of the engine that
+ * returned it. Both engines' abstracts are therefore sourced from ONE neutral
+ * provider (Europe PMC — see `build-abstract-cache.ts`) and passed through the
+ * SAME normalization here, so a judge cannot infer engine identity from abstract
+ * length, structured-heading style, or whitespace. Where no abstract is available
+ * the caller renders an identical placeholder for either engine.
+ */
+
+/** Max characters of abstract text shown per result in the packet. Long enough to
+ * judge clinical relevance/trust, short enough that structured vs plain abstracts
+ * converge in appearance and the packet stays readable. */
+export const ABSTRACT_MAX_CHARS = 500;
+
+/** Structured-abstract section headings some sources prepend (e.g. "Background:",
+ * "Methods:"). Stripped so a source that keeps headings can't be told apart from
+ * one that doesn't. */
+const SECTION_HEADING =
+  /^(background|introduction|objectives?|aims?|methods?|materials and methods|results?|conclusions?|findings|interpretation|importance|design|setting|participants|purpose|summary)\s*[:.—-]\s*/i;
+
+/** Decode the handful of HTML entities Europe PMC abstracts actually contain. */
+function decodeEntities(s: string): string {
+  return s
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)));
+}
+
+/**
+ * Normalize an abstract to a single blinding-safe line: strip HTML markup (Europe
+ * PMC wraps structured-abstract headings in `<h4>` tags), collapse all whitespace,
+ * strip a leading structured-section heading, and truncate to {@link ABSTRACT_MAX_CHARS}
+ * on a word boundary with an ellipsis. Returns "" for empty/whitespace input.
+ */
+export function normalizeAbstract(
+  raw: string | undefined | null,
+  maxChars = ABSTRACT_MAX_CHARS
+): string {
+  if (!raw) return "";
+  // Turn heading/paragraph tags into separators so words don't run together, then
+  // drop every remaining tag. Uniform for both engines (single abstract provider).
+  let text = decodeEntities(
+    String(raw)
+      .replace(/<\/(h[1-6]|p|div|sec|title)>/gi, ": ")
+      .replace(/<[^>]+>/g, " ")
+  )
+    .replace(/\s*:\s*:\s*/g, ": ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (text === "") return "";
+  text = text.replace(SECTION_HEADING, "").trim();
+  if (text.length <= maxChars) return text;
+  const clipped = text.slice(0, maxChars);
+  const lastSpace = clipped.lastIndexOf(" ");
+  const body = lastSpace > maxChars * 0.6 ? clipped.slice(0, lastSpace) : clipped;
+  return `${body.trim()}…`;
+}
+
+/** The single, engine-independent line shown when a paper has no abstract available. */
+export const ABSTRACT_UNAVAILABLE = "_(abstract unavailable)_";

--- a/eval/literature-search/council/aggregate-blinded.ts
+++ b/eval/literature-search/council/aggregate-blinded.ts
@@ -118,8 +118,23 @@ function main() {
   const mananBeatsOrTies = tally.manan + tally.tie;
   const pctBeatTie = rows.length ? Math.round((mananBeatsOrTies / rows.length) * 100) : 0;
 
+  // The project's own stop gate: Manan must beat-or-tie Elicit on ≥ 80% of
+  // queries. This is the HONEST headline — a raw win count (e.g. "47 wins")
+  // flatters the system by hiding the ties and losses the gate is defined over.
+  const STOP_GATE_PCT = 80;
+  const gatePass = pctBeatTie >= STOP_GATE_PCT;
+  const verdictLine = `${gatePass ? "PASS" : "FAIL"} — Manan beats-or-ties Elicit on ${mananBeatsOrTies}/${rows.length} queries (${pctBeatTie}%), gate ≥ ${STOP_GATE_PCT}%`;
+
   const md: string[] = [];
   md.push("# BLINDED LLM-Council Verdict — Manan vs Elicit", "");
+  md.push(`## ${gatePass ? "✅ PASS" : "❌ FAIL"} — ${pctBeatTie}% beat-or-tie vs ${STOP_GATE_PCT}% gate`, "");
+  md.push(
+    `Manan beats-or-ties Elicit on **${mananBeatsOrTies} of ${rows.length}** queries ` +
+      `(**${pctBeatTie}%**). Stop gate is **≥ ${STOP_GATE_PCT}%** → **${gatePass ? "PASS" : "FAIL"}**.`,
+    "",
+    `_Raw split (wins are NOT the gate): Manan ${tally.manan} · Elicit ${tally.elicit} · tie ${tally.tie}._`,
+    ""
+  );
   md.push(`Cycle dir: \`${dir}\` · Manan run: \`${key.run}\` · blinding salt: \`${key.salt}\``);
   md.push(`Judges (isolated, blinded A/B): ${present.join(", ")}.`, "");
   md.push("## Per-query majority vote (de-anonymized)", "");
@@ -132,10 +147,10 @@ function main() {
   }
   md.push("");
   md.push("## Tally (by per-query majority)", "");
-  md.push(`- **Manan wins: ${tally.manan}**`);
+  md.push(`- **Manan beats-or-ties: ${mananBeatsOrTies}/${rows.length} = ${pctBeatTie}% → ${gatePass ? "PASS" : "FAIL"}** (stop gate ≥ ${STOP_GATE_PCT}%)`);
+  md.push(`- Manan wins: ${tally.manan}`);
   md.push(`- Elicit wins: ${tally.elicit}`);
-  md.push(`- Ties: ${tally.tie}`);
-  md.push(`- **Manan beats-or-ties: ${mananBeatsOrTies}/${rows.length} = ${pctBeatTie}%** (Stop gate ≥ 80%)`, "");
+  md.push(`- Ties: ${tally.tie}`, "");
   md.push("## Judge overall summaries (blinded — A/B)", "");
   for (const j of present) md.push(`- **${j}:** winner=${verdicts[j].overall.winner} — ${verdicts[j].overall.summary}`);
   md.push("");
@@ -144,13 +159,24 @@ function main() {
   writeFileSync(
     join(cycleDir, "council-summary.json"),
     JSON.stringify(
-      { dir, run: key.run, salt: key.salt, judges: present, tally, mananBeatsOrTies, pctBeatTie, rows },
+      {
+        dir,
+        run: key.run,
+        salt: key.salt,
+        judges: present,
+        gate: { metric: "pctBeatTie", threshold: STOP_GATE_PCT, value: pctBeatTie, pass: gatePass },
+        tally,
+        mananBeatsOrTies,
+        pctBeatTie,
+        rows,
+      },
       null,
       2
     )
   );
+  console.log(`[council] ${verdictLine}`);
   console.log(
-    `[council] dir=${dir} judges=${present.join("+")} → Manan ${tally.manan} / Elicit ${tally.elicit} / tie ${tally.tie} · beat-or-tie ${pctBeatTie}%`
+    `[council]   raw split — Manan ${tally.manan} / Elicit ${tally.elicit} / tie ${tally.tie} (dir=${dir}, judges=${present.join("+")})`
   );
 }
 

--- a/eval/literature-search/council/build-abstract-cache.ts
+++ b/eval/literature-search/council/build-abstract-cache.ts
@@ -1,0 +1,175 @@
+/**
+ * Build a NEUTRAL abstract cache for the blinded council packet.
+ *
+ * The blinded packet shows an abstract under every result so judges score
+ * clinical relevance/trust from what a user actually sees. To keep engine
+ * blinding intact, the abstract must NOT come from the engine's own payload
+ * (Manan carries abstracts; the Elicit fixtures do not — that asymmetry would
+ * leak identity). Instead every abstract is fetched from ONE neutral provider,
+ * Europe PMC, keyed only by the paper's PMID/DOI. Papers with no id, or that
+ * Europe PMC has no abstract for, get an identical placeholder in the packet.
+ *
+ * Output: `abstract-cache.json` = { byPmid, byDoi, meta }. The packet builder
+ * reads it and renders abstracts from it alone. Re-runnable and idempotent.
+ *
+ * Usage:
+ *   op-run -- tsx eval/literature-search/council/build-abstract-cache.ts \
+ *     --run <run-label> [--out abstract-cache.json] [--concurrency 6]
+ *
+ * (No secret is strictly required — Europe PMC is keyless — but running under
+ *  op-run keeps it consistent with the rest of the eval tooling.)
+ */
+
+import { readFileSync, writeFileSync, existsSync, readdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const EUROPE_PMC = "https://www.ebi.ac.uk/europepmc/webservices/rest/search";
+
+function normalizeDoi(doi: string | undefined | null): string | undefined {
+  if (!doi) return undefined;
+  return doi
+    .trim()
+    .toLowerCase()
+    .replace(/^https?:\/\/(dx\.)?doi\.org\//, "")
+    .replace(/\s+/g, "");
+}
+
+interface Ref {
+  pmid?: string;
+  doi?: string;
+}
+
+function collectIds(runLabel: string): Ref[] {
+  const seen = new Set<string>();
+  const refs: Ref[] = [];
+  const add = (pmid?: string, doi?: string) => {
+    const nd = normalizeDoi(doi);
+    const key = `${pmid ?? ""}|${nd ?? ""}`;
+    if (key === "|" || seen.has(key)) return;
+    seen.add(key);
+    refs.push({ pmid: pmid || undefined, doi: nd });
+  };
+
+  // Manan run (top 10 per query).
+  const runDir = join(HERE, "..", "runs", runLabel, "queries");
+  if (existsSync(runDir)) {
+    for (const f of readdirSync(runDir).filter((x) => x.endsWith(".json"))) {
+      const j = JSON.parse(readFileSync(join(runDir, f), "utf8")) as {
+        results?: { pmid?: string; doi?: string }[];
+      };
+      for (const r of (j.results ?? []).slice(0, 10)) add(r.pmid, r.doi);
+    }
+  }
+
+  // Elicit fixtures (top 10 per query).
+  const fixtures = JSON.parse(
+    readFileSync(join(HERE, "..", "elicit", "fixtures.json"), "utf8")
+  ) as Record<string, { pmid?: string; doi?: string }[]>;
+  for (const [id, items] of Object.entries(fixtures)) {
+    if (!Array.isArray(items)) continue; // skip _note
+    void id;
+    for (const r of items.slice(0, 10)) add(r.pmid, r.doi);
+  }
+
+  return refs;
+}
+
+async function fetchAbstract(ref: Ref): Promise<string | undefined> {
+  const queries: string[] = [];
+  if (ref.pmid) queries.push(`EXT_ID:${ref.pmid} AND SRC:MED`);
+  if (ref.doi) queries.push(`DOI:"${ref.doi}"`);
+  for (const q of queries) {
+    const url = `${EUROPE_PMC}?query=${encodeURIComponent(q)}&resultType=core&format=json&pageSize=1`;
+    try {
+      const res = await fetch(url);
+      if (!res.ok) continue;
+      const json = (await res.json()) as {
+        resultList?: { result?: { abstractText?: string }[] };
+      };
+      const abstract = json.resultList?.result?.[0]?.abstractText;
+      if (abstract && abstract.trim()) return abstract.trim();
+    } catch {
+      // network hiccup — try the next query form / leave uncached (placeholder).
+    }
+  }
+  return undefined;
+}
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T, i: number) => Promise<R>
+): Promise<R[]> {
+  const out: R[] = new Array(items.length);
+  let next = 0;
+  async function worker() {
+    while (next < items.length) {
+      const i = next++;
+      out[i] = await fn(items[i], i);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+  return out;
+}
+
+function parseArgs(argv: string[]) {
+  let run = "council-current";
+  let out = "abstract-cache.json";
+  let concurrency = 6;
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--run") run = argv[++i];
+    else if (argv[i] === "--out") out = argv[++i];
+    else if (argv[i] === "--concurrency") concurrency = Number(argv[++i]) || 6;
+  }
+  return { run, out, concurrency };
+}
+
+async function main() {
+  const { run, out, concurrency } = parseArgs(process.argv.slice(2));
+  const refs = collectIds(run);
+  console.log(`[abstract-cache] ${refs.length} unique ids across Manan(${run}) + Elicit fixtures`);
+
+  let found = 0;
+  const abstracts = await mapWithConcurrency(refs, concurrency, async (ref, i) => {
+    const a = await fetchAbstract(ref);
+    if (a) found++;
+    if ((i + 1) % 50 === 0) console.log(`[abstract-cache]   ${i + 1}/${refs.length} (${found} found)`);
+    return a;
+  });
+
+  const byPmid: Record<string, string> = {};
+  const byDoi: Record<string, string> = {};
+  refs.forEach((ref, i) => {
+    const a = abstracts[i];
+    if (!a) return;
+    if (ref.pmid) byPmid[ref.pmid] = a;
+    if (ref.doi) byDoi[ref.doi] = a;
+  });
+
+  const outPath = join(HERE, out);
+  writeFileSync(
+    outPath,
+    JSON.stringify(
+      {
+        meta: {
+          source: "europepmc",
+          run,
+          uniqueIds: refs.length,
+          abstractsFound: found,
+          generatedAt: new Date().toISOString(),
+        },
+        byPmid,
+        byDoi,
+      },
+      null,
+      2
+    )
+  );
+  console.log(
+    `[abstract-cache] wrote ${outPath} — ${found}/${refs.length} abstracts (${Math.round((100 * found) / Math.max(refs.length, 1))}%)`
+  );
+}
+
+main();

--- a/eval/literature-search/council/build-blinded-packet.ts
+++ b/eval/literature-search/council/build-blinded-packet.ts
@@ -26,13 +26,55 @@
  *   → writes eval/literature-search/council/<out>/{PACKET.md,key.json}
  */
 
-import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createHash } from "node:crypto";
 import { BENCHMARK_QUERIES } from "../queries";
+import { normalizeAbstract, ABSTRACT_UNAVAILABLE } from "./abstract-format";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
+
+function normalizeDoi(doi: string | undefined | null): string | undefined {
+  if (!doi) return undefined;
+  return doi
+    .trim()
+    .toLowerCase()
+    .replace(/^https?:\/\/(dx\.)?doi\.org\//, "")
+    .replace(/\s+/g, "");
+}
+
+interface AbstractCache {
+  byPmid: Record<string, string>;
+  byDoi: Record<string, string>;
+}
+
+/** Load the neutral abstract cache (built by build-abstract-cache.ts). Missing →
+ * empty cache: the packet still builds, every row shows the identical placeholder. */
+function loadAbstractCache(file: string): AbstractCache {
+  const path = join(HERE, file);
+  if (!existsSync(path)) {
+    console.warn(
+      `[blinded-packet] no abstract cache at ${path} — abstracts will show as "${ABSTRACT_UNAVAILABLE}". Run build-abstract-cache.ts first.`
+    );
+    return { byPmid: {}, byDoi: {} };
+  }
+  const j = JSON.parse(readFileSync(path, "utf8")) as Partial<AbstractCache>;
+  return { byPmid: j.byPmid ?? {}, byDoi: j.byDoi ?? {} };
+}
+
+/** Abstract for a row from the NEUTRAL cache only (never the engine's payload) —
+ * keeps the two engines' abstracts from differing in provenance/style. */
+function abstractFor(
+  cache: AbstractCache,
+  pmid: string | null,
+  doi: string | null
+): string {
+  const nd = normalizeDoi(doi);
+  const raw = (pmid && cache.byPmid[pmid]) || (nd && cache.byDoi[nd]) || "";
+  const norm = normalizeAbstract(raw);
+  return norm || ABSTRACT_UNAVAILABLE;
+}
 
 interface CommonRow {
   title: string;
@@ -40,6 +82,7 @@ interface CommonRow {
   venue: string | null;
   doi: string | null;
   pmid: string | null;
+  abstract: string;
 }
 
 interface MananResult {
@@ -60,16 +103,18 @@ interface ElicitItem {
   citedByCount: number | null;
 }
 
-function parseArgs(argv: string[]): { run: string; out: string; salt: string } {
+function parseArgs(argv: string[]): { run: string; out: string; salt: string; cache: string } {
   let run = "phase0-baseline";
   let out = "phase0-baseline";
   let salt = "";
+  let cache = "abstract-cache.json";
   for (let i = 0; i < argv.length; i++) {
     if (argv[i] === "--run") run = argv[++i];
     else if (argv[i] === "--out") out = argv[++i];
     else if (argv[i] === "--salt") salt = argv[++i];
+    else if (argv[i] === "--cache") cache = argv[++i];
   }
-  return { run, out, salt: salt || out };
+  return { run, out, salt: salt || out, cache };
 }
 
 /** Deterministic, reproducible coin flip: is Manan shown as Engine A for this id? */
@@ -87,30 +132,37 @@ function idLabel(r: { doi: string | null; pmid: string | null }): string {
 
 function renderEngine(rows: CommonRow[]): string[] {
   if (rows.length === 0) return ["_(no results)_"];
-  return rows.map(
-    (r, i) => `${i + 1}. ${r.title} — ${r.year ?? "?"}, ${r.venue ?? "?"} (${idLabel(r)})`
-  );
+  return rows.flatMap((r, i) => [
+    `${i + 1}. ${r.title} — ${r.year ?? "?"}, ${r.venue ?? "?"} (${idLabel(r)})`,
+    `   ${r.abstract}`,
+  ]);
 }
 
-function mananCommon(id: string, runLabel: string): CommonRow[] {
+function mananCommon(id: string, runLabel: string, cache: AbstractCache): CommonRow[] {
   const path = join(HERE, "..", "runs", runLabel, "queries", `${id}.json`);
   const run = JSON.parse(readFileSync(path, "utf8")) as { results: MananResult[] };
-  return run.results.slice(0, 10).map((r) => ({
-    title: r.title ?? "",
-    year: typeof r.year === "number" ? r.year : null,
-    venue: r.journal ?? null,
-    doi: r.doi ?? null,
-    pmid: r.pmid ?? null,
-  }));
+  return run.results.slice(0, 10).map((r) => {
+    const pmid = r.pmid ?? null;
+    const doi = r.doi ?? null;
+    return {
+      title: r.title ?? "",
+      year: typeof r.year === "number" ? r.year : null,
+      venue: r.journal ?? null,
+      doi,
+      pmid,
+      abstract: abstractFor(cache, pmid, doi),
+    };
+  });
 }
 
-function elicitCommon(items: ElicitItem[]): CommonRow[] {
+function elicitCommon(items: ElicitItem[], cache: AbstractCache): CommonRow[] {
   return items.slice(0, 10).map((r) => ({
     title: r.title,
     year: r.year,
     venue: r.venue,
     doi: r.doi,
     pmid: r.pmid,
+    abstract: abstractFor(cache, r.pmid, r.doi),
   }));
 }
 
@@ -121,20 +173,26 @@ You are an impartial judge comparing TWO anonymous literature-search engines,
 which engine is which, and you must not guess or speculate about their identity.
 Judge ONLY the result lists shown.
 
-Score EACH engine 0–5 (5 = best) on these six dimensions:
-1. **recall** — are the landmark / must-have papers present in the top 10?
+Each result shows its title, year, venue, identifiers, AND its abstract — judge
+clinical relevance and trust from the abstract, i.e. from what a user actually reads.
+
+Score EACH engine 0–5 (5 = best) on these six dimensions, using YOUR OWN domain
+knowledge of the query — you are NOT given an answer key of expected papers:
+1. **recall** — from your knowledge of this topic, does the top 10 comprehensively
+   cover the key evidence a domain expert would expect (landmark trials, pivotal
+   reviews, the seminal paper)? Judge coverage independently — no list is provided.
 2. **ranking** — is the best / most-relevant paper near the top; is the evidence
    hierarchy respected (systematic reviews/meta-analyses & RCTs above weaker designs)?
 3. **metadata** — DOI/PMID/year/venue completeness and plausibility.
-4. **clinical_relevance** — usefulness of the top 10 to a clinician/researcher; few irrelevant items.
+4. **clinical_relevance** — usefulness of the top 10 to a clinician/researcher, judged
+   from the abstracts; few irrelevant items.
 5. **explanation** — would the list be easy to trust/act on (clear identifiers, no junk)?
 6. **trust** — absence of dubious/predatory/irrelevant/duplicate entries.
 
 Then pick a **winner** per query: "A", "B", or "tie".
 
-Use the listed must-have papers as ground truth for landmark recall. Penalize a
-missing landmark RCT and penalize irrelevant items in the top 10. For queries
-tagged recency-sensitive, favor newer high-quality evidence.`;
+Penalize an obviously missing landmark paper and penalize irrelevant items in the
+top 10. For queries tagged recency-sensitive, favor newer high-quality evidence.`;
 
 const OUTPUT_SCHEMA = `## Output format (STRICT)
 
@@ -153,8 +211,9 @@ Return ONLY a JSON object, no prose, no markdown fences, of EXACTLY this shape:
 }`;
 
 function main() {
-  const { run, out, salt } = parseArgs(process.argv.slice(2));
+  const { run, out, salt, cache: cacheFile } = parseArgs(process.argv.slice(2));
   const byId = new Map(BENCHMARK_QUERIES.map((q) => [q.id, q]));
+  const cache = loadAbstractCache(cacheFile);
   const fixtures = JSON.parse(
     readFileSync(join(HERE, "..", "elicit", "fixtures.json"), "utf8")
   ) as Record<string, ElicitItem[]>;
@@ -164,6 +223,8 @@ function main() {
   sections.push(
     "Two anonymous engines are compared on identical queries. Engine assignment is",
     "randomized per query; you cannot infer identity from position or formatting.",
+    "Each result is shown with its abstract (sourced identically for both engines),",
+    "so relevance and trust are judged from what a user actually reads.",
     ""
   );
   sections.push(RUBRIC, "");
@@ -181,11 +242,11 @@ function main() {
 
     let manan: CommonRow[];
     try {
-      manan = mananCommon(id, run);
+      manan = mananCommon(id, run, cache);
     } catch {
       continue; // Manan run missing this id — skip
     }
-    const elicit = elicitCommon(fixtures[id]);
+    const elicit = elicitCommon(fixtures[id], cache);
 
     const mananA = mananIsEngineA(salt, id);
     key[id] = mananA ? "manan" : "elicit";
@@ -195,10 +256,9 @@ function main() {
     sections.push(`## Query: \`${id}\` — "${bq.query}"`);
     sections.push(`Category: ${bq.category}. Intent: ${bq.intent}`);
     if (bq.recencyBiased) sections.push("_Recency-sensitive: newer high-quality evidence is better._");
-    if (bq.mustHaves?.length) {
-      sections.push("", "**Must-have landmark papers (ground truth):**");
-      for (const m of bq.mustHaves) sections.push(`- ${m.label}`);
-    }
+    // NOTE: the must-have landmark list is deliberately NOT printed here. Handing
+    // judges the answer key made the council's "recall" score re-derive the
+    // deterministic recall@k metric instead of contributing independent judgment.
     sections.push("", "### Engine A — top 10");
     sections.push(...renderEngine(engineA));
     sections.push("", "### Engine B — top 10");

--- a/eval/literature-search/queries-heldout.ts
+++ b/eval/literature-search/queries-heldout.ts
@@ -1,0 +1,435 @@
+/**
+ * HELD-OUT evaluation query set — Manan OS literature search.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ *  DO NOT TUNE ON THIS FILE. DO NOT REFERENCE THESE QUERY IDS IN RANKING CODE.
+ * ─────────────────────────────────────────────────────────────────────────────
+ * This set exists to measure generalization. It is kept STRICTLY SEPARATE from
+ * the 87-query training benchmark in `queries.ts`, which the pipeline (its CYCLE
+ * tables, entity-drift lists, trial-ranking heuristics, quality-ranker weights)
+ * was iterated against. If any ranking heuristic ever hardcodes, special-cases,
+ * or is fitted to a query id, DOI, PMID, or title in THIS file, the measurement
+ * is contaminated and worthless.
+ *
+ * Enforced expectations for anyone touching the ranking path:
+ *   - entity-drift.ts / quality-ranker.ts / trial-ranking.ts / query-planner.ts
+ *     MUST NOT import from this file or match on these ids.
+ *   - These queries are reported under their OWN run label (`--heldout`), never
+ *     mixed into the 87q training aggregate.
+ *
+ * Coverage rationale: the training set is almost entirely clinical medicine, so
+ * the ranking heuristics have EMPTY tables outside it. This set deliberately
+ * over-weights NON-clinical domains (computer science / ML, molecular biology,
+ * psychology, statistics, economics) where the heuristics have no priors, plus a
+ * few clinical landmarks distinct from the training topics.
+ *
+ * GROUND TRUTH: every PMID/DOI below was confirmed this session against a neutral
+ * source (Europe PMC for PMIDs; Crossref/DataCite/OpenAlex for DOIs) — see the
+ * verification log in the accompanying handover. No id is asserted unseen. A
+ * distinctive `titleIncludes` substring is included alongside each id as a
+ * matcher backstop (identifiers a source returns can vary: arXiv vs publisher DOI).
+ */
+
+import type { MustHave } from "./queries";
+
+export type HeldoutDomain =
+  | "computer_science"
+  | "biology"
+  | "psychology"
+  | "statistics"
+  | "economics"
+  | "medicine";
+
+export interface HeldoutQuery {
+  /** Stable slug (used in artifact filenames). MUST NOT appear in ranking code. */
+  id: string;
+  /** The user query as typed. */
+  query: string;
+  /** Domain, for reporting generalization SEPARATELY by field. */
+  domain: HeldoutDomain;
+  /** Free-form query class label (not the clinical QueryCategory union). */
+  category: string;
+  /** What the searcher actually wants. */
+  intent: string;
+  recencyBiased?: boolean;
+  /** Landmark/expected papers (each matches any-of its identifiers). */
+  mustHaves: MustHave[];
+  notes?: string;
+}
+
+export const HELDOUT_QUERIES: HeldoutQuery[] = [
+  // ── Computer science / ML ────────────────────────────────────────────────
+  {
+    id: "held-cs-transformers",
+    query: "attention is all you need transformer architecture",
+    domain: "computer_science",
+    category: "landmark_method",
+    intent: "Retrieve the seminal Transformer paper introducing self-attention.",
+    mustHaves: [
+      {
+        label: "Attention Is All You Need (Vaswani et al., NeurIPS 2017)",
+        dois: ["10.48550/arXiv.1706.03762"],
+        titleIncludes: ["attention is all you need"],
+      },
+    ],
+  },
+  {
+    id: "held-cs-resnet",
+    query: "deep residual learning residual networks for image recognition",
+    domain: "computer_science",
+    category: "landmark_method",
+    intent: "Retrieve the ResNet paper introducing residual connections.",
+    mustHaves: [
+      {
+        label: "Deep Residual Learning for Image Recognition (He et al., CVPR 2016)",
+        dois: ["10.1109/CVPR.2016.90"],
+        titleIncludes: ["deep residual learning for image recognition"],
+      },
+    ],
+  },
+  {
+    id: "held-cs-bert",
+    query: "BERT bidirectional transformer pretraining for language understanding",
+    domain: "computer_science",
+    category: "landmark_method",
+    intent: "Retrieve the BERT pretraining paper.",
+    mustHaves: [
+      {
+        label: "BERT (Devlin et al., NAACL 2019)",
+        dois: ["10.18653/v1/N19-1423"],
+        titleIncludes: ["bert", "pre-training of deep bidirectional transformers"],
+      },
+    ],
+  },
+  {
+    id: "held-cs-adam",
+    query: "Adam adaptive moment estimation optimizer for stochastic gradient descent",
+    domain: "computer_science",
+    category: "landmark_method",
+    intent: "Retrieve the Adam optimizer paper.",
+    mustHaves: [
+      {
+        label: "Adam: A Method for Stochastic Optimization (Kingma & Ba, ICLR 2015)",
+        dois: ["10.48550/arXiv.1412.6980"],
+        titleIncludes: ["adam", "method for stochastic optimization"],
+      },
+    ],
+  },
+  {
+    id: "held-cs-alexnet",
+    query: "ImageNet classification with deep convolutional neural networks",
+    domain: "computer_science",
+    category: "landmark_method",
+    intent: "Retrieve the AlexNet paper that launched modern deep learning for vision.",
+    mustHaves: [
+      {
+        label: "AlexNet (Krizhevsky, Sutskever & Hinton, NeurIPS 2012)",
+        dois: ["10.1145/3065386"],
+        titleIncludes: ["imagenet classification with deep convolutional"],
+      },
+    ],
+  },
+  {
+    id: "held-cs-gan",
+    query: "generative adversarial networks GAN generator discriminator",
+    domain: "computer_science",
+    category: "landmark_method",
+    intent: "Retrieve the original GAN paper.",
+    mustHaves: [
+      {
+        label: "Generative Adversarial Nets (Goodfellow et al., NeurIPS 2014)",
+        dois: ["10.48550/arXiv.1406.2661"],
+        titleIncludes: ["generative adversarial"],
+      },
+    ],
+  },
+  {
+    id: "held-cs-word2vec",
+    query: "word2vec efficient estimation of word representations in vector space",
+    domain: "computer_science",
+    category: "landmark_method",
+    intent: "Retrieve the word2vec word-embeddings paper.",
+    mustHaves: [
+      {
+        label: "Efficient Estimation of Word Representations (Mikolov et al., 2013)",
+        dois: ["10.48550/arXiv.1301.3781"],
+        titleIncludes: ["efficient estimation of word representations"],
+      },
+    ],
+  },
+
+  // ── Molecular biology / genetics ─────────────────────────────────────────
+  {
+    id: "held-bio-dna-structure",
+    query: "molecular structure of DNA double helix",
+    domain: "biology",
+    category: "landmark_discovery",
+    intent: "Retrieve the Watson–Crick DNA double-helix paper.",
+    mustHaves: [
+      {
+        label: "Molecular Structure of Nucleic Acids (Watson & Crick, Nature 1953)",
+        pmids: ["13054692"],
+        dois: ["10.1038/171737a0"],
+        titleIncludes: ["molecular structure of nucleic acids"],
+      },
+    ],
+  },
+  {
+    id: "held-bio-crispr",
+    query: "CRISPR Cas9 programmable dual-RNA guided DNA endonuclease",
+    domain: "biology",
+    category: "landmark_method",
+    intent: "Retrieve the Jinek/Doudna/Charpentier CRISPR-Cas9 paper.",
+    mustHaves: [
+      {
+        label: "Programmable Dual-RNA–Guided DNA Endonuclease (Jinek et al., Science 2012)",
+        pmids: ["22745249"],
+        dois: ["10.1126/science.1225829"],
+        titleIncludes: ["programmable dual-rna", "dna endonuclease in adaptive bacterial"],
+      },
+    ],
+  },
+  {
+    id: "held-bio-human-genome",
+    query: "initial sequencing and analysis of the human genome",
+    domain: "biology",
+    category: "landmark_discovery",
+    intent: "Retrieve the Human Genome Project initial sequencing paper.",
+    mustHaves: [
+      {
+        label: "Initial sequencing and analysis of the human genome (IHGSC, Nature 2001)",
+        pmids: ["11237011"],
+        dois: ["10.1038/35057062"],
+        titleIncludes: ["initial sequencing and analysis of the human genome"],
+      },
+    ],
+  },
+  {
+    id: "held-bio-rnai",
+    query: "RNA interference double-stranded RNA gene silencing Caenorhabditis elegans",
+    domain: "biology",
+    category: "landmark_discovery",
+    intent: "Retrieve the Fire & Mello RNAi paper.",
+    mustHaves: [
+      {
+        label: "Potent and specific genetic interference by dsRNA (Fire & Mello, Nature 1998)",
+        pmids: ["9486653"],
+        dois: ["10.1038/35888"],
+        titleIncludes: ["potent and specific genetic interference by double-stranded rna"],
+      },
+    ],
+  },
+  {
+    id: "held-bio-blast",
+    query: "BLAST basic local alignment search tool sequence similarity",
+    domain: "biology",
+    category: "landmark_method",
+    intent: "Retrieve the original BLAST algorithm paper.",
+    mustHaves: [
+      {
+        label: "Basic local alignment search tool (Altschul et al., JMB 1990)",
+        pmids: ["2231712"],
+        dois: ["10.1016/S0022-2836(05)80360-2"],
+        titleIncludes: ["basic local alignment search tool"],
+      },
+    ],
+  },
+  {
+    id: "held-bio-pcr",
+    query: "polymerase chain reaction thermostable DNA polymerase amplification",
+    domain: "biology",
+    category: "landmark_method",
+    intent: "Retrieve the Saiki et al. PCR-with-Taq paper.",
+    mustHaves: [
+      {
+        label: "Primer-directed enzymatic amplification of DNA (Saiki et al., Science 1988)",
+        pmids: ["2448875"],
+        dois: ["10.1126/science.2448875"],
+        titleIncludes: ["primer-directed enzymatic amplification of dna"],
+      },
+    ],
+  },
+
+  // ── Psychology / cognitive science ───────────────────────────────────────
+  {
+    id: "held-psy-prospect-theory",
+    query: "prospect theory decision making under risk",
+    domain: "psychology",
+    category: "landmark_theory",
+    intent: "Retrieve the Kahneman & Tversky prospect-theory paper.",
+    mustHaves: [
+      {
+        label: "Prospect Theory: An Analysis of Decision under Risk (Kahneman & Tversky, 1979)",
+        dois: ["10.2307/1914185"],
+        titleIncludes: ["prospect theory"],
+      },
+    ],
+  },
+  {
+    id: "held-psy-heuristics-biases",
+    query: "judgment under uncertainty heuristics and biases",
+    domain: "psychology",
+    category: "landmark_theory",
+    intent: "Retrieve the Tversky & Kahneman heuristics-and-biases paper.",
+    mustHaves: [
+      {
+        label: "Judgment under Uncertainty: Heuristics and Biases (Tversky & Kahneman, Science 1974)",
+        pmids: ["17835457"],
+        dois: ["10.1126/science.185.4157.1124"],
+        titleIncludes: ["judgment under uncertainty"],
+      },
+    ],
+  },
+  {
+    id: "held-psy-magical-seven",
+    query: "working memory capacity magical number seven plus or minus two",
+    domain: "psychology",
+    category: "landmark_theory",
+    intent: "Retrieve Miller's 'Magical Number Seven' paper.",
+    mustHaves: [
+      {
+        label: "The Magical Number Seven (Miller, Psychological Review 1956)",
+        pmids: ["13310704"],
+        dois: ["10.1037/h0043158"],
+        titleIncludes: ["magical number seven"],
+      },
+    ],
+  },
+  {
+    id: "held-psy-reproducibility",
+    query: "reproducibility replication crisis psychological science",
+    domain: "psychology",
+    category: "landmark_study",
+    intent: "Retrieve the Open Science Collaboration reproducibility study.",
+    mustHaves: [
+      {
+        label: "Estimating the reproducibility of psychological science (OSC, Science 2015)",
+        pmids: ["26315443"],
+        dois: ["10.1126/science.aac4716"],
+        titleIncludes: ["reproducibility of psychological science"],
+      },
+    ],
+  },
+  {
+    id: "held-psy-ego-depletion",
+    query: "ego depletion self-control as a limited resource",
+    domain: "psychology",
+    category: "landmark_study",
+    intent: "Retrieve the Baumeister et al. ego-depletion paper.",
+    mustHaves: [
+      {
+        label: "Ego depletion: Is the active self a limited resource? (Baumeister et al., JPSP 1998)",
+        pmids: ["9599441"],
+        dois: ["10.1037/0022-3514.74.5.1252"],
+        titleIncludes: ["ego depletion"],
+      },
+    ],
+  },
+
+  // ── Statistics / methods ─────────────────────────────────────────────────
+  {
+    id: "held-stat-lasso",
+    query: "lasso regression shrinkage and variable selection",
+    domain: "statistics",
+    category: "landmark_method",
+    intent: "Retrieve Tibshirani's LASSO paper.",
+    mustHaves: [
+      {
+        label: "Regression Shrinkage and Selection via the Lasso (Tibshirani, JRSS-B 1996)",
+        dois: ["10.1111/j.2517-6161.1996.tb02080.x"],
+        titleIncludes: ["regression shrinkage and selection via the lasso"],
+      },
+    ],
+  },
+  {
+    id: "held-stat-random-forests",
+    query: "random forests ensemble of decision trees",
+    domain: "statistics",
+    category: "landmark_method",
+    intent: "Retrieve Breiman's Random Forests paper.",
+    mustHaves: [
+      {
+        label: "Random Forests (Breiman, Machine Learning 2001)",
+        dois: ["10.1023/A:1010933404324"],
+        titleIncludes: ["random forests"],
+      },
+    ],
+  },
+
+  // ── Economics ────────────────────────────────────────────────────────────
+  {
+    id: "held-econ-lemons",
+    query: "market for lemons asymmetric information adverse selection",
+    domain: "economics",
+    category: "landmark_theory",
+    intent: "Retrieve Akerlof's 'The Market for Lemons'.",
+    mustHaves: [
+      {
+        label: "The Market for Lemons (Akerlof, QJE 1970)",
+        dois: ["10.2307/1879431"],
+        titleIncludes: ["market for", "lemons"],
+      },
+    ],
+  },
+
+  // ── Clinical (distinct from the training topics) ─────────────────────────
+  {
+    id: "held-clin-sprint-bp",
+    query: "intensive versus standard blood pressure control SPRINT trial",
+    domain: "medicine",
+    category: "trial",
+    intent: "Retrieve the SPRINT intensive blood-pressure RCT.",
+    mustHaves: [
+      {
+        label: "Intensive vs Standard Blood-Pressure Control, SPRINT (NEJM 2015)",
+        pmids: ["26551272"],
+        dois: ["10.1056/NEJMoa1511939"],
+        titleIncludes: ["intensive versus standard blood-pressure control"],
+      },
+    ],
+  },
+  {
+    id: "held-clin-4s-statin",
+    query: "simvastatin cholesterol lowering survival coronary heart disease 4S",
+    domain: "medicine",
+    category: "trial",
+    intent: "Retrieve the Scandinavian Simvastatin Survival Study (4S).",
+    mustHaves: [
+      {
+        label: "Scandinavian Simvastatin Survival Study, 4S (Lancet 1994)",
+        pmids: ["7968073"],
+        dois: ["10.1016/S0140-6736(94)90566-5"],
+        titleIncludes: ["randomised trial of cholesterol lowering in 4444 patients"],
+      },
+    ],
+  },
+  {
+    id: "held-clin-ukpds33",
+    query: "intensive blood glucose control type 2 diabetes UKPDS",
+    domain: "medicine",
+    category: "trial",
+    intent: "Retrieve UKPDS 33 (intensive glucose control in type 2 diabetes).",
+    mustHaves: [
+      {
+        label: "Intensive blood-glucose control, UKPDS 33 (Lancet 1998)",
+        pmids: ["9742976"],
+        dois: ["10.1016/S0140-6736(98)07019-6"],
+        titleIncludes: ["intensive blood-glucose control with sulphonylureas or insulin"],
+      },
+    ],
+  },
+];
+
+/** Held-out query ids, exported ONLY so tooling can assert separation — never so
+ * ranking code can special-case them. */
+export const HELDOUT_QUERY_IDS: ReadonlySet<string> = new Set(
+  HELDOUT_QUERIES.map((q) => q.id)
+);
+
+export const HELDOUT_DOMAIN_COUNTS: Record<string, number> = HELDOUT_QUERIES.reduce(
+  (acc, q) => {
+    acc[q.domain] = (acc[q.domain] ?? 0) + 1;
+    return acc;
+  },
+  {} as Record<string, number>
+);

--- a/eval/literature-search/recall-probe-lib.ts
+++ b/eval/literature-search/recall-probe-lib.ts
@@ -1,0 +1,159 @@
+/**
+ * Pure aggregation helpers for the UNFROZEN first-stage recall probe.
+ *
+ * The probe measures whether a landmark (must-have) paper is even RETRIEVED into
+ * the live fused candidate pool BEFORE ranking — the thing the frozen 87-query
+ * re-ranking harness (candidate-cache.ts) can never see. These functions are the
+ * deterministic, I/O-free core (matching is reused from eval/metrics), unit
+ * tested separately from the live fan-out that feeds them.
+ */
+
+import type { SourceStatus, SourceStatusKind } from "@/lib/search/source-status";
+
+/** One observation of a single must-have on a single live retrieval run. */
+export interface MustHaveRunObservation {
+  /** Present ANYWHERE in the fused candidate pool (pre-ranking) this run. */
+  inPool: boolean;
+  /** Present in the final top-k (post-ranking) this run. */
+  inTop10: boolean;
+  /** Provenance lanes that retrieved it into the pool this run (dedup, e.g. ["pubmed","medcpt_dense"]). */
+  lanes: string[];
+}
+
+/** Cross-run aggregate for a single must-have. */
+export interface MustHaveAggregate {
+  /** Fraction of runs the must-have was in the pool (0..1). */
+  inPoolRate: number;
+  /** Fraction of runs the must-have was in the final top-k (0..1). */
+  inTop10Rate: number;
+  /** Union of every lane that retrieved it across runs. */
+  lanesUnion: string[];
+  /** Per-lane count of how many runs that lane retrieved it. */
+  laneCounts: Record<string, number>;
+  /** True first-stage recall failure: never in the pool on ANY run. */
+  missedByAllLanes: boolean;
+}
+
+const DENSE_LANE_RE = /^medcpt_dense/;
+
+/** Is this a MedCPT owned dense-retrieval lane (base / recency / HyDE / recovery)? */
+export function isDenseLane(lane: string): boolean {
+  return DENSE_LANE_RE.test(lane);
+}
+
+/** Federated external API lanes (the throttleable ones), vs the owned dense corpus. */
+export function isFederatedLane(lane: string): boolean {
+  return !isDenseLane(lane);
+}
+
+export function aggregateMustHave(runs: MustHaveRunObservation[]): MustHaveAggregate {
+  const n = runs.length || 1;
+  const inPoolCount = runs.filter((r) => r.inPool).length;
+  const inTop10Count = runs.filter((r) => r.inTop10).length;
+  const laneCounts: Record<string, number> = {};
+  for (const r of runs) {
+    for (const lane of new Set(r.lanes)) {
+      laneCounts[lane] = (laneCounts[lane] ?? 0) + 1;
+    }
+  }
+  return {
+    inPoolRate: inPoolCount / n,
+    inTop10Rate: inTop10Count / n,
+    lanesUnion: Object.keys(laneCounts).sort(),
+    laneCounts,
+    missedByAllLanes: inPoolCount === 0,
+  };
+}
+
+/**
+ * Whether the owned MedCPT dense lane is actually ALIVE across the probe.
+ *
+ * A dead/dormant dense backbone means the pool is lexical-only — the single most
+ * important structural finding. We classify from the per-run status + returned
+ * count of the base `medcpt_dense` lane:
+ *  - "alive"    : returned results (count > 0) on at least one run.
+ *  - "configured_empty" : status ok but always returned 0 (reachable, no hits — suspicious).
+ *  - "dormant"  : always missing_config (encoder/turbopuffer not provisioned).
+ *  - "degraded" : reachable but every run failed (timeout / error / rate_limited).
+ */
+export type DenseLiveness = "alive" | "configured_empty" | "dormant" | "degraded";
+
+export function classifyDenseLiveness(
+  perRun: Array<{ status?: SourceStatus; count: number }>
+): DenseLiveness {
+  if (perRun.length === 0) return "dormant";
+  const anyResults = perRun.some((r) => r.count > 0);
+  if (anyResults) return "alive";
+  const kinds = perRun.map((r) => r.status?.status ?? "missing_config");
+  const allMissing = kinds.every((k) => k === "missing_config");
+  if (allMissing) return "dormant";
+  const anyOk = kinds.some((k) => k === "ok");
+  if (anyOk) return "configured_empty";
+  return "degraded";
+}
+
+export interface OverallSummary {
+  mustHaveCount: number;
+  /** Mean in-pool rate across all must-haves (retrieval recall). */
+  meanInPoolRate: number;
+  /** Mean in-top10 rate across all must-haves (end-to-end recall). */
+  meanInTop10Rate: number;
+  /** meanInPoolRate - meanInTop10Rate: how much recall is lost to RANKING, not retrieval. */
+  gap: number;
+  /** Must-haves never retrieved on any run (true first-stage recall failures). */
+  missedByAllLanesCount: number;
+}
+
+export function summarizeOverall(aggs: MustHaveAggregate[]): OverallSummary {
+  const n = aggs.length || 1;
+  const meanInPoolRate = aggs.reduce((a, m) => a + m.inPoolRate, 0) / n;
+  const meanInTop10Rate = aggs.reduce((a, m) => a + m.inTop10Rate, 0) / n;
+  return {
+    mustHaveCount: aggs.length,
+    meanInPoolRate,
+    meanInTop10Rate,
+    gap: meanInPoolRate - meanInTop10Rate,
+    missedByAllLanesCount: aggs.filter((m) => m.missedByAllLanes).length,
+  };
+}
+
+/**
+ * Per-lane attribution: for must-haves that WERE found in the pool, tally which
+ * lane(s) carried them. A must-have found by K lanes credits all K (union), so
+ * columns sum to >= the number of found must-haves. This tells us whether the
+ * owned dense corpus or the federated APIs are carrying first-stage recall.
+ */
+export function laneAttribution(aggs: MustHaveAggregate[]): {
+  perLane: Record<string, number>;
+  denseFoundCount: number;
+  federatedFoundCount: number;
+  foundByDenseOnly: number;
+  foundByFederatedOnly: number;
+} {
+  const perLane: Record<string, number> = {};
+  let denseFoundCount = 0;
+  let federatedFoundCount = 0;
+  let foundByDenseOnly = 0;
+  let foundByFederatedOnly = 0;
+  for (const agg of aggs) {
+    if (agg.missedByAllLanes) continue;
+    const lanes = agg.lanesUnion;
+    for (const lane of lanes) perLane[lane] = (perLane[lane] ?? 0) + 1;
+    const hasDense = lanes.some(isDenseLane);
+    const hasFederated = lanes.some(isFederatedLane);
+    if (hasDense) denseFoundCount++;
+    if (hasFederated) federatedFoundCount++;
+    if (hasDense && !hasFederated) foundByDenseOnly++;
+    if (hasFederated && !hasDense) foundByFederatedOnly++;
+  }
+  return { perLane, denseFoundCount, federatedFoundCount, foundByDenseOnly, foundByFederatedOnly };
+}
+
+/** Non-ok source statuses for a run, formatted for the report (never contains secrets). */
+export function nonOkStatuses(
+  statuses: Record<string, SourceStatus>
+): Array<{ lane: string; status: SourceStatusKind; message?: string }> {
+  return Object.entries(statuses)
+    .filter(([, s]) => s.status !== "ok")
+    .map(([lane, s]) => ({ lane, status: s.status, message: s.message }));
+}

--- a/eval/literature-search/recall-probe.ts
+++ b/eval/literature-search/recall-probe.ts
@@ -1,0 +1,396 @@
+/**
+ * UNFROZEN first-stage recall probe.
+ *
+ * The frozen 87-query harness (candidate-cache.ts) freezes the candidate pool and
+ * only measures RE-RANKING — it can never tell us whether a landmark paper was even
+ * RETRIEVED. This probe measures exactly that, with LIVE retrieval (no frozen
+ * cache), and attributes each hit to the lane that produced it.
+ *
+ * For every ground-truth query (those with `mustHaves`), for N runs:
+ *   1. Clear the in-process result cache → force a fresh live fan-out (no Redis in
+ *      dev/eval, so this guarantees fresh retrieval, beating throttle noise over N).
+ *   2. Call runLiteratureSearch({ includeRawCandidates: true }) — `rawCandidates`
+ *      is the FULL fused pool BEFORE rankAndAnnotate / study-type / OA filters / paging.
+ *   3. For each must-have record: in_pool (anywhere in the fused pool), in_top10
+ *      (final ranked page), and source_lane provenance (which lanes retrieved it).
+ *
+ * Reads the live path but changes NOTHING in it. Run under op-run for API keys:
+ *   op-run -- npx tsx eval/literature-search/recall-probe.ts --runs 3 --label unfrozen
+ *   op-run -- npx tsx eval/literature-search/recall-probe.ts --only tavr-low-risk-6yr --runs 1
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { BENCHMARK_QUERIES, type BenchmarkQuery, type MustHave } from "./queries";
+import { runLiteratureSearch } from "@/lib/search/run-search";
+import { searchResultCache } from "@/lib/search/result-cache";
+import { matchesMustHave, type EvalResultItem } from "@/lib/search/eval/metrics";
+import type { UnifiedSearchResult } from "@/types/search";
+import type { SourceStatus } from "@/lib/search/source-status";
+import {
+  aggregateMustHave,
+  classifyDenseLiveness,
+  summarizeOverall,
+  laneAttribution,
+  nonOkStatuses,
+  type MustHaveRunObservation,
+  type MustHaveAggregate,
+  type DenseLiveness,
+} from "./recall-probe-lib";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+function loadEnv(): void {
+  for (const f of [".env.local", ".env"]) {
+    try {
+      (process as unknown as { loadEnvFile: (p: string) => void }).loadEnvFile(
+        join(process.cwd(), f)
+      );
+    } catch {
+      /* env file absent — op-run injects secrets, and lanes fail-open without keys */
+    }
+  }
+}
+
+interface CliArgs {
+  label: string;
+  runs: number;
+  only?: string[];
+  topK: number;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const out: CliArgs = { label: "unfrozen", runs: 3, topK: 10 };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--label") out.label = argv[++i];
+    else if (a === "--runs") out.runs = Math.max(1, parseInt(argv[++i], 10) || 3);
+    else if (a === "--only") out.only = argv[++i].split(",").map((s) => s.trim());
+    else if (a === "--topK" || a === "--max") out.topK = parseInt(argv[++i], 10) || 10;
+  }
+  return out;
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const pct = (v: number) => `${Math.round(v * 100)}%`;
+
+function toItem(r: UnifiedSearchResult): EvalResultItem {
+  return { title: r.title, doi: r.doi, pmid: r.pmid, year: r.year };
+}
+
+function mustHaveKind(m: MustHave): "id" | "title" {
+  return (m.pmids?.length || 0) + (m.dois?.length || 0) > 0 ? "id" : "title";
+}
+
+/** Lanes in the fused pool that retrieved a specific must-have (dedup). */
+function lanesForMustHave(pool: UnifiedSearchResult[], m: MustHave): string[] {
+  const lanes = new Set<string>();
+  for (const p of pool) {
+    if (matchesMustHave(toItem(p), m)) {
+      for (const s of p.sources ?? []) lanes.add(s);
+    }
+  }
+  return [...lanes].sort();
+}
+
+interface PerRunRecord {
+  poolSize: number;
+  top10Size: number;
+  denseStatus?: SourceStatus;
+  denseCount: number;
+  nonOk: Array<{ lane: string; status: string; message?: string }>;
+  sourceCounts: Record<string, number>;
+}
+
+interface MustHaveResult {
+  label: string;
+  kind: "id" | "title";
+  ids: string; // human-readable pmids/dois/titleIncludes
+  agg: MustHaveAggregate;
+}
+
+interface QueryResult {
+  id: string;
+  query: string;
+  category: string;
+  perRun: PerRunRecord[];
+  mustHaves: MustHaveResult[];
+}
+
+function idsOf(m: MustHave): string {
+  const parts: string[] = [];
+  if (m.pmids?.length) parts.push(`PMID ${m.pmids.join("/")}`);
+  if (m.dois?.length) parts.push(`DOI ${m.dois.join("/")}`);
+  if (m.titleIncludes?.length) parts.push(`title~[${m.titleIncludes.join(" | ")}]`);
+  return parts.join("; ");
+}
+
+async function probeQuery(q: BenchmarkQuery, args: CliArgs): Promise<QueryResult> {
+  const perRun: PerRunRecord[] = [];
+  // observations[mustHaveIndex] = per-run observations
+  const observations: MustHaveRunObservation[][] = (q.mustHaves ?? []).map(() => []);
+
+  for (let run = 0; run < args.runs; run++) {
+    // Force a FRESH live fan-out: clear the in-process result cache (no Redis in
+    // dev/eval, so this is sufficient to bypass all caching and re-fan-out live).
+    searchResultCache._mem.clear();
+
+    let res;
+    try {
+      res = await runLiteratureSearch({
+        query: q.query,
+        perPage: args.topK,
+        includeRawCandidates: true,
+      });
+    } catch (err) {
+      perRun.push({
+        poolSize: 0,
+        top10Size: 0,
+        denseCount: 0,
+        nonOk: [{ lane: "ALL", status: "error", message: err instanceof Error ? err.message : String(err) }],
+        sourceCounts: {},
+      });
+      (q.mustHaves ?? []).forEach((_, i) =>
+        observations[i].push({ inPool: false, inTop10: false, lanes: [] })
+      );
+      continue;
+    }
+
+    const pool = res.rawCandidates ?? [];
+    const top = res.results ?? [];
+    perRun.push({
+      poolSize: pool.length,
+      top10Size: top.length,
+      denseStatus: res.sourceStatuses["medcpt_dense"],
+      denseCount: res.sourceCounts["medcpt_dense"] ?? 0,
+      nonOk: nonOkStatuses(res.sourceStatuses),
+      sourceCounts: res.sourceCounts,
+    });
+
+    (q.mustHaves ?? []).forEach((m, i) => {
+      const inPool = pool.some((p) => matchesMustHave(toItem(p), m));
+      const inTop10 = top.some((r) => matchesMustHave(toItem(r), m));
+      observations[i].push({ inPool, inTop10, lanes: lanesForMustHave(pool, m) });
+    });
+
+    // Small spacing between runs to let throttled lanes recover between attempts.
+    if (run < args.runs - 1) await sleep(1500);
+  }
+
+  const mustHaves: MustHaveResult[] = (q.mustHaves ?? []).map((m, i) => ({
+    label: m.label,
+    kind: mustHaveKind(m),
+    ids: idsOf(m),
+    agg: aggregateMustHave(observations[i]),
+  }));
+
+  return { id: q.id, query: q.query, category: q.category, perRun, mustHaves };
+}
+
+function buildReport(results: QueryResult[], args: CliArgs) {
+  const allAggs = results.flatMap((r) => r.mustHaves.map((m) => m.agg));
+  const overall = summarizeOverall(allAggs);
+  const attribution = laneAttribution(allAggs);
+
+  // Dense liveness across every query-run.
+  const densePerRun = results.flatMap((r) =>
+    r.perRun.map((pr) => ({ status: pr.denseStatus, count: pr.denseCount }))
+  );
+  const denseLiveness: DenseLiveness = classifyDenseLiveness(densePerRun);
+  const denseRunsWithResults = densePerRun.filter((d) => d.count > 0).length;
+
+  const missed = results.flatMap((r) =>
+    r.mustHaves
+      .filter((m) => m.agg.missedByAllLanes)
+      .map((m) => ({ queryId: r.id, query: r.query, label: m.label, kind: m.kind, ids: m.ids }))
+  );
+
+  // Ranking-loss: in the pool but NOT reliably surfaced (in_pool > in_top10).
+  const rankingLosses = results.flatMap((r) =>
+    r.mustHaves
+      .filter((m) => m.agg.inPoolRate > 0 && m.agg.inTop10Rate < m.agg.inPoolRate)
+      .map((m) => ({
+        queryId: r.id,
+        label: m.label,
+        inPoolRate: m.agg.inPoolRate,
+        inTop10Rate: m.agg.inTop10Rate,
+        lanes: m.agg.lanesUnion,
+      }))
+  );
+
+  return {
+    meta: {
+      label: args.label,
+      runs: args.runs,
+      topK: args.topK,
+      queryCount: results.length,
+      generatedAt: new Date().toISOString(),
+      note: "UNFROZEN live first-stage recall. rawCandidates = full fused pool BEFORE ranking/filter/paging.",
+    },
+    overall,
+    denseLane: {
+      liveness: denseLiveness,
+      runsMeasured: densePerRun.length,
+      runsWithResults: denseRunsWithResults,
+    },
+    laneAttribution: attribution,
+    missedByAllLanes: missed,
+    rankingLosses,
+    perQuery: results,
+  };
+}
+
+function renderSummaryMd(report: ReturnType<typeof buildReport>): string {
+  const { overall, denseLane, laneAttribution: attr, missedByAllLanes, rankingLosses, perQuery, meta } =
+    report;
+  const lines: string[] = [];
+  lines.push(`# Unfrozen first-stage recall probe — ${meta.label}`);
+  lines.push("");
+  lines.push(
+    `Live retrieval, ${meta.runs} run(s)/query, top-${meta.topK}. ${meta.queryCount} ground-truth queries, ${overall.mustHaveCount} must-haves.`
+  );
+  lines.push(`Generated ${meta.generatedAt}.`);
+  lines.push("");
+  lines.push("## Headline");
+  lines.push("");
+  lines.push(`- **In pool (retrieval recall):** ${pct(overall.meanInPoolRate)}`);
+  lines.push(`- **In top-10 (end-to-end recall):** ${pct(overall.meanInTop10Rate)}`);
+  lines.push(
+    `- **GAP (retrieval − ranking):** ${pct(overall.gap)}  ← in the pool but not surfaced = a RANKING problem`
+  );
+  lines.push(
+    `- **Missed by ALL lanes (true retrieval failures):** ${overall.missedByAllLanesCount} / ${overall.mustHaveCount}`
+  );
+  lines.push("");
+  const problem =
+    overall.missedByAllLanesCount / Math.max(1, overall.mustHaveCount) > overall.gap
+      ? "PRIMARILY RETRIEVAL (landmarks never enter the pool)"
+      : "PRIMARILY RANKING (landmarks are in the pool but not surfaced)";
+  lines.push(`**Conclusion:** the problem is ${problem}.`);
+  lines.push("");
+  lines.push("## MedCPT dense lane (owned corpus backbone)");
+  lines.push("");
+  lines.push(`- **Status:** \`${denseLane.liveness}\``);
+  lines.push(
+    `- Returned results on ${denseLane.runsWithResults} / ${denseLane.runsMeasured} query-runs.`
+  );
+  if (denseLane.liveness !== "alive") {
+    lines.push(
+      `- ⚠️  Dense backbone is NOT carrying recall — the pool is effectively lexical-only.`
+    );
+  }
+  lines.push("");
+  lines.push("## Per-lane attribution (who carries first-stage recall)");
+  lines.push("");
+  lines.push(
+    `Of ${overall.mustHaveCount - overall.missedByAllLanesCount} must-haves found in the pool:`
+  );
+  lines.push(`- Found by the **owned dense** corpus (any medcpt_dense lane): ${attr.denseFoundCount}`);
+  lines.push(`- Found by **federated APIs** (pubmed/europepmc/scopus/springer/…): ${attr.federatedFoundCount}`);
+  lines.push(`- Found by **dense ONLY** (federated missed it): ${attr.foundByDenseOnly}`);
+  lines.push(`- Found by **federated ONLY** (dense missed it): ${attr.foundByFederatedOnly}`);
+  lines.push("");
+  lines.push("| lane | must-haves it retrieved |");
+  lines.push("| --- | --- |");
+  for (const [lane, count] of Object.entries(attr.perLane).sort((a, b) => b[1] - a[1])) {
+    lines.push(`| ${lane} | ${count} |`);
+  }
+  lines.push("");
+  lines.push("## Missed by ALL lanes (true first-stage recall failures)");
+  lines.push("");
+  if (missedByAllLanes.length === 0) {
+    lines.push("_None — every must-have was retrieved into the pool on at least one run._");
+  } else {
+    lines.push("| query | must-have | ground truth | kind |");
+    lines.push("| --- | --- | --- | --- |");
+    for (const m of missedByAllLanes) {
+      lines.push(`| \`${m.queryId}\` | ${m.label} | ${m.ids} | ${m.kind} |`);
+    }
+  }
+  lines.push("");
+  lines.push("## Ranking losses (in the pool, not reliably in top-10)");
+  lines.push("");
+  if (rankingLosses.length === 0) {
+    lines.push("_None — every pooled must-have that was retrieved also surfaced in the top-10._");
+  } else {
+    lines.push("| query | must-have | in_pool | in_top10 | lanes |");
+    lines.push("| --- | --- | --- | --- | --- |");
+    for (const m of rankingLosses) {
+      lines.push(
+        `| \`${m.queryId}\` | ${m.label} | ${pct(m.inPoolRate)} | ${pct(m.inTop10Rate)} | ${m.lanes.join(", ")} |`
+      );
+    }
+  }
+  lines.push("");
+  lines.push("## Per-query detail");
+  lines.push("");
+  lines.push("| query | must-have | in_pool | in_top10 | lane(s) that found it |");
+  lines.push("| --- | --- | --- | --- | --- |");
+  for (const q of perQuery) {
+    for (const m of q.mustHaves) {
+      const lanes = m.agg.missedByAllLanes ? "**MISSED BY ALL LANES**" : m.agg.lanesUnion.join(", ");
+      lines.push(
+        `| \`${q.id}\` | ${m.label} | ${pct(m.agg.inPoolRate)} | ${pct(m.agg.inTop10Rate)} | ${lanes} |`
+      );
+    }
+  }
+  lines.push("");
+  lines.push("## Per-run pool + lane health");
+  lines.push("");
+  lines.push("| query | run | pool | top10 | dense count | degraded lanes |");
+  lines.push("| --- | --- | --- | --- | --- | --- |");
+  for (const q of perQuery) {
+    q.perRun.forEach((pr, i) => {
+      const degraded = pr.nonOk.map((n) => `${n.lane}:${n.status}`).join(", ") || "—";
+      lines.push(
+        `| \`${q.id}\` | ${i + 1} | ${pr.poolSize} | ${pr.top10Size} | ${pr.denseCount} | ${degraded} |`
+      );
+    });
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+async function main(): Promise<void> {
+  loadEnv();
+  const args = parseArgs(process.argv.slice(2));
+  const queries = BENCHMARK_QUERIES.filter((q) => q.mustHaves && q.mustHaves.length).filter(
+    (q) => !args.only || args.only.includes(q.id)
+  );
+
+  console.error(
+    `[recall-probe] ${queries.length} ground-truth queries × ${args.runs} run(s), top-${args.topK}`
+  );
+
+  const results: QueryResult[] = [];
+  for (const q of queries) {
+    const started = Date.now();
+    const r = await probeQuery(q, args);
+    results.push(r);
+    const poolAvg =
+      r.perRun.reduce((a, pr) => a + pr.poolSize, 0) / Math.max(1, r.perRun.length);
+    const inPool = r.mustHaves.filter((m) => m.agg.inPoolRate > 0).length;
+    const inTop = r.mustHaves.filter((m) => m.agg.inTop10Rate > 0).length;
+    console.error(
+      `[recall-probe] ${q.id}: pool~${Math.round(poolAvg)} | must-haves in_pool ${inPool}/${r.mustHaves.length} in_top10 ${inTop}/${r.mustHaves.length} (${Date.now() - started}ms)`
+    );
+  }
+
+  const report = buildReport(results, args);
+  const outDir = join(HERE, "runs", `recall-probe-${args.label}`);
+  mkdirSync(outDir, { recursive: true });
+  writeFileSync(join(outDir, "report.json"), JSON.stringify(report, null, 2));
+  writeFileSync(join(outDir, "summary.md"), renderSummaryMd(report));
+
+  console.error("");
+  console.error(`[recall-probe] in_pool ${pct(report.overall.meanInPoolRate)} | in_top10 ${pct(report.overall.meanInTop10Rate)} | gap ${pct(report.overall.gap)}`);
+  console.error(`[recall-probe] dense lane: ${report.denseLane.liveness} (${report.denseLane.runsWithResults}/${report.denseLane.runsMeasured} runs with results)`);
+  console.error(`[recall-probe] missed by all lanes: ${report.overall.missedByAllLanesCount}`);
+  console.error(`[recall-probe] report → ${outDir}`);
+}
+
+main().catch((err) => {
+  console.error("[recall-probe] fatal:", err);
+  process.exit(1);
+});

--- a/eval/literature-search/run.ts
+++ b/eval/literature-search/run.ts
@@ -16,11 +16,22 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { BENCHMARK_QUERIES, CATEGORY_COUNTS, type BenchmarkQuery } from "./queries";
+import { BENCHMARK_QUERIES, CATEGORY_COUNTS, type MustHave } from "./queries";
+import { HELDOUT_QUERIES, HELDOUT_DOMAIN_COUNTS } from "./queries-heldout";
 import { searchPapers } from "@/lib/mcp/tools";
 import type { SearchSourceId } from "@/lib/search/run-search";
 import { computeQueryMetrics, type EvalResultItem } from "@/lib/search/eval/metrics";
 import { buildSummaryMd, buildSummaryJson, type QueryRun } from "./report";
+
+/** The minimal shape the runner needs — satisfied by both the clinical training
+ * benchmark (queries.ts) and the held-out set (queries-heldout.ts). */
+interface EvalQuery {
+  id: string;
+  query: string;
+  category: string;
+  mustHaves?: MustHave[];
+  domain?: string;
+}
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 
@@ -41,18 +52,22 @@ interface CliArgs {
   only?: string[];
   max: number;
   sources?: SearchSourceId[];
+  heldout: boolean;
 }
 
 function parseArgs(argv: string[]): CliArgs {
-  const out: CliArgs = { label: "run", max: 10 };
+  const out: CliArgs = { label: "", max: 10, heldout: false };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === "--label") out.label = argv[++i];
     else if (a === "--only") out.only = argv[++i].split(",").map((s) => s.trim());
     else if (a === "--max") out.max = parseInt(argv[++i], 10) || 10;
+    else if (a === "--heldout") out.heldout = true;
     else if (a === "--sources")
       out.sources = argv[++i].split(",").map((s) => s.trim()) as CliArgs["sources"];
   }
+  // Default label differs by set so a held-out run never overwrites a training run.
+  if (!out.label) out.label = out.heldout ? "heldout" : "run";
   return out;
 }
 
@@ -71,7 +86,7 @@ function toEvalItems(results: Array<Record<string, unknown>>): EvalResultItem[] 
   }));
 }
 
-async function runQuery(q: BenchmarkQuery, args: CliArgs): Promise<QueryRun> {
+async function runQuery(q: EvalQuery, args: CliArgs): Promise<QueryRun> {
   const started = Date.now();
   try {
     const res = await searchPapers({
@@ -112,9 +127,21 @@ async function runQuery(q: BenchmarkQuery, args: CliArgs): Promise<QueryRun> {
 async function main() {
   loadEnv();
   const args = parseArgs(process.argv.slice(2));
-  const selected = args.only
-    ? BENCHMARK_QUERIES.filter((q) => args.only!.includes(q.id))
-    : BENCHMARK_QUERIES;
+
+  // Held-out set is measured SEPARATELY — never mixed into the training aggregate.
+  const pool: EvalQuery[] = args.heldout ? HELDOUT_QUERIES : BENCHMARK_QUERIES;
+  if (args.heldout) {
+    const overlap = HELDOUT_QUERIES.filter((q) =>
+      BENCHMARK_QUERIES.some((t) => t.id === q.id)
+    );
+    if (overlap.length) {
+      console.error(
+        `[eval] FATAL: held-out ids overlap training set: ${overlap.map((o) => o.id).join(", ")}`
+      );
+      process.exit(1);
+    }
+  }
+  const selected = args.only ? pool.filter((q) => args.only!.includes(q.id)) : pool;
 
   if (selected.length === 0) {
     console.error("No queries selected. Check --only ids.");
@@ -125,11 +152,14 @@ async function main() {
   mkdirSync(join(outDir, "queries"), { recursive: true });
 
   console.log(
-    `[eval] label=${args.label} queries=${selected.length} max=${args.max} sources=${
-      args.sources?.join("+") ?? "default"
-    }`
+    `[eval] label=${args.label}${args.heldout ? " (HELD-OUT — reported separately)" : ""} ` +
+      `queries=${selected.length} max=${args.max} sources=${args.sources?.join("+") ?? "default"}`
   );
-  console.log(`[eval] categories: ${JSON.stringify(CATEGORY_COUNTS)}`);
+  console.log(
+    args.heldout
+      ? `[eval] domains: ${JSON.stringify(HELDOUT_DOMAIN_COUNTS)}`
+      : `[eval] categories: ${JSON.stringify(CATEGORY_COUNTS)}`
+  );
 
   const runs: QueryRun[] = [];
   for (const q of selected) {
@@ -159,6 +189,42 @@ async function main() {
   );
   writeFileSync(join(outDir, "summary.md"), buildSummaryMd(args.label, runs));
   console.log(`\n[eval] wrote ${outDir}/summary.{json,md}`);
+
+  // Held-out: also break generalization down BY DOMAIN, since the whole point of
+  // this set is to expose where the (clinically-tuned) heuristics have no priors.
+  if (args.heldout) {
+    const domainOf = new Map(HELDOUT_QUERIES.map((q) => [q.id, q.domain]));
+    const byDomain = new Map<string, { recall: number[]; ndcg: number[] }>();
+    for (const r of runs) {
+      const d = domainOf.get(r.id) ?? "unknown";
+      if (!byDomain.has(d)) byDomain.set(d, { recall: [], ndcg: [] });
+      const bucket = byDomain.get(d)!;
+      if (r.metrics.recallAt10 !== null) bucket.recall.push(r.metrics.recallAt10);
+      if (r.metrics.ndcgAt10 !== null) bucket.ndcg.push(r.metrics.ndcgAt10);
+    }
+    const avg = (xs: number[]) => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : null);
+    const perDomain = [...byDomain.entries()]
+      .sort((a, b) => a[0].localeCompare(b[0]))
+      .map(([domain, b]) => ({
+        domain,
+        queries: b.recall.length,
+        recallAt10: avg(b.recall),
+        ndcgAt10: avg(b.ndcg),
+      }));
+    writeFileSync(
+      join(outDir, "by-domain.json"),
+      JSON.stringify({ label: args.label, perDomain }, null, 2)
+    );
+    console.log("\n[eval] held-out generalization by domain:");
+    for (const d of perDomain) {
+      console.log(
+        `  ${d.domain.padEnd(18)} n=${String(d.queries).padStart(2)} ` +
+          `recall@10=${pct(d.recallAt10).padStart(4)} nDCG@10=${
+            d.ndcgAt10 === null ? "—" : d.ndcgAt10.toFixed(2)
+          }`
+      );
+    }
+  }
 }
 
 main().catch((err) => {

--- a/src/lib/search/__tests__/pipeline.test.ts
+++ b/src/lib/search/__tests__/pipeline.test.ts
@@ -158,6 +158,68 @@ describe("rankAndAnnotate exact-title boosting", () => {
   });
 });
 
+describe("rankAndAnnotate rerank-window boundary (Lever 1 / F2)", () => {
+  it("keeps a reranked (model-scored) paper above an un-reranked lexical match", () => {
+    // F2: today only the top of the pool is reranked, so a candidate PAST the
+    // rerank depth falls back to keyword-overlap relevance, which SATURATES (~1.0)
+    // on a couple of shared distinctive words and out-sorts a calibrated
+    // cross-encoder score (0.4–0.7). The fix: any candidate the reranker scored
+    // (a model rerankScore) sorts strictly ABOVE any candidate it did not — never
+    // interleaved by raw composite.
+    const query = "empagliflozin cardiovascular outcomes heart failure";
+    const reranked = paper({
+      title: "Empagliflozin outcome trial in heart failure",
+      studyType: "rct",
+      evidenceLevel: "II",
+      year: 2020,
+      citationCount: 100,
+      rerankScore: 0.55, // calibrated model relevance
+      rrfScore: 0.02,
+      pmid: "RERANKED",
+    });
+    const lexicalTail = paper({
+      title:
+        "Empagliflozin cardiovascular outcomes heart failure: a narrative overview",
+      studyType: "narrative_review",
+      evidenceLevel: "III",
+      year: 2021,
+      citationCount: 200,
+      // no rerankScore → un-reranked tail; lexical overlap saturates on the
+      // shared distinctive tokens (empagliflozin, cardiovascular, heart, failure).
+      rrfScore: 0.02,
+      pmid: "LEXICAL",
+    });
+    const ranked = rankAndAnnotate([lexicalTail, reranked], { query });
+    expect(ranked[0].pmid).toBe("RERANKED");
+  });
+
+  it("is a no-op when no candidate was reranked (fail-open lexical floor preserved)", () => {
+    // With the reranker absent (or skipped), NO candidate carries a model score,
+    // so the boundary must not reorder — the lexical composite alone decides.
+    const strong = paper({
+      title: "Dapagliflozin in heart failure with reduced ejection fraction",
+      studyType: "rct",
+      evidenceLevel: "II",
+      citationCount: 5000,
+      journal: "N Engl J Med",
+      rrfScore: 0.03,
+      pmid: "STRONG",
+    });
+    const weak = paper({
+      title: "An unrelated case report",
+      studyType: "case_report",
+      evidenceLevel: "IV",
+      citationCount: 0,
+      rrfScore: 0.01,
+      pmid: "WEAK",
+    });
+    const ranked = rankAndAnnotate([weak, strong], {
+      query: "dapagliflozin heart failure reduced ejection fraction",
+    });
+    expect(ranked[0].pmid).toBe("STRONG");
+  });
+});
+
 describe("buildFlags", () => {
   it("flags missing metadata, never fabricates it", () => {
     const flags = buildFlags(paper({ title: "x", doi: undefined, pmid: undefined, citationCount: 0 }));

--- a/src/lib/search/__tests__/quality-ranker.test.ts
+++ b/src/lib/search/__tests__/quality-ranker.test.ts
@@ -148,3 +148,27 @@ describe("quality-ranker — signal-aware gate: lexical fallback is not a cross-
     expect(on.signals.relevance).toBeGreaterThan(0.7);
   });
 });
+
+describe("quality-ranker — citation signal breaks a reranker tie (Lever: citation enrichment)", () => {
+  it("a high-citation landmark outranks a zero-citation lookalike at equal reranker relevance", () => {
+    // When the cross-encoder saturates (on-topic papers all tie at rr≈1.0), the
+    // citation count is the tie-breaker that lifts a foundational trial into the
+    // top-10. This ONLY works if the pipeline actually populates citationCount —
+    // which the OpenAlex enrichCitationsByIds wiring restores (single-lane PubMed
+    // landmarks like PARTNER 3 arrive with citationCount=0 otherwise).
+    const landmark = paper({
+      title: "Empagliflozin outcomes trial in heart failure",
+      citationCount: 4767,
+      rerankScore: 0.95,
+      rrfScore: 0.02,
+    });
+    const lookalike = paper({
+      title: "Empagliflozin sub-analysis in heart failure",
+      citationCount: 0,
+      rerankScore: 0.95,
+      rrfScore: 0.02,
+    });
+    const ranked = qualityRank([lookalike, landmark], "empagliflozin heart failure");
+    expect(ranked[0].title).toBe("Empagliflozin outcomes trial in heart failure");
+  });
+});

--- a/src/lib/search/__tests__/rerank.test.ts
+++ b/src/lib/search/__tests__/rerank.test.ts
@@ -52,7 +52,7 @@ afterEach(() => {
   vi.unstubAllEnvs();
 });
 
-describe("rerankResults — OpenRouter primary (literature)", () => {
+describe("rerankResults — literature reranker chain (MedCPT-primary, free-first)", () => {
   it("maps relevance_score back to each input document by index and sorts desc", async () => {
     vi.stubEnv("OPENROUTER_API_KEY", OPENROUTER_KEY);
     // OpenRouter returns top_n results already sorted by relevance: B (idx 1) > C
@@ -100,49 +100,51 @@ describe("rerankResults — OpenRouter primary (literature)", () => {
     expect(body.model).toBe("cohere/rerank-4-experimental");
   });
 
-  it("is PREFERRED over MedCPT and Cohere when all are configured", async () => {
-    vi.stubEnv("OPENROUTER_API_KEY", OPENROUTER_KEY);
+  it("MedCPT (free self-hosted) is PREFERRED over paid OpenRouter and Cohere for literature", async () => {
+    // Free-first: when the self-hosted MedCPT URL is present it is the primary; the
+    // paid lanes are never called unless it fails. No opt-in flag required.
     vi.stubEnv("MEDCPT_RERANK_URL", MEDCPT_URL);
-    vi.stubEnv("ACADEMIC_USE_MEDCPT_RERANK", "1"); // even when MedCPT is explicitly enabled
+    vi.stubEnv("OPENROUTER_API_KEY", OPENROUTER_KEY);
     vi.stubEnv("COHERE_API_KEY", COHERE_KEY);
-    mockResilientFetch.mockResolvedValueOnce(rerankResponse([[1, 0.9], [0, 0.1]]));
+    // MedCPT returns raw logits in INPUT order.
+    mockResilientFetch.mockResolvedValueOnce(jsonResponse({ scores: [0.1, 4, 1] }));
 
     await rerankResults("q", RESULTS);
 
     expect(mockResilientFetch).toHaveBeenCalledTimes(1);
-    expect(mockResilientFetch.mock.calls[0][0]).toBe(OPENROUTER_URL);
+    expect(mockResilientFetch.mock.calls[0][0]).toBe(MEDCPT_URL);
   });
 
-  it("does NOT call MedCPT on the critical path unless ACADEMIC_USE_MEDCPT_RERANK=1", async () => {
-    // OpenRouter down, MedCPT URL present but NOT flagged → skip MedCPT, fall to Cohere.
-    vi.stubEnv("OPENROUTER_API_KEY", OPENROUTER_KEY);
+  it("uses MedCPT by default (no flag) and only falls to a paid lane when it fails", async () => {
+    // MedCPT present WITHOUT ACADEMIC_USE_MEDCPT_RERANK → still primary; on cold-start
+    // failure it falls through to the paid OpenRouter fallback.
     vi.stubEnv("MEDCPT_RERANK_URL", MEDCPT_URL);
+    vi.stubEnv("OPENROUTER_API_KEY", OPENROUTER_KEY);
     vi.stubEnv("COHERE_API_KEY", COHERE_KEY);
-    mockResilientFetch.mockRejectedValueOnce(new Error("[OpenRouter-Rerank] HTTP 503"));
+    mockResilientFetch.mockRejectedValueOnce(new Error("[MedCPT-Rerank] cold start timeout"));
     mockResilientFetch.mockResolvedValueOnce(rerankResponse([[1, 0.9], [0, 0.1]]));
 
     await rerankResults("q", RESULTS);
 
     expect(mockResilientFetch).toHaveBeenCalledTimes(2);
-    expect(mockResilientFetch.mock.calls[0][0]).toBe(OPENROUTER_URL);
-    // second call skipped MedCPT entirely and went straight to Cohere
-    expect(mockResilientFetch.mock.calls[1][0]).toBe(COHERE_URL);
+    expect(mockResilientFetch.mock.calls[0][0]).toBe(MEDCPT_URL);
+    // fell to the paid fallback only after the free lane failed
+    expect(mockResilientFetch.mock.calls[1][0]).toBe(OPENROUTER_URL);
   });
 
-  it("falls OpenRouter → MedCPT (when flagged) → Cohere", async () => {
-    vi.stubEnv("OPENROUTER_API_KEY", OPENROUTER_KEY);
+  it("falls MedCPT → OpenRouter → Cohere", async () => {
     vi.stubEnv("MEDCPT_RERANK_URL", MEDCPT_URL);
-    vi.stubEnv("ACADEMIC_USE_MEDCPT_RERANK", "1");
+    vi.stubEnv("OPENROUTER_API_KEY", OPENROUTER_KEY);
     vi.stubEnv("COHERE_API_KEY", COHERE_KEY);
-    mockResilientFetch.mockRejectedValueOnce(new Error("[OpenRouter-Rerank] HTTP 503"));
     mockResilientFetch.mockRejectedValueOnce(new Error("[MedCPT-Rerank] cold start timeout"));
+    mockResilientFetch.mockRejectedValueOnce(new Error("[OpenRouter-Rerank] HTTP 402"));
     mockResilientFetch.mockResolvedValueOnce(rerankResponse([[1, 0.9], [0, 0.1]]));
 
     const out = await rerankResults("q", RESULTS);
 
     expect(mockResilientFetch).toHaveBeenCalledTimes(3);
-    expect(mockResilientFetch.mock.calls[0][0]).toBe(OPENROUTER_URL);
-    expect(mockResilientFetch.mock.calls[1][0]).toBe(MEDCPT_URL);
+    expect(mockResilientFetch.mock.calls[0][0]).toBe(MEDCPT_URL);
+    expect(mockResilientFetch.mock.calls[1][0]).toBe(OPENROUTER_URL);
     expect(mockResilientFetch.mock.calls[2][0]).toBe(COHERE_URL);
     expect(out.map((r) => r.title)).toEqual(["B relevance high", "A relevance low"]);
   });
@@ -175,10 +177,9 @@ describe("rerankResults — OpenRouter primary (literature)", () => {
   });
 });
 
-describe("rerankResults — MedCPT optional / Cohere tertiary", () => {
-  it("uses MedCPT (squashing logits to [0,1]) only when flagged and OpenRouter absent", async () => {
+describe("rerankResults — MedCPT default primary / Cohere tertiary", () => {
+  it("uses MedCPT (squashing logits to [0,1]) by default when MEDCPT_RERANK_URL is set", async () => {
     vi.stubEnv("MEDCPT_RERANK_URL", MEDCPT_URL);
-    vi.stubEnv("ACADEMIC_USE_MEDCPT_RERANK", "1");
     // raw LOGITS in INPUT order: A=-2, B=4, C=1 → sorted desc by sigmoid → B, C, A.
     mockResilientFetch.mockResolvedValueOnce(jsonResponse({ scores: [-2, 4, 1] }));
 
@@ -195,8 +196,9 @@ describe("rerankResults — MedCPT optional / Cohere tertiary", () => {
     expect(mockResilientFetch.mock.calls[0][0]).toBe(MEDCPT_URL);
   });
 
-  it("ignores MEDCPT_RERANK_URL when the flag is not set, falling open with no other backend", async () => {
-    vi.stubEnv("MEDCPT_RERANK_URL", MEDCPT_URL); // present but NOT flagged
+  it("ACADEMIC_USE_MEDCPT_RERANK=0 forces the MedCPT lane OFF (escape hatch)", async () => {
+    vi.stubEnv("MEDCPT_RERANK_URL", MEDCPT_URL); // present but explicitly disabled
+    vi.stubEnv("ACADEMIC_USE_MEDCPT_RERANK", "0");
     const out = await rerankResults("q", RESULTS);
     expect(out).toBe(RESULTS);
     expect(mockResilientFetch).not.toHaveBeenCalled();

--- a/src/lib/search/pipeline.ts
+++ b/src/lib/search/pipeline.ts
@@ -217,6 +217,29 @@ export function recencyRankKey(
   return composite * (1 + RECENCY_BOOST * recencyNorm);
 }
 
+/**
+ * Hard rerank-window boundary (Lever 1 / F2). Any candidate the cross-encoder
+ * scored (a model `rerankScore`) is placed strictly ABOVE any candidate it did
+ * NOT score — the un-reranked tail beyond the rerank depth, whose relevance is a
+ * saturating keyword-overlap fallback that can otherwise out-sort a calibrated
+ * model score. Stable within each partition, so the incoming composite order is
+ * preserved inside the reranked set and inside the tail. A no-op when every
+ * candidate was reranked (the common case now that the whole pool is reranked) or
+ * none was (reranker absent / skipped → all lexical → single partition). This is
+ * the "reranked-on-top, non-reranked strictly below" window semantics the IR
+ * literature converges on (Elasticsearch #120670; sbert/BEIR/Cohere).
+ */
+function rerankedAboveTail(scored: ScoredResult[]): ScoredResult[] {
+  const reranked: ScoredResult[] = [];
+  const tail: ScoredResult[] = [];
+  for (const s of scored) {
+    if (typeof s.result.rerankScore === "number") reranked.push(s);
+    else tail.push(s);
+  }
+  if (reranked.length === 0 || tail.length === 0) return scored;
+  return [...reranked, ...tail];
+}
+
 function orderByRecency(scored: ScoredResult[]): ScoredResult[] {
   const years = scored.map((s) => s.result.year || 0).filter(Boolean);
   const minY = years.length ? Math.min(...years) : 0;
@@ -256,6 +279,10 @@ export function rankAndAnnotate(
     // recent low-value papers, while among similar-quality papers the newer wins.
     ordered = orderByRecency(scored);
   }
+  // Enforce the rerank-window boundary on the composite order: a calibrated
+  // model relevance never loses its slot to a saturating lexical-overlap score
+  // from an un-reranked tail candidate. No-op in the common all-reranked path.
+  ordered = rerankedAboveTail(ordered);
 
   const annotated = ordered.map((s) =>
     annotate(s, opts.recency ? "recency" : "quality", queryTerms)

--- a/src/lib/search/rerank.ts
+++ b/src/lib/search/rerank.ts
@@ -209,18 +209,23 @@ export async function rerankResults(
     : process.env.MEDCPT_RERANK_URL;
   const cohereKey = process.env.COHERE_API_KEY;
 
-  // OpenRouter is the literature primary; the web path keeps its own reranker chain.
+  // The self-hosted cross-encoder is the PRIMARY reranker for BOTH domains:
+  //   web → WEB_RERANK_URL, literature → MedCPT (MEDCPT_RERANK_URL).
+  // It is free (Modal GPU, scale-to-zero, $0 idle) and biomedical-SOTA. It absorbs a
+  // ~20s cold start (longer ceiling + one retry) then serves <1s warm; on cold-start
+  // failure the chain falls through to a paid fallback or the keyword-overlap floor.
+  // `ACADEMIC_USE_MEDCPT_RERANK` is retained only as an escape hatch to force it OFF.
+  const selfHostedEnabled =
+    Boolean(selfHostedUrl) &&
+    (isWeb || process.env.ACADEMIC_USE_MEDCPT_RERANK !== "0");
+  // Paid fallbacks (literature only): OpenRouter cohere/rerank-4-pro, then Cohere-direct.
+  // Used only if the free self-hosted lane is absent or failing — kept off the primary
+  // path so a pre-revenue product never bleeds per-search reranker spend.
   const openRouterEnabled = !isWeb && Boolean(openRouterKey);
-  // The self-hosted MedCPT cross-encoder is DROPPED to scale-to-zero — for the
-  // literature path it is on the critical path ONLY when explicitly opted in. The web
-  // reranker (its own scale-to-zero GPU) stays its domain's primary as before.
-  const selfHostedEnabled = isWeb
-    ? Boolean(selfHostedUrl)
-    : Boolean(selfHostedUrl) && process.env.ACADEMIC_USE_MEDCPT_RERANK === "1";
 
   if (
     results.length === 0 ||
-    (!openRouterEnabled && !selfHostedEnabled && !cohereKey)
+    (!selfHostedEnabled && !openRouterEnabled && !cohereKey)
   ) {
     return results;
   }
@@ -230,15 +235,7 @@ export async function rerankResults(
 
   const backends: { name: string; run: () => Promise<RerankScore[]> }[] = [];
 
-  // 1. OpenRouter (primary, literature) — managed, always-warm, ~1.2s.
-  if (openRouterEnabled && openRouterKey)
-    backends.push({
-      name: "OpenRouter",
-      run: () => rerankOpenRouter(openRouterKey, query, documents, limit),
-    });
-
-  // 2. Self-hosted cross-encoder — web: WEB_RERANK_URL (primary); literature: MedCPT
-  //    only when ACADEMIC_USE_MEDCPT_RERANK=1.
+  // 1. Self-hosted cross-encoder (PRIMARY, free) — web: WEB_RERANK_URL; literature: MedCPT.
   if (selfHostedEnabled && selfHostedUrl)
     backends.push({
       name: isWeb ? "WebReranker" : "MedCPT",
@@ -249,18 +246,24 @@ export async function rerankResults(
           documents,
           limit,
           isWeb ? "Web-Rerank" : "MedCPT-Rerank",
-          // Both self-hosted rerankers are GPU scale-to-zero; keeping them warm 24/7
-          // isn't worth it at this scale. The web lane fail-open-fasts (short ceiling,
-          // no retry) so a cold start degrades to un-reranked results instantly. The
-          // literature MedCPT lane is opt-in (ACADEMIC_USE_MEDCPT_RERANK) and, when
-          // on, absorbs the cold start with a longer ceiling + one retry. Warm: <1s.
+          // GPU scale-to-zero on both lanes. The web lane fail-open-fasts (short
+          // ceiling, no retry) so a cold start degrades to un-reranked results
+          // instantly. The literature MedCPT lane absorbs its ~20s cold start with a
+          // longer ceiling + one retry. Warm: <1s.
           isWeb
             ? { timeout: Number(process.env.WEB_RERANK_TIMEOUT_MS) || 4000, maxRetries: 0 }
             : { timeout: 15000, maxRetries: 1 }
         ),
     });
 
-  // 3. Cohere-direct — tertiary fallback for either domain.
+  // 2. OpenRouter cohere/rerank-4-pro (paid FALLBACK, literature only) — managed, ~1.2s.
+  if (openRouterEnabled && openRouterKey)
+    backends.push({
+      name: "OpenRouter",
+      run: () => rerankOpenRouter(openRouterKey, query, documents, limit),
+    });
+
+  // 3. Cohere-direct — last-resort paid fallback for either domain.
   if (cohereKey)
     backends.push({
       name: "Cohere",

--- a/src/lib/search/rerank.ts
+++ b/src/lib/search/rerank.ts
@@ -252,7 +252,7 @@ export async function rerankResults(
           // longer ceiling + one retry. Warm: <1s.
           isWeb
             ? { timeout: Number(process.env.WEB_RERANK_TIMEOUT_MS) || 4000, maxRetries: 0 }
-            : { timeout: 15000, maxRetries: 1 }
+            : { timeout: Number(process.env.MEDCPT_RERANK_TIMEOUT_MS) || 25000, maxRetries: 1 }
         ),
     });
 

--- a/src/lib/search/run-search.ts
+++ b/src/lib/search/run-search.ts
@@ -213,9 +213,19 @@ export function recencyYearFloor(currentYear: number, windowYears: number): numb
   return currentYear - windowYears + 1;
 }
 
-// Cap for the post-fusion rerank pool. Only the top candidates by RRF score can
-// reach the returned page, so reranking beyond this is wasted work.
+// Cap for the metadata-backfill pool (PMID resolution). Bounded to the top
+// candidates by RRF score, since a deep candidate can't reach the returned page.
 export const POST_FUSION_POOL = 50;
+
+// Cap for the cross-encoder rerank pool (Lever 1 / F2). The reranker scores the
+// WHOLE fused pool in a single call — Cohere/OpenRouter accept ≤1000 docs per
+// request and bill per search, not per doc, so 50→200 is one call at the same
+// cost — and this cap sits above the largest pools we observe (~190), so the
+// entire ranked region carries a calibrated model score and no un-reranked
+// lexical tail can out-sort it. Reranking only the top 50 (the old behavior) left
+// candidates 50+ on saturating keyword-overlap relevance that beat rank-5 model
+// scores — the documented F2 inversion.
+export const RERANK_POOL_CAP = 200;
 
 // Cap the navigable page count. `total` used to be the largest source's raw hit
 // count (millions), so the UI showed "page 2 of 340,000 pages" — but we only fetch
@@ -781,7 +791,13 @@ async function runLiteratureSearchUncached(
   // they can't reach the returned page anyway. Fail-open.
   //  - rerank: OpenRouter cohere/rerank-4-pro relevance score (managed, always-warm,
   //    ~1.2s; the dominant relevance signal). MedCPT is off the critical path now.
-  const enrichRerankPool = fused.slice(0, POST_FUSION_POOL);
+  // LEVER 1: rerank the WHOLE fused pool (bounded by RERANK_POOL_CAP), not just
+  // the top POST_FUSION_POOL. One reranker call scores every candidate, so a
+  // landmark that RRF ranked past 50 (single-lane PubMed hits especially) is
+  // judged on calibrated relevance instead of falling back to saturating lexical
+  // overlap — and the pipeline's rerank-window boundary keeps any un-reranked
+  // tail strictly below the scored set.
+  const rerankPool = fused.slice(0, RERANK_POOL_CAP);
   // The cross-encoder rerank is COUNTERPRODUCTIVE for a specific trial-acronym
   // lookup: fed a bare acronym ("KEYNOTE-189"), it scores secondary papers that
   // mention the acronym above the trial's PRIMARY report (whose title describes the
@@ -794,8 +810,8 @@ async function runLiteratureSearchUncached(
   if (!skipRerank) {
     await withSourceTimeout(
       "Cross-encoder rerank",
-      attachRerankScores(searchQuery, enrichRerankPool, POST_FUSION_POOL),
-      4000
+      attachRerankScores(searchQuery, rerankPool, rerankPool.length),
+      6000
     ).catch(() => fused);
   }
 
@@ -804,9 +820,11 @@ async function runLiteratureSearchUncached(
   // still lack one (the PMID metadata gate). Resolve the residual via NCBI
   // esearch[AID] — bounded to a handful of the top candidates, fail-open, additive
   // metadata only.
-  await withSourceTimeout("PMID backfill", backfillPmidsByDoi(enrichRerankPool), 3000).catch(
-    () => 0
-  );
+  await withSourceTimeout(
+    "PMID backfill",
+    backfillPmidsByDoi(fused.slice(0, POST_FUSION_POOL)),
+    3000
+  ).catch(() => 0);
 
   // Eval-only: snapshot the enriched candidate pool BEFORE final ranking, so the
   // offline harness can re-rank this exact pool deterministically.

--- a/src/lib/search/run-search.ts
+++ b/src/lib/search/run-search.ts
@@ -18,6 +18,7 @@ import { searchClinicalTrials } from "@/lib/search/sources/clinical-trials";
 import { searchTavily } from "@/lib/search/sources/tavily";
 import { expandByPmra } from "@/lib/search/sources/expansion";
 import { reciprocalRankFusion } from "@/lib/search/rank-fusion";
+import { enrichCitationsByIds } from "@/lib/search/sources/openalex";
 import { planQuery } from "@/lib/search/query-planner";
 import { rankAndAnnotate } from "@/lib/search/pipeline";
 import { searchResultCache, buildCacheKey } from "@/lib/search/result-cache";
@@ -782,10 +783,10 @@ async function runLiteratureSearchUncached(
     maxTotal = Math.max(maxTotal, sr.total);
   }
 
-  // Post-fusion rerank. Citation counts now come natively from Europe PMC's
-  // `citedByCount` (and later Scopus) on each result, so the former OpenAlex
-  // citation-enrichment step is gone — there is no separate metadata backfill to
-  // run concurrently here. Bounded to the top `POST_FUSION_POOL` candidates by RRF
+  // Post-fusion rerank + citation enrichment (run concurrently below). Europe PMC and
+  // Scopus carry `citedByCount` natively, but PubMed-only and dense-only results do
+  // not — so OpenAlex backfills citations by PMID/DOI to give the composite its
+  // landmark signal. Bounded to the top `POST_FUSION_POOL` candidates by RRF
   // score, in place (slice shares object refs, so the originals in `fused` still
   // get the mutated rerankScore). Candidates past the pool are never reranked, so
   // they can't reach the returned page anyway. Fail-open.
@@ -807,13 +808,28 @@ async function runLiteratureSearchUncached(
   // composite + demoteSecondaryTrialResults already float the primary first, so we
   // skip the rerank. Non-acronym queries keep it.
   const skipRerank = plan.trialAcronyms.length > 0;
-  if (!skipRerank) {
-    await withSourceTimeout(
-      "Cross-encoder rerank",
-      attachRerankScores(searchQuery, rerankPool, rerankPool.length),
-      6000
-    ).catch(() => fused);
-  }
+  // LEVER 2 (citation signal): backfill citation counts on the pool via OpenAlex by
+  // PMID/DOI, concurrently with the rerank. The cross-encoder saturates on-topic
+  // papers at ~1.0, so the citation count is the tie-breaker that floats a
+  // foundational trial into the top-10 — but single-lane PubMed landmarks (PARTNER 3,
+  // Evolut, ARISTOTLE) arrive with citationCount=0. This restores the dormant signal
+  // the quality composite already log-normalizes. Fail-open: OpenAlex has a circuit
+  // breaker and returns 0 when unreachable, so a bad key/outage is never worse than
+  // the current zero-citation state. Mutates in place (shared refs with `fused`).
+  await Promise.all([
+    skipRerank
+      ? Promise.resolve(null)
+      : withSourceTimeout(
+          "Cross-encoder rerank",
+          attachRerankScores(searchQuery, rerankPool, rerankPool.length),
+          6000
+        ).catch(() => fused),
+    withSourceTimeout(
+      "Citation enrichment",
+      enrichCitationsByIds(rerankPool),
+      5000
+    ).catch(() => 0),
+  ]);
 
   // PMID backfill: PubMed and Europe PMC (MEDLINE records) carry PMIDs natively,
   // but DOI-only results (Crossref, preprints, non-MEDLINE Europe PMC sources)


### PR DESCRIPTION
## What changed
Academic-search Phase 1: fixes a live production reranker outage, removes a per-search cost, and closes half the ranking gap — all measured on an honest, unfrozen probe.

**Source fixes (runtime):**
- **Free MedCPT cross-encoder is now the primary academic reranker.** The paid OpenRouter reranker had run out of credits (HTTP 402), silently degrading live search to keyword-only. MedCPT is free (Modal, scale-to-zero, $0 idle), biomedical-SOTA, same embedding space as the corpus. Paid lanes demoted to optional fallbacks. Escape hatch: `ACADEMIC_USE_MEDCPT_RERANK=0`.
- **Cold-start timeout widened** (15s→25s) so the A10G scale-from-zero doesn't drop to a fallback.
- **Lever 1 — rerank the whole fused pool**, reranked results sorted strictly above the un-reranked tail (was only reranking the top 50).
- **Citation/landmark signal restored** — re-wired OpenAlex `enrichCitationsByIds` (by PMID/DOI, concurrent with rerank, fail-open). The cross-encoder saturates on-topic papers at ~1.0, so the composite's log-normalized citation count is the tie-breaker that floats foundational trials into the top 10.

**Eval instruments (no runtime impact):** unfrozen recall probe, BEIR biomedical harness, held-out multi-domain query set, honest council packet (abstracts, no answer key, PASS/FAIL headline).

## Results (unfrozen probe, 37 landmark queries × 3 runs)
- **Top-10 recall: 74% → 83%** (ranking gap 16% → 8%)
- Landmarks unburied: PARTNER 3, Evolut, EMPEROR-Reduced, ARISTOTLE all 0/33% → **100%** top-10
- Held-out (non-clinical): **71% → 71%, zero regression** across all domains
- BEIR: invariant (reranker path untouched by ranking changes)

Lever 2 (demote RRF) was tried and **reverted** — measured no gain; the citation signal was the actual fix. Lever 3 (recency) was skipped after the diagnosis showed it doesn't fire on the buried queries.

## How to test
`op-run -- npx tsx eval/literature-search/recall-probe.ts --runs 3 --label verify` — expect ~83% top-10, ~91% pool, MedCPT serving every query (0 OpenRouter 402s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a held-out literature search benchmark, recall probe tooling, and BEIR-based evaluation support.
  * Expanded search ranking behavior so reranked results stay above non-reranked ones, with a larger rerank pool and stronger citation enrichment.

* **Bug Fixes**
  * Improved reranker fallback behavior and made the self-hosted literature reranker the default primary option when available.
  * Added safeguards for evaluation consistency and clearer reporting of retrieval vs. ranking gaps.

* **Documentation**
  * Added detailed search design, diagnosis, and evaluation notes for literature search workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->