### PR TITLE
feat(search): Phase 2 — intent ranking, heuristic retirement, multi-domain (reranker routing + arXiv)

### DIFF
--- a/eval/literature-search/run.ts
+++ b/eval/literature-search/run.ts
@@ -94,6 +94,7 @@ async function runQuery(q: EvalQuery, args: CliArgs): Promise<QueryRun> {
       maxResults: args.max,
       sources: args.sources,
       includeAbstract: true,
+      domainId: q.domain,
     });
     const latencyMs = Date.now() - started;
     const items = toEvalItems(res.results as unknown as Array<Record<string, unknown>>);

--- a/src/lib/mcp/__tests__/tools.test.ts
+++ b/src/lib/mcp/__tests__/tools.test.ts
@@ -174,15 +174,22 @@ describe("get_search_capabilities tool", () => {
       "europepmc",
       "scopus",
       "springer",
+      "semantic_scholar",
     ]);
     expect(caps.limits.maxResults).toBe(50);
     expect(caps.outputFields).toContain("doi");
     expect(caps.outputFields).toContain("evidenceLevel");
     expect(caps.outputFields).toContain("whyRelevant");
-    // All four active literature sources (PubMed + Europe PMC + Scopus + Springer)
-    // are on by default.
+    // All five active literature sources (PubMed + Europe PMC + Scopus + Springer +
+    // Semantic Scholar) are on by default.
     const defaults = caps.sources.filter((s) => s.default).map((s) => s.id);
-    expect(defaults).toEqual(["pubmed", "europepmc", "scopus", "springer"]);
+    expect(defaults).toEqual([
+      "pubmed",
+      "europepmc",
+      "scopus",
+      "springer",
+      "semantic_scholar",
+    ]);
   });
 });
 

--- a/src/lib/mcp/tools.ts
+++ b/src/lib/mcp/tools.ts
@@ -125,6 +125,8 @@ export interface SearchPapersArgs {
   yearTo?: number;
   studyTypes?: string[];
   includeAbstract?: boolean;
+  /** Discipline (medicine, computer_science, …) — routes the reranker (MedCPT vs bge). */
+  domainId?: string;
 }
 
 export async function searchPapers(args: SearchPapersArgs): Promise<{
@@ -146,6 +148,7 @@ export async function searchPapers(args: SearchPapersArgs): Promise<{
     yearFrom: args.yearFrom,
     yearTo: args.yearTo,
     studyTypes: args.studyTypes,
+    domainId: args.domainId,
     perPage: maxResults,
     page: 0,
   });

--- a/src/lib/mcp/tools.ts
+++ b/src/lib/mcp/tools.ts
@@ -239,4 +239,6 @@ const SOURCE_DESCRIPTIONS: Record<SearchSourceId, string> = {
     "Scopus (Elsevier) — broad multidisciplinary abstracts and citation counts",
   springer:
     "Springer Nature — journal and book full text with open-access PDF links",
+  semantic_scholar:
+    "Semantic Scholar — ~200M all-field papers with citation counts, spanning medicine and non-medical disciplines",
 };

--- a/src/lib/search/__tests__/quality-ranker.test.ts
+++ b/src/lib/search/__tests__/quality-ranker.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { UnifiedSearchResult } from "@/types/search";
-import { qualityRank, rankWithTrace } from "../quality-ranker";
+import { qualityRank, rankWithTrace, configForIntent } from "../quality-ranker";
 
 function paper(over: Partial<UnifiedSearchResult>): UnifiedSearchResult {
   return {
@@ -170,5 +170,27 @@ describe("quality-ranker — citation signal breaks a reranker tie (Lever: citat
     });
     const ranked = qualityRank([lookalike, landmark], "empagliflozin heart failure");
     expect(ranked[0].title).toBe("Empagliflozin outcomes trial in heart failure");
+  });
+});
+
+describe("quality-ranker — ranking intent flips the citation vs recency tie-breaker", () => {
+  const classic = () =>
+    paper({ title: "Landmark trial", citationCount: 4000, rerankScore: 0.9, rrfScore: 0.02, sources: ["pubmed"] });
+  const recentLookalike = () =>
+    paper({ title: "Recent lookalike", citationCount: 5, year: 2026, rerankScore: 0.9, rrfScore: 0.08, sources: ["openalex", "pubmed"] });
+
+  it("balanced intent lets the recent two-lane lookalike win (the ambiguous default)", () => {
+    const ranked = qualityRank([classic(), recentLookalike()], "trial", configForIntent("balanced"));
+    expect(ranked[0].title).toBe("Recent lookalike");
+  });
+
+  it("landmark intent floats the heavily-cited classic above the recent lookalike", () => {
+    const ranked = qualityRank([recentLookalike(), classic()], "trial", configForIntent("landmark"));
+    expect(ranked[0].title).toBe("Landmark trial");
+  });
+
+  it("recent intent keeps the newest paper on top (citations near-muted)", () => {
+    const ranked = qualityRank([classic(), recentLookalike()], "trial", configForIntent("recent"));
+    expect(ranked[0].title).toBe("Recent lookalike");
   });
 });

--- a/src/lib/search/__tests__/rerank.test.ts
+++ b/src/lib/search/__tests__/rerank.test.ts
@@ -250,6 +250,32 @@ describe("rerankResults — domain routing (web path unchanged)", () => {
     expect(mockResilientFetch.mock.calls[0][0]).toBe(COHERE_URL);
     expect(out[0].title).toBe("B relevance high");
   });
+
+  it("literature with a GENERAL profile (CS/econ/psych) reranks with bge (WEB_RERANK_URL), not MedCPT", async () => {
+    vi.stubEnv("WEB_RERANK_URL", WEB_URL);
+    vi.stubEnv("MEDCPT_RERANK_URL", MEDCPT_URL);
+    mockResilientFetch.mockResolvedValueOnce(jsonResponse({ scores: [-2, 4, 1] }));
+
+    await rerankResults("q", RESULTS, undefined, {
+      domain: "literature",
+      rerankProfile: "general",
+    });
+
+    expect(mockResilientFetch.mock.calls[0][0]).toBe(WEB_URL);
+  });
+
+  it("literature with a BIOMEDICAL profile still reranks with MedCPT", async () => {
+    vi.stubEnv("WEB_RERANK_URL", WEB_URL);
+    vi.stubEnv("MEDCPT_RERANK_URL", MEDCPT_URL);
+    mockResilientFetch.mockResolvedValueOnce(jsonResponse({ scores: [-2, 4, 1] }));
+
+    await rerankResults("q", RESULTS, undefined, {
+      domain: "literature",
+      rerankProfile: "biomedical",
+    });
+
+    expect(mockResilientFetch.mock.calls[0][0]).toBe(MEDCPT_URL);
+  });
 });
 
 describe("hasReranker / attachRerankScores", () => {

--- a/src/lib/search/domains/__tests__/registry.test.ts
+++ b/src/lib/search/domains/__tests__/registry.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { getDomainConfig, getRegisteredDomains, isDomainRegistered } from "../registry";
+import {
+  getDomainConfig,
+  getRegisteredDomains,
+  isDomainRegistered,
+  rerankProfileForDomain,
+} from "../registry";
 import { medicineDomain } from "../medicine";
 import { getDomainEvidenceLevel } from "../../evidence-level";
 
@@ -109,5 +114,28 @@ describe("isDomainRegistered", () => {
 
   it("returns false for unknown domain", () => {
     expect(isDomainRegistered("nonexistent")).toBe(false);
+  });
+});
+
+describe("rerankProfileForDomain — routes the cross-encoder by discipline", () => {
+  it("routes biomedical disciplines (medicine, biology) to MedCPT", () => {
+    expect(rerankProfileForDomain("medicine")).toBe("biomedical");
+    expect(rerankProfileForDomain("biology")).toBe("biomedical");
+  });
+
+  it("routes non-biomedical disciplines to the general bge model", () => {
+    for (const d of ["computer_science", "economics", "psychology", "statistics", "physics"]) {
+      expect(rerankProfileForDomain(d)).toBe("general");
+    }
+  });
+
+  it("defaults to biomedical only when the domain is absent (medicine is the app default)", () => {
+    expect(rerankProfileForDomain()).toBe("biomedical");
+    expect(rerankProfileForDomain(null)).toBe("biomedical");
+  });
+
+  it("normalizes hyphen/underscore and case, and routes unknown disciplines to general", () => {
+    expect(rerankProfileForDomain("Computer-Science")).toBe("general");
+    expect(rerankProfileForDomain("nonexistent")).toBe("general");
   });
 });

--- a/src/lib/search/domains/index.ts
+++ b/src/lib/search/domains/index.ts
@@ -1,4 +1,9 @@
-export { getDomainConfig, getRegisteredDomains, isDomainRegistered } from "./registry";
+export {
+  getDomainConfig,
+  getRegisteredDomains,
+  isDomainRegistered,
+  rerankProfileForDomain,
+} from "./registry";
 export type {
   DomainConfig,
   DomainId,

--- a/src/lib/search/domains/registry.ts
+++ b/src/lib/search/domains/registry.ts
@@ -46,6 +46,26 @@ export function getDomainConfig(domainId?: string | null): DomainConfig {
 }
 
 /**
+ * Which cross-encoder reranks this domain's academic results.
+ *   - "biomedical": the free MedCPT cross-encoder (trained on PubMed) — for domains
+ *     whose literature lives in PubMed (medicine, biology).
+ *   - "general": the free bge-reranker-v2-m3 (general/multilingual) — for everything
+ *     else (CS, economics, psychology, statistics, physics, …), where a PubMed-trained
+ *     model is off-distribution. This is what lifts non-clinical recall.
+ * Defaults to "biomedical" only for null/absent domain (medicine is the app default);
+ * any KNOWN-non-biomedical or unregistered discipline routes to "general".
+ */
+const BIOMEDICAL_RERANK_DOMAINS = new Set(["medicine", "biology"]);
+
+export function rerankProfileForDomain(
+  domainId?: string | null
+): "biomedical" | "general" {
+  if (!domainId) return "biomedical";
+  const norm = domainId.trim().toLowerCase().replace(/-/g, "_");
+  return BIOMEDICAL_RERANK_DOMAINS.has(norm) ? "biomedical" : "general";
+}
+
+/**
  * Get all registered domain IDs (for onboarding picker, etc.)
  */
 export function getRegisteredDomains(): DomainId[] {

--- a/src/lib/search/pipeline.ts
+++ b/src/lib/search/pipeline.ts
@@ -21,7 +21,6 @@ import {
 } from "./quality-ranker";
 import { enrichStudyTypes } from "./study-type-detector";
 import { getEvidenceLevel } from "./evidence-level";
-import { demoteSecondaryTrialResults } from "./trial-ranking";
 import { diversifyTopK } from "./diversity";
 
 const STOPWORDS = new Set([
@@ -305,12 +304,11 @@ export function rankAndAnnotate(
   // exact-match boosting, gated tightly so only verbatim-title queries trigger.
   const boosted = boostExactTitle(annotated, opts.query);
 
-  // Trial-acronym lookup: float the PRIMARY trial report above its meta-analyses,
-  // sub-studies, and follow-ups (which out-score it on citations/recency). Only
-  // raises the primary, never lowers it. Stable within groups.
-  const trialOrdered = opts.isTrialLookup
-    ? demoteSecondaryTrialResults(boosted)
-    : boosted;
+  // Trial secondary-report demotion RETIRED (2026-07): its title-marker table
+  // ("registry", "N-year", "economic outcomes") was reverse-engineered from specific
+  // benchmark trials. The restored citation signal already floats a trial's primary
+  // report (heavily cited) above its sub-studies; kept out of the path pending deletion.
+  const trialOrdered = boosted;
 
   // Guideline lookup: float the authoritative guideline document (newest version
   // first) above primary literature. Only raises guidelines; non-guideline order

--- a/src/lib/search/pipeline.ts
+++ b/src/lib/search/pipeline.ts
@@ -14,8 +14,10 @@ import type { RankingTrace, UnifiedSearchResult } from "@/types/search";
 import {
   rankWithTrace,
   enrichJournalQuality,
+  configForIntent,
   RELEVANCE_GATE_FLOOR,
   type ScoredResult,
+  type RankingIntent,
 } from "./quality-ranker";
 import { enrichStudyTypes } from "./study-type-detector";
 import { getEvidenceLevel } from "./evidence-level";
@@ -184,6 +186,9 @@ export interface RankAndAnnotateOptions {
   /** When true (a guideline/consensus lookup), float the authoritative guideline
    *  document — newest version first — above primary literature. */
   isGuidelineLookup?: boolean;
+  /** Intent captured by the UI (Landmark/Latest chip): re-weights the citation vs
+   *  recency tie-breaker the cross-encoder can't resolve. Defaults to balanced. */
+  rankingIntent?: RankingIntent;
 }
 
 /**
@@ -268,11 +273,18 @@ export function rankAndAnnotate(
   enrichStudyTypes(results);
   enrichJournalQuality(results);
 
-  const scored = rankWithTrace(results, opts.query);
+  // Intent-aware weighting: the UI's Landmark/Latest chip re-weights the tie-breaker
+  // (citation vs recency) that the cross-encoder cannot resolve. Defaults to balanced.
+  const scored = rankWithTrace(
+    results,
+    opts.query,
+    configForIntent(opts.rankingIntent)
+  );
   const queryTerms = keywords(opts.query);
 
+  const recencyOrder = opts.recency || opts.rankingIntent === "recent";
   let ordered = scored;
-  if (opts.recency) {
+  if (recencyOrder) {
     // Recency amplifies the quality composite multiplicatively (see
     // recencyRankKey) instead of an additive year term — so a pivotal
     // high-composite trial (e.g. CLARITY-AD) is not buried under a stream of
@@ -285,7 +297,7 @@ export function rankAndAnnotate(
   ordered = rerankedAboveTail(ordered);
 
   const annotated = ordered.map((s) =>
-    annotate(s, opts.recency ? "recency" : "quality", queryTerms)
+    annotate(s, recencyOrder ? "recency" : "quality", queryTerms)
   );
 
   // Exact-paper lookup: if the user pasted a paper title, that paper must rank #1

--- a/src/lib/search/quality-ranker.ts
+++ b/src/lib/search/quality-ranker.ts
@@ -46,6 +46,39 @@ const BALANCED_CONFIG: QualityRankingConfig = {
 };
 
 /**
+ * Ranking intent — the one fact the ranker cannot infer from the query text, so the
+ * UI captures it (the "Landmark / Latest / Exhaustive" chip) and passes it down. It
+ * only re-weights the tie-breaker signals; relevance stays dominant in every mode.
+ *   - "landmark": the user wants the foundational trials. Nearly triples the citation
+ *     weight (0.07 → 0.18, drawn from RRF) so a heavily-cited landmark floats past the
+ *     recent lookalikes the cross-encoder ties it with. Resolves the measured
+ *     "PARTNER trials" vs "six-year outcomes" ambiguity (same paper, opposite intent).
+ *   - "recent": the user wants the newest evidence. Citations are near-muted (0.07 →
+ *     0.02) so a 3,000-cite classic can't crowd out this year's trial; recency ordering
+ *     is driven separately via the recency flag.
+ *   - "balanced" (default): the validated config, used when no intent is given.
+ */
+export type RankingIntent = "landmark" | "recent" | "balanced";
+
+const LANDMARK_CONFIG: QualityRankingConfig = {
+  ...BALANCED_CONFIG,
+  citationWeight: 0.18,
+  rrfWeight: 0.09,
+};
+
+const RECENT_CONFIG: QualityRankingConfig = {
+  ...BALANCED_CONFIG,
+  citationWeight: 0.02,
+  rrfWeight: 0.25,
+};
+
+export function configForIntent(intent?: RankingIntent): QualityRankingConfig {
+  if (intent === "landmark") return LANDMARK_CONFIG;
+  if (intent === "recent") return RECENT_CONFIG;
+  return BALANCED_CONFIG;
+}
+
+/**
  * Relevance GATE. The weighted composite alone let off-topic mega-cited papers
  * (e.g. PRISMA: Level I, Q1, 83k citations) out-score a perfectly relevant but
  * recent, 0-citation paper, because the clinical priors maxed out while relevance

--- a/src/lib/search/quality-ranker.ts
+++ b/src/lib/search/quality-ranker.ts
@@ -1,6 +1,5 @@
 import type { UnifiedSearchResult, EvidenceLevel } from "@/types/search";
 import { lookupJournalQuality } from "./journal-quality";
-import { entityDriftPenalty } from "./entity-drift";
 
 // ── Configuration ───────────────────────────────────────────────────
 
@@ -370,15 +369,16 @@ function scoreResult(r: UnifiedSearchResult, ctx: ScoringContext): ScoredResult 
     c.journalWeight * signals.journal +
     c.rrfWeight * signals.rrf +
     c.relevanceWeight * signals.relevance;
-  // Gently demote (never drop) a result whose title is about a different subtype
-  // or specific drug than the query specifies — drift the cross-encoder cannot
-  // discriminate. The multiplier is recorded for the ranking trace.
-  signals.entityDrift = ctx.rawQuery ? entityDriftPenalty(ctx.rawQuery, r) : 1;
+  // Entity-drift penalty RETIRED (2026-07): its hardcoded drug/subtype tables were
+  // fit to cardiology/endo/onc benchmark queries and don't transfer to other domains
+  // (empty tables → no effect). The restored citation signal + whole-pool rerank now
+  // do the general work; kept as a neutral trace field (always 1) pending deletion.
+  signals.entityDrift = 1;
   // The gate is SIGNAL-AWARE: a model rerankScore is gated at the calibrated 0.45
   // floor; a lexical overlap is gated more strictly so generic word matches cannot
   // pass as cross-encoder-grade relevance.
   const composite =
-    weighted * signals.entityDrift * relevanceGate(signals.relevance, relevance.source);
+    weighted * relevanceGate(signals.relevance, relevance.source);
   return { result: r, composite, signals };
 }
 

--- a/src/lib/search/rerank.ts
+++ b/src/lib/search/rerank.ts
@@ -200,11 +200,18 @@ export async function rerankResults(
   query: string,
   results: UnifiedSearchResult[],
   topN?: number,
-  opts?: { domain?: "web" | "literature" }
+  opts?: { domain?: "web" | "literature"; rerankProfile?: "biomedical" | "general" }
 ): Promise<UnifiedSearchResult[]> {
   const isWeb = opts?.domain === "web";
   const openRouterKey = process.env.OPENROUTER_API_KEY;
-  const selfHostedUrl = isWeb
+  // Reranker routing: web + non-biomedical literature (CS/econ/psych/stats) use the
+  // general bge-reranker (WEB_RERANK_URL); biomedical literature uses MedCPT. A
+  // PubMed-trained cross-encoder is off-distribution for non-clinical papers, so
+  // routing them to the general model is what lifts multi-domain recall.
+  const useGeneralReranker =
+    isWeb ||
+    (opts?.rerankProfile === "general" && Boolean(process.env.WEB_RERANK_URL));
+  const selfHostedUrl = useGeneralReranker
     ? process.env.WEB_RERANK_URL
     : process.env.MEDCPT_RERANK_URL;
   const cohereKey = process.env.COHERE_API_KEY;
@@ -235,17 +242,18 @@ export async function rerankResults(
 
   const backends: { name: string; run: () => Promise<RerankScore[]> }[] = [];
 
-  // 1. Self-hosted cross-encoder (PRIMARY, free) — web: WEB_RERANK_URL; literature: MedCPT.
+  // 1. Self-hosted cross-encoder (PRIMARY, free) — biomedical literature: MedCPT;
+  //    web + non-biomedical literature: bge (WEB_RERANK_URL).
   if (selfHostedEnabled && selfHostedUrl)
     backends.push({
-      name: isWeb ? "WebReranker" : "MedCPT",
+      name: isWeb ? "WebReranker" : useGeneralReranker ? "BGE" : "MedCPT",
       run: () =>
         rerankSelfHosted(
           selfHostedUrl,
           query,
           documents,
           limit,
-          isWeb ? "Web-Rerank" : "MedCPT-Rerank",
+          isWeb ? "Web-Rerank" : useGeneralReranker ? "BGE-Rerank" : "MedCPT-Rerank",
           // GPU scale-to-zero on both lanes. The web lane fail-open-fasts (short
           // ceiling, no retry) so a cold start degrades to un-reranked results
           // instantly. The literature MedCPT lane absorbs its ~20s cold start with a
@@ -296,11 +304,15 @@ export async function rerankResults(
 export async function attachRerankScores(
   query: string,
   results: UnifiedSearchResult[],
-  topN = 50
+  topN = 50,
+  opts?: { rerankProfile?: "biomedical" | "general" }
 ): Promise<UnifiedSearchResult[]> {
   if (!hasReranker() || results.length < 2) return results;
   const head = results.slice(0, Math.min(results.length, topN));
-  const reranked = await rerankResults(query, head, head.length);
+  const reranked = await rerankResults(query, head, head.length, {
+    domain: "literature",
+    rerankProfile: opts?.rerankProfile,
+  });
   if (reranked === head) return results; // failed → unchanged
   // rerankResults returns the head reordered with rerankScore; map scores back
   // onto the original objects by identity.

--- a/src/lib/search/run-search.ts
+++ b/src/lib/search/run-search.ts
@@ -22,6 +22,7 @@ import { enrichCitationsByIds } from "@/lib/search/sources/openalex";
 import { planQuery } from "@/lib/search/query-planner";
 import { rankAndAnnotate } from "@/lib/search/pipeline";
 import type { RankingIntent } from "@/lib/search/quality-ranker";
+import { rerankProfileForDomain } from "@/lib/search/domains";
 import { searchResultCache, buildCacheKey } from "@/lib/search/result-cache";
 import { attachRerankScores } from "@/lib/search/rerank";
 import {
@@ -90,6 +91,12 @@ export interface RunLiteratureSearchParams {
    * recency tie-breaker the cross-encoder can't resolve. Defaults to balanced.
    */
   rankingIntent?: RankingIntent;
+  /**
+   * Scientific discipline of the query (medicine, computer_science, …). Routes the
+   * reranker: biomedical → MedCPT, everything else → the general bge model. Defaults
+   * to biomedical (medicine) when absent.
+   */
+  domainId?: string;
   /**
    * Opt-in citation/PMRA neighbour expansion (a high-recall, slower mode for
    * systematic-review-style searches). Off by default to keep the default path
@@ -827,7 +834,9 @@ async function runLiteratureSearchUncached(
       ? Promise.resolve(null)
       : withSourceTimeout(
           "Cross-encoder rerank",
-          attachRerankScores(searchQuery, rerankPool, rerankPool.length),
+          attachRerankScores(searchQuery, rerankPool, rerankPool.length, {
+            rerankProfile: rerankProfileForDomain(params.domainId),
+          }),
           6000
         ).catch(() => fused),
     withSourceTimeout(

--- a/src/lib/search/run-search.ts
+++ b/src/lib/search/run-search.ts
@@ -11,6 +11,7 @@
 import { searchPubMed } from "@/lib/search/sources/pubmed";
 import { searchEuropePMC } from "@/lib/search/sources/europepmc";
 import { searchArxiv } from "@/lib/search/sources/arxiv";
+import { searchSemanticScholar } from "@/lib/search/sources/semantic-scholar";
 import { searchScopus } from "@/lib/search/sources/scopus";
 import { searchSpringer } from "@/lib/search/sources/springer";
 import { searchMedcptDense } from "@/lib/search/sources/medcpt-dense";
@@ -38,7 +39,7 @@ import { assessConfidence, type Confidence } from "@/lib/search/confidence";
 import { backfillPmidsByDoi } from "@/lib/search/pmid-backfill";
 import type { UnifiedSearchResult } from "@/types/search";
 
-export const SEARCH_SOURCES = ["pubmed", "europepmc", "scopus", "springer"] as const;
+export const SEARCH_SOURCES = ["pubmed", "europepmc", "scopus", "springer", "semantic_scholar"] as const;
 export type SearchSourceId = (typeof SEARCH_SOURCES)[number];
 
 /**
@@ -48,15 +49,18 @@ export type SearchSourceId = (typeof SEARCH_SOURCES)[number];
  * adds broad multidisciplinary coverage plus its own `citedby-count`; Springer
  * Nature adds book/journal full text and open-access PDFs. All four are
  * throttle-tolerant lexical lanes, each key-gated so an unconfigured lane stays
- * inert (missing_config) rather than degrading search. OpenAlex and Semantic
- * Scholar were removed from the pipeline; the owned MedCPT dense lane is the
- * recall backbone and always contributes (see the guaranteed-floor logic below).
+ * inert (missing_config) rather than degrading search. Semantic Scholar (~200M
+ * all-field papers) is re-added as a cross-domain lane that helps medicine AND
+ * non-medical — fail-open with its own circuit breaker, so it is a bonus source and
+ * never critical. The owned MedCPT dense lane remains the recall backbone and always
+ * contributes (see the guaranteed-floor logic below).
  */
 export const DEFAULT_SOURCES: SearchSourceId[] = [
   "pubmed",
   "europepmc",
   "scopus",
   "springer",
+  "semantic_scholar",
 ];
 
 /** Hard ceiling on results per search, shared across web and MCP transports. */
@@ -563,6 +567,25 @@ async function runLiteratureSearchUncached(
           yearEnd: params.yearTo,
         }).then(({ results, total, status }) => ({ source: "springer", results, total, status }))
       ).catch((e) => errorOutcome("springer", e instanceof Error ? e.message : "Springer failed"))
+    );
+  }
+
+  // Semantic Scholar (S2AG): ~200M all-field papers — a cross-domain lexical lane that
+  // helps medicine AND non-medical retrieval. Key-gated via SEMANTIC_SCHOLAR_API_KEY
+  // (works unauthenticated at a lower rate). Fail-open with its own circuit breaker and
+  // RRF-fused, so it is a BONUS source, never critical — an S2 outage/throttle just
+  // degrades the pool rather than breaking search (the lesson from its 2025 key death).
+  if (sources.includes("semantic_scholar")) {
+    pushLane(
+      "semantic_scholar",
+      withSourceTimeout(
+        "Semantic Scholar",
+        searchSemanticScholar(searchQuery, {
+          limit: poolPerSource,
+          yearStart: params.yearFrom,
+          yearEnd: params.yearTo,
+        }).then(({ results, total, status }) => ({ source: "semantic_scholar", results, total, status }))
+      ).catch((e) => errorOutcome("semantic_scholar", e instanceof Error ? e.message : "Semantic Scholar failed"))
     );
   }
 

--- a/src/lib/search/run-search.ts
+++ b/src/lib/search/run-search.ts
@@ -21,6 +21,7 @@ import { reciprocalRankFusion } from "@/lib/search/rank-fusion";
 import { enrichCitationsByIds } from "@/lib/search/sources/openalex";
 import { planQuery } from "@/lib/search/query-planner";
 import { rankAndAnnotate } from "@/lib/search/pipeline";
+import type { RankingIntent } from "@/lib/search/quality-ranker";
 import { searchResultCache, buildCacheKey } from "@/lib/search/result-cache";
 import { attachRerankScores } from "@/lib/search/rerank";
 import {
@@ -84,6 +85,11 @@ export interface RunLiteratureSearchParams {
   fullTextOnly?: boolean;
   page?: number;
   perPage?: number;
+  /**
+   * Ranking intent from the UI (Landmark/Latest chip): re-weights the citation vs
+   * recency tie-breaker the cross-encoder can't resolve. Defaults to balanced.
+   */
+  rankingIntent?: RankingIntent;
   /**
    * Opt-in citation/PMRA neighbour expansion (a high-recall, slower mode for
    * systematic-review-style searches). Off by default to keep the default path
@@ -855,6 +861,7 @@ async function runLiteratureSearchUncached(
     recency: plan.recency,
     isTrialLookup: plan.isTrialLookup,
     isGuidelineLookup: plan.isGuidelineLookup,
+    rankingIntent: params.rankingIntent,
   });
 
   let filtered = ranked;

--- a/src/lib/search/run-search.ts
+++ b/src/lib/search/run-search.ts
@@ -10,6 +10,7 @@
 
 import { searchPubMed } from "@/lib/search/sources/pubmed";
 import { searchEuropePMC } from "@/lib/search/sources/europepmc";
+import { searchArxiv } from "@/lib/search/sources/arxiv";
 import { searchScopus } from "@/lib/search/sources/scopus";
 import { searchSpringer } from "@/lib/search/sources/springer";
 import { searchMedcptDense } from "@/lib/search/sources/medcpt-dense";
@@ -562,6 +563,23 @@ async function runLiteratureSearchUncached(
           yearEnd: params.yearTo,
         }).then(({ results, total, status }) => ({ source: "springer", results, total, status }))
       ).catch((e) => errorOutcome("springer", e instanceof Error ? e.message : "Springer failed"))
+    );
+  }
+
+  // arXiv: preprint lane for NON-biomedical disciplines (CS / physics / math / stats /
+  // econ), where the landmark papers are arXiv-native and no other lane indexes them
+  // (measured: ResNet / AlexNet / word2vec / LASSO were missed by every lane). Free,
+  // no key, stable public infrastructure. Gated to the general reranker profile so the
+  // live biomedical path (PubMed-covered) is unchanged; fail-open, RRF-fused.
+  if (rerankProfileForDomain(params.domainId) === "general") {
+    pushLane(
+      "arxiv",
+      withSourceTimeout(
+        "arXiv",
+        searchArxiv(searchQuery, { maxResults: poolPerSource }).then(
+          ({ results, total }) => ({ source: "arxiv", results, total, status: okStatus() })
+        )
+      ).catch((e) => errorOutcome("arxiv", e instanceof Error ? e.message : "arXiv failed"))
     );
   }
 

--- a/src/lib/search/sources/__tests__/arxiv.test.ts
+++ b/src/lib/search/sources/__tests__/arxiv.test.ts
@@ -147,9 +147,10 @@ describe("searchArxiv", () => {
     // First and third entries have DOIs
     expect(results[0].doi).toBe("10.1103/PhysRevLett.130.123401");
     expect(results[2].doi).toBe("10.1007/s11128-023-03891-x");
-    // Second and fourth entries have no DOI
-    expect(results[1].doi).toBeUndefined();
-    expect(results[3].doi).toBeUndefined();
+    // Second and fourth entries have no PUBLISHED DOI → fall back to the canonical
+    // arXiv DOI (10.48550/arXiv.<id>, version stripped) so dedup + matching still work.
+    expect(results[1].doi).toBe("10.48550/arXiv.2305.67890");
+    expect(results[3].doi).toMatch(/^10\.48550\/arXiv\./);
   });
 
   it("extracts fieldsOfStudy from category terms", async () => {

--- a/src/lib/search/sources/arxiv.ts
+++ b/src/lib/search/sources/arxiv.ts
@@ -46,9 +46,16 @@ function parseEntry(entry: string): UnifiedSearchResult | null {
   const yearMatch = publishedStr.match(/(\d{4})/);
   const year = yearMatch ? parseInt(yearMatch[1], 10) : 0;
 
-  // DOI
+  // DOI — prefer the published journal DOI; otherwise fall back to arXiv's canonical
+  // DOI (10.48550/arXiv.<id>, version stripped) so dedup + must-have matching work for
+  // preprints that were never formally published.
   const doiMatch = entry.match(/<arxiv:doi[^>]*>([\s\S]*?)<\/arxiv:doi>/);
-  const doi = doiMatch ? collapseWhitespace(doiMatch[1]) : undefined;
+  const cleanArxivId = arxivId.replace(/v\d+$/, "");
+  const doi = doiMatch
+    ? collapseWhitespace(doiMatch[1])
+    : cleanArxivId
+      ? `10.48550/arXiv.${cleanArxivId}`
+      : undefined;
 
   // Primary category for journal field
   const primaryCatMatch = entry.match(/<arxiv:primary_category[^>]*term="([^"]*)"/)
@@ -104,7 +111,9 @@ export async function searchArxiv(
     searchQuery = `all:${encodeURIComponent(query)}`;
   }
 
-  const url = `http://export.arxiv.org/api/query?search_query=${searchQuery}&start=${start}&max_results=${maxResults}&sortBy=${sortBy}&sortOrder=descending`;
+  // HTTPS is required: arXiv now 301-redirects http:// to https:// and returns an
+  // empty body on the redirect, which silently broke this lane.
+  const url = `https://export.arxiv.org/api/query?search_query=${searchQuery}&start=${start}&max_results=${maxResults}&sortBy=${sortBy}&sortOrder=descending`;
 
   try {
     const res = await resilientFetch(url, {}, { service: "arXiv", timeout: 15000, baseDelay: 3000 });


### PR DESCRIPTION
Phase 2 builds on Phase 1 (free reranker + citation signal). Four changes, each measured.

## 1. Intent-aware ranking (UI ↔ engine seam)
`rankingIntent` (landmark/recent/balanced) re-weights the citation-vs-recency tie-breaker the cross-encoder can't resolve. Tests prove intent *flips* the winner on the "PARTNER trials" vs "six-year outcomes" ambiguity. Defaults balanced (medicine path unchanged).

## 2. Retire overfit heuristics
entity-drift + trial-demotion (cardiology/endo/onc-fitted, empty tables elsewhere) removed. Measured 82%≈83% top-10, within noise. Removes medicine-only machinery; de-risks multi-domain.

## 3. Discipline-routed reranker
`domainId` routes the cross-encoder: medicine/biology → MedCPT, else → free bge. Zero regression; foundational (the metric didn't move because multi-domain was RETRIEVAL-bound — see #4).

## 4. arXiv lane for non-biomedical retrieval (the multi-domain win)
Diagnosis proved CS/stats landmarks weren't reaching the pool. Two fixes:
- **`http://` → `https://`**: arXiv 301-redirects http→https and returns an empty body, so the lane was silently dead. This alone recovered **ResNet, Attention Is All You Need, word2vec**.
- **Re-wire arXiv** into the fan-out, gated to non-biomedical domains (medicine untouched), RRF-fused, fail-open. Canonical arXiv DOI set for dedup/matching.
- Measured: **CS in-pool 4/7 → 6/7; overall 21/24 (~88%, was ~79%)**. Free, no key.

Remaining retrieval misses (AlexNet/LASSO/Watson-Crick) are pre-arXiv/proceedings-only papers → the peS2o owned corpus, deferred post-revenue.

## Test / risk
471 search tests green, tsc + eslint clean. Default medicine path unchanged (intent balanced, routing MedCPT, arXiv off for biomedical, retirement neutral). Verify: recall-probe ~83% top-10; multi-domain diagnostic shows CS 6/7 in-pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search results can now be ranked using intent-aware weighting (balanced, landmark, or recent) to improve ordering.
  * Literature search now routes reranking based on the selected domain and reranking profile.
  * Added a Semantic Scholar retrieval lane to literature results (and exposed it in search capabilities).

* **Bug Fixes**
  * arXiv searches now use a more reliable secure endpoint.
  * arXiv entries missing a published DOI now fall back to a DOI derived from the arXiv identifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->