### PR TITLE
feat(web-search): Phase 0 — cost/observability foundation (caching, budget caps, telemetry)

### DIFF
--- a/docs/web-search/IMPROVEMENT-PLAN.md
+++ b/docs/web-search/IMPROVEMENT-PLAN.md
@@ -1,0 +1,209 @@
+# Non-Academic Search — Improvement Plan (web / news / discussions / videos + eval)
+
+> Scope: the WEB, NEWS, DISCUSSIONS, VIDEOS tabs and the eval that measures them.
+> Academic search and Deep Research are out of scope (both in a good state).
+> Grounded in July-2026 literature, repos, and API pricing. Every lever is tagged
+> with **cost** and **effort** so spend stays deliberate. Pre-revenue posture:
+> *free/owned first, a little paid spend where it clearly earns it, nothing gratuitous.*
+
+---
+
+## 0. The verdict up front
+
+The rebuild is genuinely good — fully keyed in prod, all tabs federated, and **discussions
+is a real, measured win (100% beat-or-tie vs Exa)**. The improvement work here is **mostly
+free**: the highest-leverage move on every tab is a ranking/observability change we can make
+with tools we already own (the bge cross-encoder, RRF, the transcript fetcher), not a new
+paid API.
+
+**The money truth:** at pre-revenue traffic the marginal cost of search is near-zero *if we
+don't multiply calls*. Exa carries a 20k-request/mo free tier; the real spend risks are
+(a) **fan-out multiplication** (calling 4 engines per query) and (b) **premium endpoints**
+(Exa Deep/Answer at 2–3× Search). So cost discipline = **caching + capped tiered fallback**,
+not penny-pinching. Two external facts to internalize:
+- **Brave killed its free Search API tier (Feb 2026)** — now $5/1k, ~$5/mo (~1k) credit only
+  with public attribution. Our **discussions Reddit path and web/news fallback run through
+  Brave**, so it is now a *paid dependency to defend with caching*.
+- **Bing News API is retired (HTTP 410, Aug 2025)** — do not build on it.
+
+---
+
+## 1. The cost/observability foundation (build once, every tab benefits)
+
+This is the substrate. Do it first; it de-risks spend on all four tabs and is the insurance
+against the next free-tier kill.
+
+| Lever | What it does | Cost | Effort | Evidence |
+|---|---|---|---|---|
+| **Two-layer result cache (exact + semantic), per-tab TTL** | Serve repeat/near-repeat queries from cache; call paid APIs only on miss | **$0** | Low–Med | 40–80% spend cut, 250× latency; one AWS study 86% cut over 63,796 real queries (Percona; MeanCache arXiv:2403.02694) |
+| **Per-tab TTLs + ±10% jitter** | Match freshness to truth: news 5–30 min, discussions 1–6 h, web 6–24 h, video 6–24 h, embeddings ∞ (content-hash) | $0 | Low | AWS API Gateway caching; easyparser 2026 |
+| **Capped tiered fallback (free-first)** | Cache → SearXNG (free) → free-tier paid (Exa 20k/mo, NewsData, YouTube) → metered paid, only on quality shortfall/quota-exhaust | $0 (saves) | Med | eval-cost research |
+| **Per-tab paid-budget guardrail** | Hard daily cap on Exa/Linkup/Brave; when tripped, degrade to owned SearXNG+Brave+RRF+bge instead of erroring — *cost becomes a dial, not a surprise* | $0 (saves) | Low | web-news research §5 |
+| **Request coalescing (single-flight) + stale-while-revalidate** | One upstream call per hot query on cache expiry; serve stale instantly, refresh in bg | $0 | Low | coalescer patterns; SWR |
+| **Embedding cache (content-hash keyed, never expire)** | Never re-embed the same string; repeat reranks are free | $0 | Low | eval-cost research |
+| **`primaryLed` + per-source telemetry** | Emit whether Exa led or the fallback kicked in; alert when Exa-led rate drops — makes the silent web-degradation failure visible | $0 | Low | audit risk #1 |
+
+**Cost ceiling to enforce:** a per-tab daily cap (e.g. Exa ≤ N/day) that trips into the free
+owned machinery. This single guardrail means no traffic spike or free-tier kill can bleed money.
+
+---
+
+## 2. WEB tab
+
+**Today:** Exa's top-10 passed through verbatim (paid, per-query); own machinery (SearXNG +
+Brave + RRF → bge rerank → MMR) runs only on the Exa-down fallback. Quality = Exa's quality;
+it fails silently if Exa drops.
+
+**Verdict: rent, don't build.** An owned open-web crawl+embed index loses build-vs-rent
+pre-revenue (embedding is cheap — ~$14 to embed 10M docs on one GPU — but *continuous
+crawling of tens of billions of pages for coverage + minute-freshness is Exa's actual
+product*, and Common Crawl is a stale monthly snapshot). The money is in caching + routing +
+the reranker we already own, not an index.
+
+| # | Lever | What it does | Cost | Effort |
+|---|---|---|---|---|
+| 1 | **Semantic query-result cache** (from §1) | Shrinks Exa spend directly; overlapping queries repeat heavily | **$0** | Low |
+| 2 | **Query routing / tiering** | Navigational/keyword → Serper ($0.30–1/1k) or Brave + **our existing bge reranker**; semantic/exploratory "find pages like this" → Exa. We pay Exa prices for queries a cheap feed + our rerank already answers | **↓ spend** | Med |
+| 3 | **Add Linkup in parallel, rerank Exa∪Linkup** | Kills the Exa single-point-of-failure; Linkup benchmarks at Exa quality (~92% F on Verified SimpleQA) at ~same price | **~€5/1k (worth it)** | Med |
+| 4 | **Authority as a ranking feature** | Replace the hardcoded allowlist with **Open PageRank / Tranco** rank → demote content farms, break reranker ties | **$0** | Low–Med |
+| 5 | **`primaryLed` telemetry** (from §1) | Make the Exa dependency's failure observable | $0 | Low |
+
+**Do NOT:** build an owned web index; build an AI-slop classifier (no detector >85% acc,
+3–12% false positives — use authority + engagement instead).
+
+**Money note:** cheap-keyword + our strong reranker *approximates* neural retrieval for a large
+query slice — the "fallback" is good enough to be the *primary* for many queries. Exa's edge is
+narrow (semantic/exploratory). Routing exploits exactly that, cutting bleed **and** the SPOF at once.
+
+---
+
+## 3. NEWS tab
+
+**Today:** federated (SearXNG-news + Brave-News + NewsData + Exa-news), weighted RRF, MMR
+diversity, no rerank. "Recency-first" is a misnomer — no explicit recency sort.
+
+**The biggest win costs nothing and it isn't another API — it's clustering.**
+
+| # | Lever | What it does | Cost | Effort |
+|---|---|---|---|---|
+| 1 | **Cluster-then-rank + near-dup dedup** | The real wire-flood fix MMR can't do: SimHash/RETSim on **title + lead/locations first**, collapse each cluster to one canonical (highest Open-PageRank authority) + "N more outlets" roll-up | **$0** (CPU) | Med |
+| 2 | **Explicit recency-decay score** | Makes "recency-first" true: `e^(−λ·age)` (or Reddit-style `log + t/τ`) with a news half-life (hours–days) — recency becomes a tunable knob | **$0** | Low |
+| 3 | **Re-add GDELT done right** | The 12s rejection was an integration bug: query **async, time-range chunked, non-blocking with a timeout budget**, cache hard → free 100+ lang, 15-min-fresh breadth | **$0** | Med |
+| 4 | **Light bge rerank over the post-clustering canonical set** | Semantic relevance on the deduped set (small pool = cheap) | **$0** (own GPU) | Low |
+| 5 | **Drop / de-weight paid Exa-news** | Redundant once GDELT + Brave News + NewsData + **Guardian (5k/day free)** + clustering are in; reallocate Exa budget to the web tab | **↓ spend** | Low |
+| 6 | **Per-domain caps + cluster diversity** | Authority-aware canonical pick + demote farms | **$0** | Low |
+
+**Sources:** keep Brave News (bundled) + NewsData (reliable structured headlines) + add
+**Guardian Open Platform** (5k/day free, quality full-text). Skip Event Registry (native
+clustering but from $600/mo — we build it free). Bing News: dead (410).
+
+---
+
+## 4. DISCUSSIONS tab  *(the 100% win — broaden cheaply, protect fiercely)*
+
+**Today:** Reddit (via Brave `site:reddit.com`) + Hacker News (Algolia) + Stack Exchange
+(only 2 sites) + RRF + MMR. Measured at Exa parity. **Two structural facts:** Reddit's own API
+403s from datacenter IPs (and now needs pre-approval + is paid >100 QPM), and the Brave path
+is now a **paid dependency** (Brave free tier died Feb 2026).
+
+| # | Lever | What it does | Cost | Effort |
+|---|---|---|---|---|
+| 1 | **Register free Stack Exchange key + add domain sites** | 2 → many sites (Stats, Data Science, Software Eng, MathOverflow, Bioinformatics); free key lifts 300→**10,000 req/day** (33×). Cheapest, safest broadening | **$0** | Low |
+| 2 | **Fold free thread-quality signals into fusion (behind an A/B flag)** | HN points/comments, SE score/`is_answered`/accepted, Reddit/Lemmy upvotes — data already fetched; add **Time-Weighted RRF** for recency. Test vs the frozen 100% baseline before promoting | **$0** | Med |
+| 3 | **Add Lemmy + PullPush/Arctic Shift as free Reddit fallback** | Reddit coverage survives a Brave outage/credit-exhaust; Lemmy adds federated threads + vote signals, no auth | **$0** | Med |
+| 4 | **Defend the Brave dependency** | Cache hard, normalize keys (lowercase/trim/sort), monitor spend — the one place a traffic spike bleeds money ($5/1k) | **$0** | Low |
+
+**Guardrail:** every change here ships **behind an A/B flag measured against the frozen
+100%-parity baseline** — protect the win first.
+
+---
+
+## 5. VIDEOS tab  *(thinnest tab, biggest upside)*
+
+**Today:** YouTube Data API only, **zero ranking layer** (raw YouTube order), no fallback;
+prod has one YouTube key (100 searches/day → empty tab on exhaust). The transcript/AI-notes
+feature is a separate per-video action, not a search lever.
+
+**The biggest win is the ranking layer we don't have — using tools we already own.**
+
+| # | Lever | What it does | Cost | Effort |
+|---|---|---|---|---|
+| 1 | **Transcript + metadata cross-encoder rerank** | YouTube top ~20–40 → self-host `youtube-transcript-api` (no key/quota) → rerank `(query, title+desc+transcript-snippet)` with **bge-reranker-v2-m3 on CPU** (~50–100 ms) → tie-break recency/engagement. **Transcripts are the strongest untapped relevance signal** (94% of top videos carry captions). Single highest-ROI change | **$0** | Med |
+| 2 | **TTL caching + normalized keys** (from §1) | Collapses YouTube call volume → the 100/day ceiling becomes a non-event | **$0** | Low |
+| 3 | **Supadata as quota-free FALLBACK** (not primary) | Overflow for exhausted key + Whisper transcripts for caption-less videos | **free 100/mo, ~$9/1k** | Low |
+
+**Do NOT:** rotate multiple YouTube keys (explicit ToS violation, Google bans *all* projects
+incl. the legitimate one); self-host Invidious/Piped as backbone (ToS takedowns, slow/blocked);
+federate Vimeo/Dailymotion/podcasts (thin catalogs, low yield — YouTube-with-better-ranking wins).
+
+---
+
+## 6. EVAL — make it honest and cheap (escape the Exa tautology)
+
+**Today:** stale (2 cycles behind shipped code) and **tautological** — Exa is *both* the
+council's opponent *and* a runtime source, and the winning move was `web = raw Exa`, so
+"web beats-or-ties Exa" = "you can't lose to yourself." The gate is set-based (blind to order);
+gold set unratified (N=12, one salt); authority = a hardcoded list.
+
+| # | Lever | What it does | Cost | Effort |
+|---|---|---|---|---|
+| 1 | **Ordering-aware deterministic gate** | Replace the set-based gate with **nDCG@10 + MRR@10 + ERR/RBP** via **`ir_measures` / `pytrec_eval`** — pure functions of ranked list + frozen labels, **no LLM per run**, runs in CI in seconds | **$0** | Med |
+| 2 | **Score vs a frozen, pooled, human-ratified gold set** | ~50 queries/tab (not 12), pooled top-10 across an **engine panel**, graded 0–3, **Krippendorff α reported**, versioned, re-pooled quarterly (monthly for news) | **$0** (your time + LLM pre-label) | Med–High |
+| 3 | **Panel of reference engines, never Exa alone** | Pool Exa + Brave + Tavily + a SERP → the gold set records docs Exa *missed*, so raw-Exa stops being an automatic win. **Breaks the tautology** | **$0–small** | Med |
+| 4 | **Ensembled, different-family, order-swapped LLM council — only for gold refresh / config change** | Small open judges (**Prometheus-2**), majority vote, position-bias guarded, self-preference guarded (judge ≠ the model that ranks). Not every CI run | **~$0** (local) | Med |
+| 5 | **Team-Draft Interleaving on live clicks** | The one signal that *can't* be gamed by copying a reference engine — wire now, meaningful once traffic exists | **$0** | Med |
+
+**OSS:** `ir_measures`, `pytrec_eval`, BEIR (Apache-2.0), RAGAS/DeepEval (Apache-2.0),
+Prometheus-2. **Public benchmarks to sanity-check:** BEIR (web), TREC DL/RAG + Tip-of-the-Tongue,
+MIND (news — *research-license*, methodology only), MSR-VTT/ActivityNet (video).
+
+---
+
+## 7. Phased roadmap (recommended order)
+
+**Phase 0 — Foundation & de-risk (mostly $0, no measurement needed):**
+- §1 result cache + per-tab TTLs + capped tiered fallback + per-tab budget guardrail.
+- Web `primaryLed` telemetry.
+- Videos: TTL caching (makes the quota ceiling a non-event) + Supadata fallback wired.
+- *Outcome: silent failures visible, spend capped, quota risk gone.*
+
+**Phase 1 — Honest eval (so everything after is measured):**
+- §6 #1–#3: ordering-aware `ir_measures` gate + ~50-query pooled gold set + engine panel.
+- *Outcome: a trustworthy, non-tautological baseline for every tab.*
+
+**Phase 2 — The free high-leverage quality wins (measured against Phase 1):**
+- Videos #1: transcript+metadata bge rerank (biggest upside).
+- News #1–#2: clustering/dedup + recency-decay.
+- Discussions #1: free SE key + domain sites.
+- *Outcome: the thinnest tab gets its first ranking layer; news wire-flood fixed; discussions broadened.*
+
+**Phase 3 — Resilience & measured spend:**
+- Web #2–#4: query routing + Linkup redundancy + Open-PageRank authority.
+- News #3, #5: GDELT-async + drop Exa-news.
+- Discussions #2–#3: thread-quality signals (A/B) + Lemmy/PullPush fallback.
+
+**Deferred (post-revenue, explicit):** owned semantic web index (the true Exa-parity retrieval
+lever — the web analog of the peS2o academic corpus). Not justified pre-revenue.
+
+---
+
+## 8. What NOT to spend on (the money-savers)
+
+- ❌ Owned open-web crawl+embed index (rent Exa; owning loses pre-revenue).
+- ❌ AI-slop classifier (no detector >85%; use authority+engagement free).
+- ❌ YouTube multi-key rotation (ToS violation → all-project ban).
+- ❌ Self-hosted Invidious/Piped backbone (ToS takedowns, brittle).
+- ❌ Vimeo/Dailymotion/podcast video federation (low yield).
+- ❌ Event Registry / paid native news clustering ($600/mo — build free with SimHash).
+- ❌ Paid Exa-news (redundant; drop it and reallocate to web).
+- ❌ Cohere Rerank as default (we own bge at $0; Cohere only if bge proven insufficient).
+
+## 9. Rough cost envelope at pre-revenue traffic
+
+Almost entirely **$0**: caching, reranking (own bge), clustering, recency-decay, GDELT,
+Guardian, HN, Stack Exchange, Lemmy, transcripts, the whole eval. The only deliberate paid
+lines: **Exa** (web semantic queries, inside/near its 20k free tier), **Linkup** (~€5/1k, web
+redundancy), **Brave** (discussions Reddit path + fallback, ~1k/mo free credit), **NewsData**
+(free tier), **Supadata** (video fallback, free tier). With the §1 caching + per-tab budget
+caps, total controllable spend at low traffic is a small, bounded monthly figure — a dial, not
+a surprise.

--- a/src/app/api/search/unified/__tests__/route.test.ts
+++ b/src/app/api/search/unified/__tests__/route.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { searchResultCache } from "@/lib/search/result-cache";
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks
@@ -116,6 +117,9 @@ function literatureResult(overrides: Record<string, unknown> = {}) {
 describe("GET /api/search/unified", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Non-academic results are now cached (process-global); reset it between tests so
+    // one case's fan-out can't be served to the next, just as mocks are reset.
+    searchResultCache._mem.clear();
     mockGetCurrentUserId.mockResolvedValue("dev_user_001");
     mockCheckRateLimit.mockResolvedValue(null);
 
@@ -177,6 +181,24 @@ describe("GET /api/search/unified", () => {
     const body = await res.json();
     expect(body.results).toBeDefined();
     expect(body.total).toBeGreaterThanOrEqual(0);
+  });
+
+  it("caches the non-academic fan-out — a repeat query is served from cache, not re-fetched", async () => {
+    await GET(makeRequest({ q: "quantum computing breakthrough", tab: "web" }));
+    await GET(makeRequest({ q: "quantum computing breakthrough", tab: "web" }));
+    expect(mockFederateNonAcademic).toHaveBeenCalledTimes(1);
+  });
+
+  it("never caches a degraded fan-out — the next request retries instead of serving a bad result", async () => {
+    mockFederateNonAcademic.mockResolvedValue({
+      results: [],
+      perSource: [],
+      perSourceRows: [],
+      degraded: true,
+    });
+    await GET(makeRequest({ q: "obscure sparse topic xyz", tab: "web" }));
+    await GET(makeRequest({ q: "obscure sparse topic xyz", tab: "web" }));
+    expect(mockFederateNonAcademic).toHaveBeenCalledTimes(2);
   });
 
   it("returns 400 when query is missing", async () => {

--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from "next/server";
 import type { SearchResponse } from "@/types/search";
 import { runLiteratureSearch } from "@/lib/search/run-search";
 import { federateNonAcademic } from "@/lib/search/web/federate";
+import { searchResultCache, buildCacheKey } from "@/lib/search/result-cache";
+import { nonAcademicCacheTtl, shouldCacheFederatedList } from "@/lib/search/web/cache-policy";
 import { searchYouTube } from "@/lib/search/sources/youtube";
 import { rerankResults } from "@/lib/search/rerank";
 import { diversifyForTab } from "@/lib/search/diversity";
@@ -171,29 +173,25 @@ async function rerankWebTabOnly(
  * preferences) the single-source path uses. The fused pool is already the full
  * available set, so there is no incremental re-fetch loop — we page over it.
  */
-async function fetchFederatedNonAcademicResults(
+/**
+ * The query-global, cacheable part of a non-academic search: the expensive fan-out
+ * (+ web-tab rerank), independent of the user's domain preferences and the page. This
+ * is what gets cached — every page and every user of the same query then shares one
+ * paid fan-out. Preferences, diversity, and paging are applied per-request afterwards.
+ */
+async function computeNonAcademicList(
   query: string,
   tab: "web" | "news" | "discussions" | "videos",
-  page: number,
-  perPage: number,
-  preferences: Awaited<ReturnType<typeof getDomainPreferences>>,
   timeRange?: "24h" | "week" | "month" | "year"
-): Promise<{
-  results: UnifiedSearchResult[];
-  total: number;
-  hasMore: boolean;
-  degraded: boolean;
-}> {
-  // Videos is a single-source tab (YouTube) — no federation/rerank/diversity, just
-  // YouTube's own relevance order paged through the shared response pipeline.
+): Promise<{ results: UnifiedSearchResult[]; degraded: boolean; primaryLed: boolean }> {
+  // Videos is a single-source tab (YouTube) — no federation/rerank; just YouTube's own
+  // relevance order. Caching it also shields the scarce 100-searches/day YouTube quota.
   if (tab === "videos") {
     const yt = await searchYouTube(query, { limit: MAX_NON_ACADEMIC_RESULTS });
-    const start = page * perPage;
     return {
-      results: yt.results.slice(start, start + perPage),
-      total: yt.results.length,
-      hasMore: yt.results.length > start + perPage,
+      results: yt.results,
       degraded: yt.status.status !== "ok" && yt.results.length === 0,
+      primaryLed: false,
     };
   }
 
@@ -211,16 +209,58 @@ async function fetchFederatedNonAcademicResults(
   const reranked = federation.primaryLed
     ? federation.results
     : await rerankWebTabOnly(query, federation.results, tab === "web");
-  const ranked = applyDomainPreferences(reranked, preferences);
-  const diversified = federation.primaryLed ? ranked : diversifyForTab(ranked, tab);
+  return { results: reranked, degraded: federation.degraded, primaryLed: federation.primaryLed };
+}
+
+async function fetchFederatedNonAcademicResults(
+  query: string,
+  tab: "web" | "news" | "discussions" | "videos",
+  page: number,
+  perPage: number,
+  preferences: Awaited<ReturnType<typeof getDomainPreferences>>,
+  timeRange?: "24h" | "week" | "month" | "year"
+): Promise<{
+  results: UnifiedSearchResult[];
+  total: number;
+  hasMore: boolean;
+  degraded: boolean;
+}> {
+  // Cache the query-global fan-out (keyed by tab+query+timeRange, per-tab TTL). The
+  // paid tabs (Exa/Brave/NewsData/YouTube) were previously uncached — this is the
+  // single biggest cost lever. Degraded/empty responses are never cached.
+  const cacheKey = buildCacheKey("websearch:v1", { tab, query, timeRange: timeRange ?? "" });
+  const { value: list } = await searchResultCache.getOrCompute(
+    cacheKey,
+    () => computeNonAcademicList(query, tab, timeRange),
+    {
+      ttlSeconds: nonAcademicCacheTtl(tab),
+      staleSeconds: 6 * 3600,
+      shouldCache: shouldCacheFederatedList,
+    }
+  );
 
   const start = page * perPage;
-  const paged = diversified.slice(start, start + perPage);
+
+  // Videos: raw YouTube order, paged — no preferences/diversity (unchanged behavior).
+  if (tab === "videos") {
+    return {
+      results: list.results.slice(start, start + perPage),
+      total: list.results.length,
+      hasMore: list.results.length > start + perPage,
+      degraded: list.degraded,
+    };
+  }
+
+  // Per-request (cheap, user-specific): domain preferences + diversity + paging run
+  // OUTSIDE the cache so the cache stays query-global (high hit rate, no per-user
+  // pollution). Primary-led lists keep their native order (no diversity), as before.
+  const ranked = applyDomainPreferences(list.results, preferences);
+  const diversified = list.primaryLed ? ranked : diversifyForTab(ranked, tab);
   return {
-    results: paged,
+    results: diversified.slice(start, start + perPage),
     total: diversified.length,
     hasMore: diversified.length > start + perPage,
-    degraded: federation.degraded,
+    degraded: list.degraded,
   };
 }
 

--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import type { SearchResponse } from "@/types/search";
 import { runLiteratureSearch } from "@/lib/search/run-search";
 import { federateNonAcademic } from "@/lib/search/web/federate";
-import { searchResultCache, buildCacheKey } from "@/lib/search/result-cache";
+import { searchResultCache, buildCacheKey, type CacheHit } from "@/lib/search/result-cache";
 import { nonAcademicCacheTtl, shouldCacheFederatedList } from "@/lib/search/web/cache-policy";
 import { searchYouTube } from "@/lib/search/sources/youtube";
 import { rerankResults } from "@/lib/search/rerank";
@@ -179,19 +179,29 @@ async function rerankWebTabOnly(
  * is what gets cached — every page and every user of the same query then shares one
  * paid fan-out. Preferences, diversity, and paging are applied per-request afterwards.
  */
+interface NonAcademicList {
+  results: UnifiedSearchResult[];
+  degraded: boolean;
+  primaryLed: boolean;
+  /** Per-source contribution, for telemetry (which lanes fired, which were empty/down). */
+  perSource: { id: string; count: number; ok: boolean }[];
+}
+
 async function computeNonAcademicList(
   query: string,
   tab: "web" | "news" | "discussions" | "videos",
   timeRange?: "24h" | "week" | "month" | "year"
-): Promise<{ results: UnifiedSearchResult[]; degraded: boolean; primaryLed: boolean }> {
+): Promise<NonAcademicList> {
   // Videos is a single-source tab (YouTube) — no federation/rerank; just YouTube's own
   // relevance order. Caching it also shields the scarce 100-searches/day YouTube quota.
   if (tab === "videos") {
     const yt = await searchYouTube(query, { limit: MAX_NON_ACADEMIC_RESULTS });
+    const ok = yt.status.status === "ok";
     return {
       results: yt.results,
-      degraded: yt.status.status !== "ok" && yt.results.length === 0,
+      degraded: !ok && yt.results.length === 0,
       primaryLed: false,
+      perSource: [{ id: "youtube", count: yt.results.length, ok }],
     };
   }
 
@@ -209,7 +219,16 @@ async function computeNonAcademicList(
   const reranked = federation.primaryLed
     ? federation.results
     : await rerankWebTabOnly(query, federation.results, tab === "web");
-  return { results: reranked, degraded: federation.degraded, primaryLed: federation.primaryLed };
+  return {
+    results: reranked,
+    degraded: federation.degraded,
+    primaryLed: federation.primaryLed,
+    perSource: federation.perSource.map((s) => ({
+      id: s.id,
+      count: s.count,
+      ok: s.status.status === "ok",
+    })),
+  };
 }
 
 async function fetchFederatedNonAcademicResults(
@@ -224,12 +243,15 @@ async function fetchFederatedNonAcademicResults(
   total: number;
   hasMore: boolean;
   degraded: boolean;
+  primaryLed: boolean;
+  perSource: { id: string; count: number; ok: boolean }[];
+  cacheHit: CacheHit;
 }> {
   // Cache the query-global fan-out (keyed by tab+query+timeRange, per-tab TTL). The
   // paid tabs (Exa/Brave/NewsData/YouTube) were previously uncached — this is the
   // single biggest cost lever. Degraded/empty responses are never cached.
   const cacheKey = buildCacheKey("websearch:v1", { tab, query, timeRange: timeRange ?? "" });
-  const { value: list } = await searchResultCache.getOrCompute(
+  const { value: list, hit: cacheHit } = await searchResultCache.getOrCompute(
     cacheKey,
     () => computeNonAcademicList(query, tab, timeRange),
     {
@@ -240,6 +262,7 @@ async function fetchFederatedNonAcademicResults(
   );
 
   const start = page * perPage;
+  const telemetry = { primaryLed: list.primaryLed, perSource: list.perSource, cacheHit };
 
   // Videos: raw YouTube order, paged — no preferences/diversity (unchanged behavior).
   if (tab === "videos") {
@@ -248,6 +271,7 @@ async function fetchFederatedNonAcademicResults(
       total: list.results.length,
       hasMore: list.results.length > start + perPage,
       degraded: list.degraded,
+      ...telemetry,
     };
   }
 
@@ -261,6 +285,7 @@ async function fetchFederatedNonAcademicResults(
     total: diversified.length,
     hasMore: diversified.length > start + perPage,
     degraded: list.degraded,
+    ...telemetry,
   };
 }
 
@@ -348,6 +373,9 @@ export async function GET(req: Request) {
         total: visibleTotal,
         hasMore,
         degraded,
+        primaryLed,
+        perSource,
+        cacheHit,
       } = await fetchFederatedNonAcademicResults(
         effectiveQuery,
         tabParam,
@@ -356,6 +384,18 @@ export async function GET(req: Request) {
         userDomainPreferences,
         timeRange as "24h" | "week" | "month" | "year" | undefined
       );
+
+      // Telemetry: makes the silent web-tab degradation visible. On the web tab,
+      // `primaryLed: false` means Exa did NOT lead (down/throttled/unkeyed) and we fell
+      // back to the keyword stack — alert on a drop in the Exa-led rate. Also surfaces
+      // per-source contribution and cache effectiveness.
+      log.info("Non-academic search served", {
+        tab: tabParam,
+        primaryLed,
+        cacheHit,
+        degraded,
+        sources: perSource,
+      });
 
       // Apply scope domain constraints if a custom scope is active
       let scopeFilteredResults = paged;

--- a/src/lib/search/web/__tests__/cache-policy.test.ts
+++ b/src/lib/search/web/__tests__/cache-policy.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { nonAcademicCacheTtl, shouldCacheFederatedList } from "../cache-policy";
+
+describe("nonAcademicCacheTtl", () => {
+  it("uses a short TTL for news — freshness is the product", () => {
+    expect(nonAcademicCacheTtl("news")).toBeGreaterThan(0);
+    expect(nonAcademicCacheTtl("news")).toBeLessThanOrEqual(30 * 60);
+  });
+
+  it("uses long TTLs for web and videos (relevance is stable; video also shields the YouTube quota)", () => {
+    expect(nonAcademicCacheTtl("web")).toBeGreaterThanOrEqual(6 * 3600);
+    expect(nonAcademicCacheTtl("videos")).toBeGreaterThanOrEqual(6 * 3600);
+  });
+
+  it("uses a medium TTL for discussions — between news and web", () => {
+    expect(nonAcademicCacheTtl("discussions")).toBeGreaterThan(nonAcademicCacheTtl("news"));
+    expect(nonAcademicCacheTtl("discussions")).toBeLessThan(nonAcademicCacheTtl("web"));
+  });
+
+  it("news is the shortest-lived tab of all", () => {
+    const others = (["web", "videos", "discussions"] as const).map(nonAcademicCacheTtl);
+    expect(Math.min(...others)).toBeGreaterThan(nonAcademicCacheTtl("news"));
+  });
+});
+
+describe("shouldCacheFederatedList", () => {
+  it("never caches a degraded (throttled/partial) response — it must not be served for the whole TTL", () => {
+    expect(shouldCacheFederatedList({ results: [{}], degraded: true })).toBe(false);
+  });
+
+  it("never caches an empty response", () => {
+    expect(shouldCacheFederatedList({ results: [], degraded: false })).toBe(false);
+  });
+
+  it("caches a healthy, non-empty response", () => {
+    expect(shouldCacheFederatedList({ results: [{}, {}], degraded: false })).toBe(true);
+  });
+});

--- a/src/lib/search/web/__tests__/federate.test.ts
+++ b/src/lib/search/web/__tests__/federate.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { federateWith, braveSourceForTab, type WebSource } from "../federate";
 import { okStatus } from "@/lib/search/source-status";
+import { sourceBudget } from "../source-budget";
 import type { UnifiedSearchResult } from "@/types/search";
 
 vi.mock("@/lib/search/sources/brave", () => ({
@@ -109,6 +110,30 @@ describe("federateWith — primary-led ordering", () => {
     ]);
     expect(fed.primaryLed).toBe(false);
     expect(fed.results.map((r) => r.url)).toEqual(["https://kw/1"]);
+  });
+});
+
+describe("federateWith — paid-source budget guardrail", () => {
+  it("skips a source over its daily budget (marks it rate_limited) without ever calling it, and still serves the free lanes", async () => {
+    const cappedRun = vi.fn(async () => ({
+      results: [row("https://exa/1", "exa result")],
+      total: 1,
+      status: okStatus(),
+    }));
+    const capped: WebSource = { id: "exa", label: "Exa", run: cappedRun };
+    const free = okSource("searxng", [row("https://sx/1", "free result")]);
+
+    const spy = vi
+      .spyOn(sourceBudget, "canSpend")
+      .mockImplementation(async (id: string) => id !== "exa");
+
+    const fed = await federateWith("q", "web", [capped, free]);
+
+    expect(cappedRun).not.toHaveBeenCalled();
+    expect(fed.perSource.find((s) => s.id === "exa")?.status.status).toBe("rate_limited");
+    expect(fed.results.some((r) => r.url === "https://sx/1")).toBe(true);
+
+    spy.mockRestore();
   });
 });
 

--- a/src/lib/search/web/__tests__/source-budget.test.ts
+++ b/src/lib/search/web/__tests__/source-budget.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { budgetFamily, createSourceBudget } from "../source-budget";
+
+describe("budgetFamily", () => {
+  it("maps paid source ids to their billing family", () => {
+    expect(budgetFamily("exa")).toBe("exa");
+    expect(budgetFamily("exa-news")).toBe("exa");
+    expect(budgetFamily("brave")).toBe("brave");
+    expect(budgetFamily("brave-news")).toBe("brave");
+    expect(budgetFamily("brave-reddit")).toBe("brave");
+    expect(budgetFamily("newsdata")).toBe("newsdata");
+  });
+
+  it("returns null for free / uncapped sources", () => {
+    for (const id of ["searxng", "hackernews", "stackexchange", "youtube"]) {
+      expect(budgetFamily(id)).toBeNull();
+    }
+  });
+});
+
+describe("createSourceBudget (in-memory, injected clock + caps)", () => {
+  it("allows spend under the cap and blocks once the cap is reached", async () => {
+    const budget = createSourceBudget({ now: () => 0, redis: null, caps: { exa: 2 } });
+    expect(await budget.canSpend("exa")).toBe(true);
+    await budget.recordSpend("exa");
+    expect(await budget.canSpend("exa")).toBe(true); // 1 < 2
+    await budget.recordSpend("exa");
+    expect(await budget.canSpend("exa")).toBe(false); // 2 >= 2
+  });
+
+  it("never caps a free source", async () => {
+    const budget = createSourceBudget({ now: () => 0, redis: null, caps: { exa: 1 } });
+    expect(await budget.canSpend("searxng")).toBe(true);
+    await budget.recordSpend("searxng");
+    expect(await budget.canSpend("searxng")).toBe(true);
+  });
+
+  it("resets the count on a new day", async () => {
+    let t = 0;
+    const budget = createSourceBudget({ now: () => t, redis: null, caps: { brave: 1 } });
+    await budget.recordSpend("brave");
+    expect(await budget.canSpend("brave")).toBe(false);
+    t = 1000 * 60 * 60 * 24 * 2; // +2 days
+    expect(await budget.canSpend("brave")).toBe(true);
+  });
+
+  it("fails OPEN (allows the call) when the counter store errors — never blocks search", async () => {
+    const brokenRedis = {
+      get: async () => {
+        throw new Error("redis down");
+      },
+      incr: async () => {
+        throw new Error("redis down");
+      },
+      expire: async () => {
+        throw new Error("redis down");
+      },
+    };
+    const budget = createSourceBudget({ now: () => 0, redis: brokenRedis, caps: { exa: 1 } });
+    expect(await budget.canSpend("exa")).toBe(true);
+  });
+});

--- a/src/lib/search/web/cache-policy.ts
+++ b/src/lib/search/web/cache-policy.ts
@@ -1,0 +1,35 @@
+/**
+ * Cache policy for the non-academic search tabs (web / news / discussions / videos).
+ *
+ * These tabs fan out to paid/quota'd upstreams (Exa, Brave, NewsData, YouTube), so
+ * caching the query-global federation result is the single biggest cost lever. TTL is
+ * matched to how fast the truth changes (IMPROVEMENT-PLAN §1): news is freshness-first
+ * and caches only briefly (still collapsing bursts of the same query); web/videos
+ * relevance is stable so they cache long — and the long video TTL also shields the
+ * scarce 100-searches/day YouTube quota. Discussions sit between.
+ */
+
+export type NonAcademicTab = "web" | "news" | "discussions" | "videos";
+
+const TTL_SECONDS: Record<NonAcademicTab, number> = {
+  news: 10 * 60,
+  discussions: 3 * 3600,
+  web: 6 * 3600,
+  videos: 12 * 3600,
+};
+
+export function nonAcademicCacheTtl(tab: NonAcademicTab): number {
+  return TTL_SECONDS[tab];
+}
+
+/**
+ * Only cache a healthy, non-empty result. A degraded (throttled/partial) or empty
+ * response must never be cached — otherwise one bad fan-out is served for the whole
+ * TTL. Mirrors the academic path's `shouldCache` guard.
+ */
+export function shouldCacheFederatedList(value: {
+  results: unknown[];
+  degraded: boolean;
+}): boolean {
+  return !value.degraded && value.results.length > 0;
+}

--- a/src/lib/search/web/federate.ts
+++ b/src/lib/search/web/federate.ts
@@ -10,6 +10,7 @@
  */
 import type { UnifiedSearchResult } from "@/types/search";
 import { okStatus, classifyRejectionReason, type SourceStatus } from "@/lib/search/source-status";
+import { sourceBudget } from "@/lib/search/web/source-budget";
 import { searchSearXNG, type SearXNGCategory } from "@/lib/search/sources/searxng";
 import { searchBrave } from "@/lib/search/sources/brave";
 import { searchNewsData } from "@/lib/search/sources/newsdata";
@@ -231,7 +232,20 @@ export async function federateWith(
 
   const settled = await Promise.all(
     sources.map(async (source) => {
+      // Paid-source budget guardrail: once a metered family (Exa/Brave/NewsData) hits
+      // its daily cap, skip it and let the federation degrade to the remaining free
+      // lanes rather than spend more. Free sources are never capped.
+      if (!(await sourceBudget.canSpend(source.id))) {
+        return {
+          id: source.id,
+          label: source.label,
+          results: [] as UnifiedSearchResult[],
+          total: 0,
+          status: { status: "rate_limited" as const, message: "daily budget cap reached" },
+        };
+      }
       try {
+        await sourceBudget.recordSpend(source.id);
         const r = await withTimeout(source.id, source.run(query, options), timeoutMs);
         return { id: source.id, label: source.label, ...r };
       } catch (error) {

--- a/src/lib/search/web/source-budget.ts
+++ b/src/lib/search/web/source-budget.ts
@@ -1,0 +1,120 @@
+/**
+ * Per-source daily spend guardrail for the paid non-academic search sources.
+ *
+ * The paid tabs fan out to metered upstreams (Exa, Brave, NewsData). This bounds how
+ * many paid calls each billing family can make per day; once a family hits its cap the
+ * federation simply drops that source and runs on the remaining (free) lanes — cost
+ * becomes a dial, not a surprise (IMPROVEMENT-PLAN §1). Counting is best-effort and
+ * fail-open: if the counter store errors, the call is ALLOWED (search availability wins
+ * over a perfectly-enforced cap). Shared Upstash counter in prod; per-instance in-memory
+ * fallback when Upstash is absent.
+ */
+
+export type BudgetFamily = "exa" | "brave" | "newsdata";
+
+/** Map a federation source id to its billing family, or null if the source is free. */
+export function budgetFamily(sourceId: string): BudgetFamily | null {
+  if (sourceId.startsWith("exa")) return "exa";
+  if (sourceId.startsWith("brave")) return "brave";
+  if (sourceId === "newsdata") return "newsdata";
+  return null;
+}
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  const n = raw ? Number(raw) : NaN;
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+function defaultCaps(): Record<BudgetFamily, number> {
+  return {
+    exa: envInt("BUDGET_EXA_DAILY", 2000),
+    brave: envInt("BUDGET_BRAVE_DAILY", 800),
+    newsdata: envInt("BUDGET_NEWSDATA_DAILY", 180),
+  };
+}
+
+interface RedisLike {
+  get(key: string): Promise<unknown>;
+  incr(key: string): Promise<number>;
+  expire(key: string, seconds: number): Promise<unknown>;
+}
+
+const TWO_DAYS_SECONDS = 2 * 24 * 3600;
+
+export function createSourceBudget(deps?: {
+  now?: () => number;
+  redis?: RedisLike | null;
+  caps?: Partial<Record<BudgetFamily, number>>;
+}) {
+  const now = deps?.now ?? Date.now;
+  const caps = { ...defaultCaps(), ...deps?.caps };
+  const mem = new Map<string, number>();
+
+  let redis: RedisLike | null | undefined =
+    deps && "redis" in deps ? deps.redis ?? null : undefined;
+  function getRedis(): RedisLike | null {
+    if (redis !== undefined) return redis;
+    const url = process.env.UPSTASH_REDIS_REST_URL;
+    const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+    redis = null;
+    if (url && token) {
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { Redis } = require("@upstash/redis");
+        redis = new Redis({ url, token }) as RedisLike;
+      } catch {
+        redis = null;
+      }
+    }
+    return redis;
+  }
+
+  function dayKey(family: BudgetFamily): string {
+    const day = new Date(now()).toISOString().slice(0, 10);
+    return `budget:${family}:${day}`;
+  }
+
+  async function count(family: BudgetFamily): Promise<number> {
+    const key = dayKey(family);
+    const r = getRedis();
+    if (r) {
+      const raw = await r.get(key);
+      return typeof raw === "number" ? raw : Number(raw ?? 0) || 0;
+    }
+    return mem.get(key) ?? 0;
+  }
+
+  async function canSpend(sourceId: string): Promise<boolean> {
+    const family = budgetFamily(sourceId);
+    if (!family) return true;
+    const cap = caps[family];
+    if (!cap || cap <= 0) return true;
+    try {
+      return (await count(family)) < cap;
+    } catch {
+      return true; // fail-open: never block search on a counter error
+    }
+  }
+
+  async function recordSpend(sourceId: string): Promise<void> {
+    const family = budgetFamily(sourceId);
+    if (!family) return;
+    const key = dayKey(family);
+    try {
+      const r = getRedis();
+      if (r) {
+        await r.incr(key);
+        await r.expire(key, TWO_DAYS_SECONDS);
+      } else {
+        mem.set(key, (mem.get(key) ?? 0) + 1);
+      }
+    } catch {
+      // fail-open: a counter error must not break the search path.
+    }
+  }
+
+  return { canSpend, recordSpend };
+}
+
+export const sourceBudget = createSourceBudget();


### PR DESCRIPTION
## What & why
Phase 0 of the non-academic search improvement plan (`docs/web-search/IMPROVEMENT-PLAN.md`): make spend a **capped dial** and silent failures **visible**, before any quality work. The paid tabs (web/news/discussions/videos) fan out to metered upstreams (Exa, Brave, NewsData, YouTube) — this bounds and observes that cost.

## Changes (each TDD'd)
1. **Cache the non-academic fan-out** — the paid tabs were *uncached* on every query. Wire the existing two-tier cache (memory + Upstash, coalescing, stale-if-error) with per-tab TTLs (news 10m, discussions 3h, web 6h, video 12h — video's long TTL also shields the 100/day YouTube quota). Cache boundary is the query-global fan-out; per-user prefs/diversity/paging stay outside it. Degraded/empty never cached. **The single biggest cost lever.**
2. **`primaryLed` + per-source + cache telemetry** — logs whether the web tab was Exa-led or fell back, which lanes fired, and cache-hit status. A monitor can now alert when web silently drops off Exa.
3. **Per-source daily budget guardrail** — each metered family (Exa/Brave/NewsData) has an env-tunable daily cap; once reached, the source is skipped and federation degrades to the free lanes. Fail-open (a counter outage never blocks search). Free sources never capped.
4. **Improvement-plan doc** — the cost-tagged reference this branch implements.

## How to test
`npx vitest run src/lib/search/web src/app/api/search` — full suite 7016 green, tsc clean. New tests: cache-policy TTLs + shouldCache, route cache-behavior (repeat served from cache, degraded never cached), budget family/cap/day-reset/fail-open, and federate budget-gate integration.

## Risk
Low — all fail-open. No result-shape change; the live serving path degrades gracefully on cache/budget/counter issues. Prod already has all keys + Upstash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ByDVtE96tY2jeYfL8M5nvb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved non-academic search with smarter caching, freshness controls, and better telemetry.
  * Added safer handling for multiple search tabs, including web, news, discussions, and videos.

* **Bug Fixes**
  * Prevented low-quality or incomplete search results from being reused in later requests.
  * Reduced unnecessary calls to paid search sources by enforcing daily usage limits and falling back to other available results when limits are reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->