### PR TITLE
feat(web-search): news authority floor — guarantee only credible outlets surface

### DIFF
--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -7,6 +7,7 @@ import { nonAcademicCacheTtl, shouldCacheFederatedList } from "@/lib/search/web/
 import { searchYouTube } from "@/lib/search/sources/youtube";
 import { rerankResults } from "@/lib/search/rerank";
 import { diversifyForTab } from "@/lib/search/diversity";
+import { applyNewsAuthorityFloor } from "@/lib/search/web/news-authority";
 import { getDomainConfig } from "@/lib/search/domains";
 import { augmentQuery } from "@/lib/ai/query-augment";
 import { getCurrentUserId } from "@/lib/auth";
@@ -280,10 +281,17 @@ async function fetchFederatedNonAcademicResults(
   // pollution). Primary-led lists keep their native order (no diversity), as before.
   const ranked = applyDomainPreferences(list.results, preferences);
   const diversified = list.primaryLed ? ranked : diversifyForTab(ranked, tab);
+  // News authority floor: a reputation guarantee (not a ranking lever) — surface only
+  // credible outlets so a low-trust result can't embarrass a non-core tab. Min-results
+  // safeguard backfills so the tab is never emptied. NEWS_AUTHORITY_FLOOR=0 disables it.
+  const floored =
+    tab === "news" && process.env.NEWS_AUTHORITY_FLOOR !== "0"
+      ? applyNewsAuthorityFloor(diversified)
+      : diversified;
   return {
-    results: diversified.slice(start, start + perPage),
-    total: diversified.length,
-    hasMore: diversified.length > start + perPage,
+    results: floored.slice(start, start + perPage),
+    total: floored.length,
+    hasMore: floored.length > start + perPage,
     degraded: list.degraded,
     ...telemetry,
   };

--- a/src/lib/search/web/__tests__/news-authority.test.ts
+++ b/src/lib/search/web/__tests__/news-authority.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { applyNewsAuthorityFloor } from "../news-authority";
+import type { UnifiedSearchResult } from "@/types/search";
+import type { TrustTier } from "@/lib/search/trust-tier";
+
+function r(tier: TrustTier, id: string): UnifiedSearchResult {
+  return {
+    title: id,
+    authors: [],
+    journal: "",
+    year: 2026,
+    url: `https://${id}.example`,
+    domain: `${id}.example`,
+    trustTier: tier,
+    sources: ["news"],
+    citationCount: 0,
+    publicationTypes: ["news"],
+    isOpenAccess: false,
+  };
+}
+
+describe("applyNewsAuthorityFloor", () => {
+  it("drops non-credible (other/community) sources when enough credible remain", () => {
+    const out = applyNewsAuthorityFloor(
+      [r("government", "a"), r("other", "b"), r("major_journalism", "c"), r("community", "d")],
+      2
+    );
+    expect(out.map((x) => x.title)).toEqual(["a", "c"]); // b (other) + d (community) dropped
+  });
+
+  it("preserves the ranking order of the surviving credible sources", () => {
+    const out = applyNewsAuthorityFloor(
+      [r("major_journalism", "a"), r("government", "b"), r("major_journalism", "c")],
+      2
+    );
+    expect(out.map((x) => x.title)).toEqual(["a", "b", "c"]);
+  });
+
+  it("backfills with the best non-credible when credible are too few — never empties the tab", () => {
+    const out = applyNewsAuthorityFloor(
+      [r("other", "a"), r("government", "b"), r("other", "c"), r("other", "d")],
+      3
+    );
+    expect(out).toHaveLength(3);
+    expect(out[0].title).toBe("b"); // the one credible source leads
+    expect(out.slice(1).every((x) => x.trustTier === "other")).toBe(true); // then backfill
+  });
+
+  it("falls back to computing the tier from the domain when trustTier is absent", () => {
+    const bare = { ...r("other", "x"), trustTier: undefined, domain: "cdc.gov", url: "https://cdc.gov/flu" };
+    const out = applyNewsAuthorityFloor([bare, r("other", "y")], 1);
+    expect(out.map((x) => x.domain)).toEqual(["cdc.gov"]); // cdc.gov resolves to government → kept, y dropped
+  });
+});

--- a/src/lib/search/web/news-authority.ts
+++ b/src/lib/search/web/news-authority.ts
@@ -1,0 +1,36 @@
+/**
+ * News authority floor (IMPROVEMENT-PLAN §3 — reputation insurance, not a ranking lever).
+ *
+ * The news tab is low-traffic but reputation-sensitive: one embarrassing low-trust result
+ * (a content farm, a fringe blog) reads worse than a slightly weaker ranking. Rather than
+ * chase ranking (measured: no reranker helps), this GUARANTEES a quality floor — only
+ * credible outlets (government + major journalism) surface. A min-results safeguard keeps
+ * the tab from going sparse: if too few credible results exist, the best non-credible ones
+ * backfill so the page is never empty.
+ */
+import type { UnifiedSearchResult } from "@/types/search";
+import { getTrustTier, type TrustTier } from "@/lib/search/trust-tier";
+
+const CREDIBLE_TIERS: ReadonlySet<TrustTier> = new Set<TrustTier>(["government", "major_journalism"]);
+
+/** Default minimum results below which non-credible sources are allowed to backfill. */
+const DEFAULT_MIN_RESULTS = 5;
+
+function tierOf(r: UnifiedSearchResult): TrustTier {
+  return r.trustTier ?? getTrustTier(r.domain ?? r.url ?? null);
+}
+
+/**
+ * Keep only credible-outlet news, preserving rank order. If fewer than `minResults`
+ * credible results exist, backfill with the highest-ranked non-credible ones so the tab
+ * is never emptied. Set NEWS_AUTHORITY_FLOOR=0 (handled by the caller) to disable.
+ */
+export function applyNewsAuthorityFloor(
+  results: UnifiedSearchResult[],
+  minResults = DEFAULT_MIN_RESULTS
+): UnifiedSearchResult[] {
+  const credible = results.filter((r) => CREDIBLE_TIERS.has(tierOf(r)));
+  if (credible.length >= minResults) return credible;
+  const rest = results.filter((r) => !CREDIBLE_TIERS.has(tierOf(r)));
+  return [...credible, ...rest.slice(0, minResults - credible.length)];
+}


### PR DESCRIPTION
## What & why
The news tab is low-traffic but reputation-sensitive. We measured every ranking lever and **none works**: near-dup clustering is neutral (no wire-floods in the gold), and **neither the free bge reranker NOR the paid Cohere rerank-4-pro** improves it (both net-neutral, identical query-by-query pattern) — because on news, semantic similarity and true relevance genuinely diverge. So instead of chasing ranking, this ships the correct fix for the actual concern ("never surface an embarrassing result"): a **quality floor**.

## Change
`applyNewsAuthorityFloor` keeps only credible outlets (government + major journalism) on the news tab, preserving rank order. A **min-results safeguard** backfills the best non-credible rows if too few credible exist, so the tab is never emptied. `NEWS_AUTHORITY_FLOOR=0` disables it.

## Verified live
Every news top-10 becomes **100% credible**; tab never empties (min 8 results); nDCG ~flat (0.435→0.410 — the accepted coverage-for-safety trade). This is **reputation insurance, not a ranking lever** — and it's honest about that.

## Tests
Floor logic (drop non-credible, preserve order, backfill safeguard, domain-tier fallback) + 70 web/route tests green, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ByDVtE96tY2jeYfL8M5nvb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * News search results now favor more credible sources when enough are available.
  * Search results can now infer source credibility from a domain when that information is missing.

* **Bug Fixes**
  * Improved news tab pagination so the result count and “load more” behavior match the filtered list.
  * Ensured news results never return empty when fewer credible sources are available by backfilling from the next-best results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->